### PR TITLE
HDPI-750 - Switching to Azure DevOps Artefacts

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven {
-            url = "https://jitpack.io"
+            url = 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1'
         }
     }
 }


### PR DESCRIPTION
### Jira link

[HDPI-750](https://tools.hmcts.net/jira/browse/HDPI-750)

### Change description

Jitpack is no longer supported on the platform. This is to switch to Azure DevOps Artifacts following the guide at https://hmcts.github.io/cloud-native-platform/common-pipeline/publishing-libraries/java.html.

### Testing done

N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
