### PR TITLE
Ignored test "Courts endpoint - returns 200 and expected court data for valid postcode" as required test data is not available in AAT env.

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcs/functional/tests/CourtsEndpointTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcs/functional/tests/CourtsEndpointTests.java
@@ -4,6 +4,7 @@ import net.serenitybdd.annotations.Issue;
 import net.serenitybdd.annotations.Title;
 import net.serenitybdd.junit5.SerenityJUnit5Extension;
 import net.serenitybdd.annotations.Steps;
+import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
@@ -61,6 +62,7 @@ class CourtsEndpointTests {
             apiSteps.checkStatusCode(200);
         }
 
+        @Ignore("This test is ignored for now due to missing test data in AAT")
         @Issue("HDPI-352")
         @Title("Courts endpoint - returns 200 and expected court data for valid postcode")
         @Test

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcs/functional/tests/CourtsEndpointTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcs/functional/tests/CourtsEndpointTests.java
@@ -4,13 +4,14 @@ import net.serenitybdd.annotations.Issue;
 import net.serenitybdd.annotations.Title;
 import net.serenitybdd.junit5.SerenityJUnit5Extension;
 import net.serenitybdd.annotations.Steps;
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.gov.hmcts.reform.pcs.functional.steps.ApiSteps;
+import org.junit.jupiter.api.Disabled;
+
 
 @Tag("Functional")
 @ExtendWith(SerenityJUnit5Extension.class)
@@ -62,7 +63,7 @@ class CourtsEndpointTests {
             apiSteps.checkStatusCode(200);
         }
 
-        @Ignore("This test is ignored for now due to missing test data in AAT")
+        @Disabled("This test is ignored/disabled for now due to missing test data in AAT")
         @Issue("HDPI-352")
         @Title("Courts endpoint - returns 200 and expected court data for valid postcode")
         @Test


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/HDPI-352

Change description

Test case @Title("Courts endpoint - returns 200 and expected court data for valid postcode") is ignored as test data used is present only in preview env and not in AAT, so causing test failure while running the tests in AAT.



Testing done

Tests were executed locally and this "Courts endpoint - returns 200 and expected court data for valid postcode") is ignored/not running any more now

Checklist



- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change