### PR TITLE
HDPI-504: Get email delivery Status (Asynchronously)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/config/AsyncConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/config/AsyncConfiguration.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.pcs.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.context.annotation.Bean;
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfiguration {
+    
+    @Bean(name = "notificationExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("NotifyAsync-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/notify/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/notify/service/NotificationService.java
@@ -1,29 +1,36 @@
 package uk.gov.hmcts.reform.pcs.notify.service;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.pcs.notify.exception.NotificationException;
 import uk.gov.hmcts.reform.pcs.notify.model.EmailNotificationRequest;
 import uk.gov.service.notify.NotificationClient;
-import org.springframework.stereotype.Service;
 import uk.gov.service.notify.NotificationClientException;
 import uk.gov.service.notify.SendEmailResponse;
+import uk.gov.service.notify.Notification;
 
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @Service
-@Slf4j
 public class NotificationService {
-
-    private  final NotificationClient notificationClient;
+    private static final Logger log = LoggerFactory.getLogger(NotificationService.class);
+    private final NotificationClient notificationClient;
+    private final long statusCheckDelay;
 
     public NotificationService(
-        NotificationClient notificationClient) {
+        NotificationClient notificationClient,
+        @Value("${notify.status-check-delay}") long statusCheckDelay) {
         this.notificationClient = notificationClient;
+        this.statusCheckDelay = statusCheckDelay;
     }
 
     public SendEmailResponse sendEmail(EmailNotificationRequest emailRequest) {
-        final SendEmailResponse sendEmailResponse;
+        SendEmailResponse sendEmailResponse;
         final String destinationAddress = emailRequest.getEmailAddress();
         final String templateId = emailRequest.getTemplateId();
         final Map<String, Object> personalisation = emailRequest.getPersonalisation();
@@ -38,6 +45,9 @@ public class NotificationService {
             );
 
             log.debug("Email sent successfully. Reference ID: {}", referenceId);
+            
+            // Trigger async status check
+            checkNotificationStatus(sendEmailResponse.getNotificationId().toString());
 
             return sendEmailResponse;
         } catch (NotificationClientException notificationClientException) {
@@ -48,6 +58,31 @@ public class NotificationService {
             );
 
             throw new NotificationException("Email failed to send, please try again.", notificationClientException);
+        }
+    }
+
+    @Async("notificationExecutor")
+    protected void checkNotificationStatus(String notificationId) {
+        try {
+            // Wait for configured delay
+            TimeUnit.MILLISECONDS.sleep(statusCheckDelay);
+            
+            Notification notification = notificationClient.getNotificationById(notificationId);
+            log.info("Notification status check - ID: {}, Status: {}, CreatedAt: {}, CompletedAt: {}", 
+                notificationId,
+                notification.getStatus(),
+                notification.getCreatedAt(),
+                notification.getCompletedAt()
+            );
+        } catch (NotificationClientException | InterruptedException e) {
+            log.error("Error checking notification status for ID: {}. Error: {}", 
+                notificationId, 
+                e.getMessage(),
+                e
+            );
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/notify/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/notify/service/NotificationService.java
@@ -26,7 +26,7 @@ public class NotificationService {
 
     public NotificationService(
         NotificationClient notificationClient,
-        @Value("${notify.status-check-delay}") long statusCheckDelay) {
+        @Value("${notify.status-check-delay-millis}") long statusCheckDelay) {
         this.notificationClient = notificationClient;
         this.statusCheckDelay = statusCheckDelay;
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -92,4 +92,4 @@ hmc:
 
 notify:
   api-key: ${PCS_NOTIFY_API_KEY:AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}
-  status-check-delay: ${NOTIFY_STATUS_CHECK_DELAY:3000}
+  status-check-delay-millis: ${NOTIFY_STATUS_CHECK_DELAY:3000}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -92,3 +92,4 @@ hmc:
 
 notify:
   api-key: ${PCS_NOTIFY_API_KEY:AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}
+  status-check-delay: ${NOTIFY_STATUS_CHECK_DELAY:3000}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/notify/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/notify/service/NotificationServiceTest.java
@@ -1,19 +1,26 @@
 package uk.gov.hmcts.reform.pcs.notify.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import uk.gov.hmcts.reform.pcs.config.AsyncConfiguration;
 import uk.gov.hmcts.reform.pcs.notify.exception.NotificationException;
 import uk.gov.hmcts.reform.pcs.notify.model.EmailNotificationRequest;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 import uk.gov.service.notify.SendEmailResponse;
+import uk.gov.service.notify.Notification;
 
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -24,13 +31,20 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@SpringJUnitConfig(AsyncConfiguration.class)
 class NotificationServiceTest {
 
     @Mock
     private NotificationClient notificationClient;
 
-    @InjectMocks
     private NotificationService notificationService;
+
+    private static final long STATUS_CHECK_DELAY = 100L; // 100ms for faster tests
+
+    @BeforeEach
+    void setUp() {
+        notificationService = new NotificationService(notificationClient, STATUS_CHECK_DELAY);
+    }
 
     @Test
     void testSendEmailSuccess() throws NotificationClientException {
@@ -74,5 +88,56 @@ class NotificationServiceTest {
             .hasMessage("Email failed to send, please try again.");
 
         verify(notificationClient).sendEmail(anyString(), anyString(), anyMap(), anyString());
+    }
+
+    @Test
+    void testCheckNotificationStatusDelivered() throws NotificationClientException, InterruptedException, ExecutionException, TimeoutException {
+        String notificationId = UUID.randomUUID().toString();
+        Notification notification = mock(Notification.class);
+        
+        when(notification.getStatus()).thenReturn("delivered");
+        when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
+
+        CompletableFuture<Notification> future = notificationService.checkNotificationStatus(notificationId);
+        Notification result = future.get(6, TimeUnit.SECONDS);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getStatus()).isEqualTo("delivered");
+        verify(notificationClient).getNotificationById(notificationId);
+    }
+
+    @Test
+    void testCheckNotificationStatusPending() throws NotificationClientException, InterruptedException, ExecutionException, TimeoutException {
+        String notificationId = UUID.randomUUID().toString();
+        Notification notification = mock(Notification.class);
+
+        when(notification.getStatus()).thenReturn("pending");
+        when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
+
+        CompletableFuture<Notification> future = notificationService.checkNotificationStatus(notificationId);
+        Notification result = future.get(6, TimeUnit.SECONDS);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getStatus()).isEqualTo("pending");
+        verify(notificationClient).getNotificationById(notificationId);
+    }
+
+    @Test
+    void testCheckNotificationStatusError() throws NotificationClientException {
+        String notificationId = UUID.randomUUID().toString();
+        when(notificationClient.getNotificationById(notificationId))
+            .thenThrow(new NotificationClientException("Failed to fetch notification status"));
+
+        CompletableFuture<Notification> future = notificationService.checkNotificationStatus(notificationId);
+        
+        assertThatThrownBy(() -> future.get(6, TimeUnit.SECONDS))
+            .isInstanceOf(ExecutionException.class)
+            .satisfies(thrown -> {
+                assertThat(thrown.getCause())
+                    .isInstanceOf(NotificationClientException.class)
+                    .hasMessage("Failed to fetch notification status");
+            });
+
+        verify(notificationClient).getNotificationById(notificationId);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/notify/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/notify/service/NotificationServiceTest.java
@@ -66,7 +66,8 @@ class NotificationServiceTest {
         SendEmailResponse response = notificationService.sendEmail(emailRequest);
 
         assertThat(response).isNotNull();
-        assertThat(response.getNotificationId()).isEqualTo(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"));
+        assertThat(response.getNotificationId())
+            .isEqualTo(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"));
         assertThat(response.getReference()).contains("reference");
         verify(notificationClient).sendEmail(anyString(), anyString(), anyMap(), anyString());
     }
@@ -91,7 +92,8 @@ class NotificationServiceTest {
     }
 
     @Test
-    void testCheckNotificationStatusDelivered() throws NotificationClientException, InterruptedException, ExecutionException, TimeoutException {
+    void testCheckNotificationStatusDelivered() throws NotificationClientException, 
+            InterruptedException, ExecutionException, TimeoutException {
         String notificationId = UUID.randomUUID().toString();
         Notification notification = mock(Notification.class);
         
@@ -107,7 +109,8 @@ class NotificationServiceTest {
     }
 
     @Test
-    void testCheckNotificationStatusPending() throws NotificationClientException, InterruptedException, ExecutionException, TimeoutException {
+    void testCheckNotificationStatusPending() throws NotificationClientException, 
+            InterruptedException, ExecutionException, TimeoutException {
         String notificationId = UUID.randomUUID().toString();
         Notification notification = mock(Notification.class);
 


### PR DESCRIPTION
### Jira link

[HDPI-504](https://tools.hmcts.net/jira/browse/HDPI-504)

### Change description

This PR implements an asynchronous notification status check feature, that monitors the delivery status of notifications after they are sent. Main updates include:

- System now checks the status of sent emails, after waiting for a configurable amount of time
- Added a setting to control how long to wait, before checking email status
- Added proper handling of any errors, that might occur during status checks
- System logs the results of these status checks, for monitoring purposes

### Testing done

Added unit tests to verify:
- Email status checks work correctly, when emails are successfully delivered
- System handles emails that are still waiting to be delivered
- System properly handles and reports any errors during status checks

Changes have been _manually_ tested by: 
- sending test emails, via Swagger 
- checking expected results in the logs


https://github.com/user-attachments/assets/04ab62f3-01f5-43d9-86de-4423fddec2a6



### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change