### PR TITLE
Mocking Integration tests at correct level

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ sourceSets {
       runtimeClasspath += main.output
       srcDir file('src/integrationTest/java')
     }
+    resources.srcDir file('src/integrationTest/resources')
   }
 
   smokeTest {
@@ -343,6 +344,10 @@ tasks.withType(CftlibExec).configureEach {
 
 // Ensure we cover Cftlib dev & test with our CI checks
 check.dependsOn cftlibTest
+
+rootProject.tasks.named("processIntegrationTestResources") {
+  duplicatesStrategy = 'include'
+}
 
 rootProject.tasks.named("processContractTestResources") {
   duplicatesStrategy = 'include'

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ sourceSets {
       runtimeClasspath += main.output
       srcDir file('src/integrationTest/java')
     }
-    resources.srcDir file('src/integrationTest/resources')
   }
 
   smokeTest {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcs/controllers/GetWelcomeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcs/controllers/GetWelcomeTest.java
@@ -9,15 +9,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@TestPropertySource(properties = {
-    "security.anonymousPaths[0]=/"
-})
+@ActiveProfiles("integration")
 class GetWelcomeTest {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcs/hearings/endpoint/HearingsControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcs/hearings/endpoint/HearingsControllerIT.java
@@ -35,10 +35,10 @@ class HearingsControllerIT {
     private ObjectMapper objectMapper;
 
     @MockitoBean
-    AuthTokenGenerator authTokenGenerator;
+    private AuthTokenGenerator authTokenGenerator;
 
     @MockitoBean
-    HmcHearingApi hmcHearingApi;
+    private HmcHearingApi hmcHearingApi;
 
     private static final String AUTH_HEADER = "Bearer token";
     private static final String SERVICE_AUTH_HEADER = "ServiceAuthToken";

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcs/hearings/endpoint/HearingsControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcs/hearings/endpoint/HearingsControllerIT.java
@@ -14,25 +14,31 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.hmcts.reform.authorisation.filters.ServiceAuthFilter;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.pcs.hearings.model.DeleteHearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.model.HearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.model.UpdateHearingRequest;
+import uk.gov.hmcts.reform.pcs.hearings.service.api.HmcHearingApi;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
+@ActiveProfiles("integration")
 class HearingsControllerIT {
 
     @Autowired
-    private transient MockMvc mockMvc;
-
-    @MockitoBean
-    private ServiceAuthFilter serviceAuthFilter;
+    private MockMvc mockMvc;
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @MockitoBean
+    AuthTokenGenerator authTokenGenerator;
+
+    @MockitoBean
+    HmcHearingApi hmcHearingApi;
 
     private static final String AUTH_HEADER = "Bearer token";
     private static final String SERVICE_AUTH_HEADER = "ServiceAuthToken";
@@ -57,6 +63,7 @@ class HearingsControllerIT {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk());
+
     }
 
     @Test
@@ -77,5 +84,4 @@ class HearingsControllerIT {
                             .header(SERVICE_AUTHORIZATION, SERVICE_AUTH_HEADER))
             .andExpect(status().isOk());
     }
-
 }

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -1,0 +1,3 @@
+security:
+  anonymousPaths:
+    - "/**"


### PR DESCRIPTION
Currently mocking of ServiceAuthfilter is restricting the call to even reach beyond this point in filter chain. Instead configured a profile to add all paths to anonymous in Integration tests. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
