### PR TITLE
Change primary key for postcode lookup

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -58,3 +58,9 @@ resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
   value        = var.product
   key_vault_id = data.azurerm_key_vault.pcs_key_vault.id
 }
+
+resource "azurerm_key_vault_secret" "POSTGRES_PORT" {
+  name         = "${var.component}-POSTGRES-PORT"
+  value        = "5432"
+  key_vault_id = data.azurerm_key_vault.pcs_key_vault.id
+}

--- a/src/main/resources/db/migration/V001__postcode_court.sql
+++ b/src/main/resources/db/migration/V001__postcode_court.sql
@@ -1,8 +1,11 @@
 CREATE TABLE postcode_court_mapping (
-    postcode VARCHAR(20) PRIMARY KEY,
+    postcode VARCHAR(20) NOT NULL,
     epimid INT NOT NULL,
     legislative_country VARCHAR(80) NOT NULL,
     effective_from TIMESTAMP,
     effective_to TIMESTAMP,
-    audit JSONB NOT NULL
+    audit JSONB NOT NULL,
+    PRIMARY KEY (postcode, epimid)
 );
+
+CREATE INDEX idx_postcode ON postcode_court_mapping(postcode);


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/HDPI-350

Based on further discussions, a post code can have multiple entries in table when a postcode is reassigned to another court but managed with effective dates. Hence changing the primary key to be based of postcode, epimid and adding a index on postcode.

Migration isn;t applied anywhere yet due to missing secret, so changing is fine.

Also adds missing secret for flyway to run in AAT.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
