### PR TITLE
Cleanup of deprecations on build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ ccd {
   configDir = file('build/definitions')
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
   options.compilerArgs << "-Xlint:unchecked" << "-Werror"
 }
 
@@ -106,7 +106,7 @@ tasks.withType(JavaExec).configureEach {
   javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
   useJUnitPlatform()
   maxParallelForks = 1
 
@@ -119,7 +119,7 @@ test {
   failFast = true
 }
 
-task functional(type: Test) {
+tasks.register('functional', Test) {
   description = "Runs functional tests"
   group = "verification"
   dependsOn assemble, testClasses
@@ -155,7 +155,7 @@ serenity {
   reports = ["single-page-html"]
 }
 
-task integration(type: Test) {
+tasks.register('integration', Test) {
   description = "Runs integration tests"
   group = "Verification"
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
@@ -163,36 +163,36 @@ task integration(type: Test) {
   failFast = true
 }
 
-task smoke(type: Test) {
+tasks.register('smoke', Test) {
   description = "Runs Smoke Tests"
   testClassesDirs = sourceSets.smokeTest.output.classesDirs
   classpath = sourceSets.smokeTest.runtimeClasspath
 }
 
-task yarnInstall(type: Exec) {
+tasks.register('yarnInstall', Exec) {
   workingDir = file("${project.projectDir}/src/e2eTest")
   commandLine 'yarn', 'install'
 }
 
-task runE2eTests(type: Exec) {
+tasks.register('runE2eTests', Exec) {
   dependsOn yarnInstall
   workingDir = file("${project.projectDir}/src/e2eTest")
   commandLine 'yarn', 'test:functional'
 }
 
-task runE2eChromeTests(type: Exec) {
+tasks.register('runE2eChromeTests', Exec) {
   dependsOn yarnInstall
   workingDir = file("${project.projectDir}/src/e2eTest")
   commandLine 'yarn', 'test:chrome'
 }
 
-task runE2eFirefoxTests(type: Exec) {
+tasks.register('runE2eFirefoxTests', Exec) {
   dependsOn yarnInstall
   workingDir = file("${project.projectDir}/src/e2eTest")
   commandLine 'yarn', 'test:firefox'
 }
 
-task contract(type: Test) {
+tasks.register('contract', Test) {
   description = 'Runs the consumer Pact tests'
   useJUnitPlatform()
   testClassesDirs = sourceSets.contractTest.output.classesDirs
@@ -200,7 +200,7 @@ task contract(type: Test) {
   systemProperty 'pact.rootDir', "pacts"
 }
 
-task runAndPublishConsumerPactTests(type: Test) {
+tasks.register('runAndPublishConsumerPactTests', Test) {
   testClassesDirs = sourceSets.contractTest.output.classesDirs
   classpath = sourceSets.contractTest.runtimeClasspath
 }
@@ -222,7 +222,7 @@ runAndPublishConsumerPactTests.dependsOn contract
 
 runAndPublishConsumerPactTests.finalizedBy pactPublish
 
-def getCheckedOutGitCommitHash() {
+static def getCheckedOutGitCommitHash() {
   'git rev-parse --verify --short HEAD'.execute().text.trim()
 }
 
@@ -235,8 +235,13 @@ jacocoTestReport {
   }
 }
 
-project.tasks['sonarqube'].dependsOn jacocoTestReport
-project.tasks['check'].dependsOn integration
+tasks.named('sonarqube') {
+  dependsOn jacocoTestReport
+}
+
+tasks.named('check') {
+  dependsOn integration
+}
 
 sonarqube {
   properties {
@@ -271,37 +276,30 @@ repositories {
   maven { url = 'https://jitpack.io' }
 }
 
-def versions = [
-  lombok: '1.18.38',
-  flyway: "$flywayVersion",
-  springSecurityVersion: '6.4.4'
-]
-
 ext {
   log4JVersion = "2.24.3"
   logbackVersion = "1.5.18"
   testcontainersVersion = "1.20.6"
+  springFrameworkBootVersion = "3.4.4"
+  lombokVersion = "1.18.38"
+  springSecurityVersion = "6.4.4"
+  pactVersion = "4.6.17"
 }
 
 ext['snakeyaml.version'] = '2.0'
 
 dependencies {
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springFrameworkBootVersion
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: springFrameworkBootVersion
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: springFrameworkBootVersion
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json', version: springFrameworkBootVersion
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springFrameworkBootVersion
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: springFrameworkBootVersion
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '3.4.3'
 
-  constraints {
-    implementation('org.hibernate.orm:hibernate-core:6.6.11')
-  }
+  runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: flywayVersion
 
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'
-
-  runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: versions.flyway
-  implementation group: 'org.flywaydb', name: 'flyway-core', version: versions.flyway
-
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: flywayVersion
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.6'
   implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '5.2.1-RELEASE'
   implementation platform(group: 'com.azure.spring', name :'spring-cloud-azure-dependencies', version :'5.22.0')
@@ -318,11 +316,11 @@ dependencies {
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.5'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.0'
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.2.1'
-  implementation group: 'org.projectlombok', name: 'lombok', version: versions.lombok
+  implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
   implementation 'org.postgresql:postgresql:42.7.5'
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
+  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
 
-  implementation group: 'io.rest-assured', name: 'rest-assured'
+  testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.1'
 
   functionalTestImplementation group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: serenityBddVersion
   functionalTestImplementation group: 'net.serenity-bdd', name: 'serenity-core', version: serenityBddVersion
@@ -332,25 +330,23 @@ dependencies {
 
   testImplementation group: 'org.junit.platform', name: 'junit-platform-suite-api', version: '1.12.2'
 
-  contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: '4.6.17'
+  contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: pactVersion
   contractTestImplementation group: 'org.hamcrest', name: 'java-hamcrest', version: '2.0.0.0'
   contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.12.2')
   contractTestImplementation sourceSets.main.runtimeClasspath
   contractTestImplementation sourceSets.test.runtimeClasspath
 
   testImplementation(platform('org.junit:junit-bom:5.12.2'))
-  testImplementation group: 'org.springframework.security', name: 'spring-security-test', version: versions.springSecurityVersion
+  testImplementation group: 'org.springframework.security', name: 'spring-security-test', version: springSecurityVersion
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
+  testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springFrameworkBootVersion) {
     exclude group: 'junit', module: 'junit'
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
   testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
-
   testImplementation group: 'org.testcontainers', name: 'testcontainers', version: testcontainersVersion
   testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: testcontainersVersion
   testImplementation group: 'org.testcontainers', name: 'postgresql', version: testcontainersVersion
-
   testImplementation 'com.h2database:h2'
 
   // Allow fast reloading during dev; recompile a class to trigger fast reload + definition reimport.


### PR DESCRIPTION
### Jira link

[HDPI-602](https://tools.hmcts.net/jira/browse/HDPI-602)

### Change description

Cleanup of the build.gradle to get rid of deprecated declarations as well as multiple declarations. JPA must be set to 3.4.3 to work with our setup, hence it is one lower than the rest of the Spring Framework.

### Testing done

Automated testing.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
