### PR TITLE
Add db integration test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -377,6 +377,7 @@ tasks.withType(CftlibExec).configureEach {
   environment 'RSE_LIB_ADDITIONAL_DATABASES', 'pcs'
   environment 'PCS_DB_USER_NAME', 'postgres'
   environment 'PCS_DB_PASSWORD', 'postgres'
+  environment 'DB_PORT', '6432'
   environment 'SPRING_PROFILES_ACTIVE', 'dev'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -374,6 +374,9 @@ project.tasks.named("processSmokeTestResources") {
 tasks.withType(CftlibExec).configureEach {
   group = 'ccd tasks'
   authMode = AuthMode.Local
+  environment 'RSE_LIB_ADDITIONAL_DATABASES', 'pcs'
+  environment 'PCS_DB_USER_NAME', 'postgres'
+  environment 'PCS_DB_PASSWORD', 'postgres'
   environment 'SPRING_PROFILES_ACTIVE', 'dev'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -282,6 +282,7 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
@@ -331,6 +332,9 @@ dependencies {
     exclude group: 'junit', module: 'junit'
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
+  testImplementation group: 'com.h2database', name: 'h2', version: '2.3.232'
+  testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.20.6'
+  testImplementation group: 'org.apache.commons', name: 'commons-compress', version: '1.27.1'
   // Allow fast reloading during dev; recompile a class to trigger fast reload + definition reimport.
   cftlibImplementation 'org.springframework.boot:spring-boot-devtools'
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     ports:
-      - "${DB_PORT}:${DB_PORT}"
+      - "${DB_PORT}:5432"
     volumes:
       - pcs-api-db-data:/var/lib/postgresql/data
     healthcheck:

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcs/PostgresContainerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcs/PostgresContainerTest.java
@@ -28,6 +28,7 @@ public abstract class PostgresContainerTest {
         registry.add("spring.datasource.username", postgres::getUsername);
         registry.add("spring.datasource.password", postgres::getPassword);
         registry.add("spring.datasource.driver-class-name", postgres::getDriverClassName);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
         registry.add("spring.flyway.enabled", () -> true);
         registry.add("flyway.noop.strategy", () -> false);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcs/PostgresContainerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcs/PostgresContainerTest.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.pcs;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public abstract class PostgresContainerTest {
+
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
+        "postgres:16-alpine"
+    );
+
+    @BeforeAll
+    static void beforeAll() {
+        postgres.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        postgres.stop();
+    }
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driver-class-name", postgres::getDriverClassName);
+        registry.add("spring.flyway.enabled", () -> true);
+        registry.add("flyway.noop.strategy", () -> false);
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcs/repository/PostcodeCourtMappingRepositoryIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcs/repository/PostcodeCourtMappingRepositoryIT.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.pcs.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.jdbc.Sql;
+import uk.gov.hmcts.reform.pcs.PostgresContainerTest;
+import uk.gov.hmcts.reform.pcs.entity.PostcodeCourtMapping;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Sql("/postcode-court-mappings.sql")
+public class PostcodeCourtMappingRepositoryIT extends PostgresContainerTest {
+
+    @Autowired
+    private PostcodeCourtMappingRepository underTest;
+
+    @Test
+    void shouldCreateHearing() {
+        List<PostcodeCourtMapping> allMappings = underTest.findAll();
+
+        assertThat(allMappings).hasSize(2);
+    }
+
+}

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -4,3 +4,11 @@ security:
 spring:
   flyway:
     enabled: false
+  jpa:
+    hibernate:
+      ddl-auto: none
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:db;DB_CLOSE_DELAY=-1
+    username: sa
+    password: sa

--- a/src/integrationTest/resources/postcode-court-mappings.sql
+++ b/src/integrationTest/resources/postcode-court-mappings.sql
@@ -1,0 +1,4 @@
+INSERT INTO postcode_court_mapping (postcode, epimid, legislative_country, effective_from, effective_to, audit)
+VALUES
+  ('W3 7RX', 20262, 'England', NULL, '2035-04-01 18:00:00', '{"created_by": "test", "change_reason": "test insert"}'::jsonb),
+  ('W1 6AB', 36791, 'England', '2025-02-01 08:00:00', NULL, '{"created_by": "test", "change_reason": "test insert"}'::jsonb);

--- a/src/main/java/uk/gov/hmcts/reform/pcs/entity/PostcodeCourtMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/entity/PostcodeCourtMapping.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.pcs.entity;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * Placeholder entity for repository integration test.
+ */
+@Entity
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "postcode_court_mapping")
+public class PostcodeCourtMapping {
+
+    @EmbeddedId
+    @Builder.Default
+    private PostcodeEpimId id = new PostcodeEpimId();
+
+    private String legislativeCountry;
+    private Instant effectiveFrom;
+    private Instant effectiveTo;
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/entity/PostcodeEpimId.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/entity/PostcodeEpimId.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.pcs.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+public class PostcodeEpimId implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private String postcode;
+
+    private int epimid;
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/repository/PostcodeCourtMappingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/repository/PostcodeCourtMappingRepository.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.pcs.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.hmcts.reform.pcs.entity.PostcodeCourtMapping;
+import uk.gov.hmcts.reform.pcs.entity.PostcodeEpimId;
+
+public interface PostcodeCourtMappingRepository extends JpaRepository<PostcodeCourtMapping, PostcodeEpimId> {
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,6 +52,7 @@ spring:
   jpa:
     properties:
       hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
         jdbc:
           lob:
             # silence the 'wall-of-text' - unnecessary exception throw about blob types


### PR DESCRIPTION
### Change description

Add Spring Data JPA as a dependency to the project and ensure that existing integration tests still pass. Then adding a simple entity, JPA repository and @DataJpaTest along with a Postgres DB running in TestContainers, as a sample of how it can be done.

ITs that don't need a DB are configured to use an in-memory H2 DB, with none of the DB migrations applied. ITs that do need the DB can extend PostgresContainerTest to have a Postgres DB spun up and the app configured to point to it.

### Testing done

All automated tests run

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
