### PR TITLE
HDPI-753 Enhancements to courts endpoint

### DIFF
--- a/charts/pcs-api/values.preview.template.yaml
+++ b/charts/pcs-api/values.preview.template.yaml
@@ -12,6 +12,12 @@ java:
           alias: PCS_NOTIFY_API_KEY
         - name: hmc-servicebus-connection-string
           alias: HEARINGS_SERVICEBUS_CONNECTION_STRING
+        - name: idam-secret
+          alias: IDAM_CLIENT_SECRET
+        - name: idam-systemupdate-username
+          alias: IDAM_SYSTEM_UPDATE_USERNAME
+        - name: idam-systemupdate-password
+          alias: IDAM_SYSTEM_UPDATE_PASSWORD
   environment:
     PCS_DB_HOST: "{{ .Release.Name }}-postgresql"
     PCS_DB_USER_NAME: "{{ .Values.postgresql.auth.username}}"

--- a/charts/pcs-api/values.yaml
+++ b/charts/pcs-api/values.yaml
@@ -15,12 +15,21 @@ java:
           alias: PCS_NOTIFY_API_KEY
         - name: hmc-servicebus-connection-string
           alias: HEARINGS_SERVICEBUS_CONNECTION_STRING
+        - name: idam-secret
+          alias: IDAM_CLIENT_SECRET
+        - name: idam-systemupdate-username
+          alias: IDAM_SYSTEM_UPDATE_USERNAME
+        - name: idam-systemupdate-password
+          alias: IDAM_SYSTEM_UPDATE_PASSWORD
+
   environment:
     PCS_DB_USER_NAME: pgadmin
     PCS_DB_NAME: pcs
     DRAFT_STORE_DB_CONN_OPTIONS: "?sslmode=require&gssEncMode=disable"
     PCS_DB_HOST: "pcs-{{ .Values.global.environment }}.postgres.database.azure.com"
     IDAM_S2S_AUTH_URL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    IDAM_API_REDIRECT_URL: https://pcs-pfe-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/authenticated
+    IDAM_API_URL: "https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net"
     HMC_API_URL: "http://hmc-cft-hearing-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     LOCATION_REF_URL: "http://rd-location-ref-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     FLYWAY_NOOP_STRATEGY: "true"

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcs/functional/tests/CourtsEndpointTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcs/functional/tests/CourtsEndpointTests.java
@@ -5,7 +5,6 @@ import net.serenitybdd.annotations.Title;
 import net.serenitybdd.junit5.SerenityJUnit5Extension;
 import net.serenitybdd.annotations.Steps;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -77,9 +76,6 @@ class CourtsEndpointTests {
         apiSteps.checkStatusCode(401);
     }
 
-    //This test needs to be modified later to assert the response code as 401. As of now API response code is 200
-    //for Invalid/Expired Idam Token
-    @Disabled("Disabled as this needs to return 401, not 200")
     @Title("Courts endpoint - return 401 Unauthorised when the request uses an expired Idam token")
     @Test
     void courts401UnauthorisedScenarioExpiredIdamToken() {
@@ -91,8 +87,6 @@ class CourtsEndpointTests {
         apiSteps.checkStatusCode(401);
     }
 
-    //This test needs to be modified to check for response status 400, currently API returns 200
-    @Disabled("Disabled as this should return 400, not 200")
     @Title("Courts endpoint - returns 400 Bad Request for missing postcode")
     @Test
     void shouldReturn400ForInvalidPostcode() {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcs/postcodecourt/controller/PostCodeCourtControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcs/postcodecourt/controller/PostCodeCourtControllerIT.java
@@ -12,16 +12,16 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.pcs.Application;
 import uk.gov.hmcts.reform.pcs.config.AbstractPostgresContainerIT;
+import uk.gov.hmcts.reform.pcs.idam.IdamService;
 import uk.gov.hmcts.reform.pcs.location.service.api.LocationReferenceApi;
 import uk.gov.hmcts.reform.pcs.postcodecourt.entity.PostCodeCourtEntity;
 import uk.gov.hmcts.reform.pcs.location.model.CourtVenue;
 import uk.gov.hmcts.reform.pcs.postcodecourt.entity.PostCodeCourtKey;
+import uk.gov.hmcts.reform.pcs.exception.InvalidAuthorisationToken;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.Court;
 import uk.gov.hmcts.reform.pcs.postcodecourt.repository.PostCodeCourtRepository;
-
 import java.util.Collections;
 import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -51,6 +51,9 @@ class PostCodeCourtControllerIT extends AbstractPostgresContainerIT {
 
     @MockitoBean
     private LocationReferenceApi locationReferenceApi;
+
+    @MockitoBean
+    private IdamService idamService;
 
     @Test
     @DisplayName("Should return valid Http OK for known postcodes. The response should be empty for all epimIds.")
@@ -177,6 +180,74 @@ class PostCodeCourtControllerIT extends AbstractPostgresContainerIT {
                 .header(SERVICE_AUTHORIZATION, PCS_SERVICE_AUTH_HEADER)
                 .exchange().expectStatus().isBadRequest();
 
+    }
+
+    @Test
+    @DisplayName("Should return bad request when postcode is empty")
+    void shouldReturnStatus400WhenPostcodeEmpty() {
+        String postCode = "";
+
+        webTestClient.get()
+            .uri(uriBuilder -> uriBuilder.path(COURTS_ENDPOINT)
+                .queryParam(POSTCODE, postCode).build())
+            .header(SERVICE_AUTHORIZATION, PCS_SERVICE_AUTH_HEADER)
+            .header(AUTHORIZATION, AUTH_HEADER)
+            .exchange().expectStatus().isBadRequest();
+    }
+
+    @Test
+    @DisplayName("Should return bad request when postcode is missing")
+    void shouldReturnStatus400WhenPostcodeMissing() {
+
+        webTestClient.get()
+            .uri(COURTS_ENDPOINT)
+            .header(SERVICE_AUTHORIZATION, PCS_SERVICE_AUTH_HEADER)
+            .header(AUTHORIZATION, AUTH_HEADER)
+            .exchange().expectStatus().isBadRequest();
+    }
+
+    @Test
+    @DisplayName("Should return 401 when authorisation token is missing")
+    void shouldReturnStatus401WhenAuthorisationTokenIsMissing() {
+        String postCode = "E10 6DS";
+
+        when(idamService.validateAuthToken(""))
+            .thenThrow(new InvalidAuthorisationToken("Auth Token is empty"));
+
+        webTestClient.get()
+            .uri(uriBuilder -> uriBuilder.path(COURTS_ENDPOINT)
+                .queryParam(POSTCODE, postCode).build())
+            .header(SERVICE_AUTHORIZATION, PCS_SERVICE_AUTH_HEADER)
+            .header(AUTHORIZATION, "")
+            .exchange().expectStatus().isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("Should return status 200 when token is valid")
+    void shouldReturnStatus200WhenTokenIsValid() {
+        String postCode = "E10 QBX";
+        when(idamService.validateAuthToken(AUTH_HEADER)).thenReturn(true);
+
+        webTestClient.get().uri(uriBuilder -> uriBuilder.path(COURTS_ENDPOINT)
+                .queryParam(POSTCODE, postCode)
+                .build())
+            .header(SERVICE_AUTHORIZATION, PCS_SERVICE_AUTH_HEADER)
+            .header(AUTHORIZATION, AUTH_HEADER)
+            .exchange().expectStatus().isOk();
+    }
+
+    @Test
+    @DisplayName("Should return status 401 when token is invalid")
+    void shouldReturnStatus401WhenTokenInvalid() {
+        String postCode = "N17 EYM";
+        when(idamService.validateAuthToken(AUTH_HEADER)).thenThrow(new InvalidAuthorisationToken("Token is invalid"));
+
+        webTestClient.get().uri(uriBuilder -> uriBuilder.path(COURTS_ENDPOINT)
+                .queryParam(POSTCODE, postCode)
+                .build())
+            .header(SERVICE_AUTHORIZATION, PCS_SERVICE_AUTH_HEADER)
+            .header(AUTHORIZATION, AUTH_HEADER)
+            .exchange().expectStatus().isUnauthorized();
     }
 
     private void assertingResponseToBeEmptyList(List<PostCodeCourtEntity> all) {

--- a/src/main/java/uk/gov/hmcts/reform/pcs/config/IdamAuthenticationFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/config/IdamAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.reform.pcs.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import uk.gov.hmcts.reform.pcs.exception.InvalidAuthTokenException;
+import uk.gov.hmcts.reform.pcs.idam.IdamService;
+import uk.gov.hmcts.reform.pcs.idam.User;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Slf4j
+@Component
+public class IdamAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private  IdamService idamService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String path = request.getRequestURI();
+
+        if (!path.startsWith("/courts")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String authToken = request.getHeader("Authorization");
+
+        try {
+            User user = idamService.validateAuthToken(authToken);
+            Authentication authentication =
+                new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } catch (InvalidAuthTokenException ex) {
+            log.error("Authentication failed: {}", ex.getMessage(), ex);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            String json = "{\"error\":\"" + ex.getMessage() + "\"}";
+            response.getWriter().write(json);
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/config/SecurityConfiguration.java
@@ -17,6 +17,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 import uk.gov.hmcts.reform.authorisation.filters.ServiceAuthFilter;
 
+
 @Configuration
 @ConfigurationProperties(prefix = "security")
 @EnableWebSecurity
@@ -25,11 +26,13 @@ public class SecurityConfiguration {
     @Getter
     private final List<String> anonymousPaths = new ArrayList<>();
     private final ServiceAuthFilter serviceAuthFilter;
+    private final IdamAuthenticationFilter idamAuthFilter;
 
     @Autowired
-    public SecurityConfiguration(ServiceAuthFilter serviceAuthFilter) {
+    public SecurityConfiguration(ServiceAuthFilter serviceAuthFilter, IdamAuthenticationFilter idamAuthFilter) {
         super();
         this.serviceAuthFilter = serviceAuthFilter;
+        this.idamAuthFilter = idamAuthFilter;
     }
 
     @Bean
@@ -43,6 +46,11 @@ public class SecurityConfiguration {
 
         http
             .addFilterBefore(serviceAuthFilter, AbstractPreAuthenticatedProcessingFilter.class)
+            .addFilterBefore(idamAuthFilter, AbstractPreAuthenticatedProcessingFilter.class)
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/courts/**").authenticated() // Secure courts endpoints
+                .anyRequest().permitAll()                      // All other endpoints allowed
+            )
             .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(STATELESS))
             .httpBasic(AbstractHttpConfigurer::disable)
             .formLogin(AbstractHttpConfigurer::disable)

--- a/src/main/java/uk/gov/hmcts/reform/pcs/controllers/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/controllers/RestExceptionHandler.java
@@ -1,12 +1,15 @@
 package uk.gov.hmcts.reform.pcs.controllers;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import uk.gov.hmcts.reform.pcs.exception.CaseNotFoundException;
+import uk.gov.hmcts.reform.pcs.exception.InvalidAuthorisationToken;
 
+@Slf4j
 @ControllerAdvice
 public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
@@ -15,6 +18,14 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)
             .body(new Error(caseNotFoundException.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidAuthorisationToken.class)
+    public ResponseEntity<Error> handleInvalidAuthorisationToken(InvalidAuthorisationToken ex) {
+        log.error("Auth token validation failed: {}", ex.getMessage(), ex);
+        return ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(new Error(ex.getMessage()));
     }
 
     public record Error(String message) {}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/controllers/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/controllers/RestExceptionHandler.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import uk.gov.hmcts.reform.pcs.exception.CaseNotFoundException;
-import uk.gov.hmcts.reform.pcs.exception.InvalidAuthorisationToken;
 
 @Slf4j
 @ControllerAdvice
@@ -18,14 +17,6 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)
             .body(new Error(caseNotFoundException.getMessage()));
-    }
-
-    @ExceptionHandler(InvalidAuthorisationToken.class)
-    public ResponseEntity<Error> handleInvalidAuthorisationToken(InvalidAuthorisationToken ex) {
-        log.error("Auth token validation failed: {}", ex.getMessage(), ex);
-        return ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(new Error(ex.getMessage()));
     }
 
     public record Error(String message) {}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/exception/InvalidAuthTokenException.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/exception/InvalidAuthTokenException.java
@@ -1,6 +1,10 @@
 package uk.gov.hmcts.reform.pcs.exception;
 
 public class InvalidAuthorisationToken extends RuntimeException {
+    public InvalidAuthorisationToken(String message, Exception cause) {
+        super(message, cause);
+    }
+
     public InvalidAuthorisationToken(String message) {
         super(message);
     }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/exception/InvalidAuthTokenException.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/exception/InvalidAuthTokenException.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.reform.pcs.exception;
 
-public class InvalidAuthorisationToken extends RuntimeException {
-    public InvalidAuthorisationToken(String message, Exception cause) {
+public class InvalidAuthTokenException extends RuntimeException {
+    public InvalidAuthTokenException(String message, Exception cause) {
         super(message, cause);
     }
 
-    public InvalidAuthorisationToken(String message) {
+    public InvalidAuthTokenException(String message) {
         super(message);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/exception/InvalidAuthorisationToken.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/exception/InvalidAuthorisationToken.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.pcs.exception;
+
+public class InvalidAuthorisationToken extends RuntimeException {
+    public InvalidAuthorisationToken(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/idam/IdamService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/idam/IdamService.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.reform.pcs.idam;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import feign.FeignException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.pcs.exception.InvalidAuthorisationToken;
+
+import static com.azure.spring.cloud.autoconfigure.implementation.aad.security.constants.Constants.BEARER_PREFIX;
+
+@Service
+@Slf4j
+public class IdamService {
+
+    @Autowired
+    private IdamClient idamClient;
+
+    public boolean validateAuthToken(String authorisation) {
+        if (authorisation == null || authorisation.isBlank()) {
+            log.warn("Missing or empty Authorisation token");
+            throw new InvalidAuthorisationToken("Authorisation token is missing or empty");
+        }
+        try {
+            retrieveUser(authorisation);
+            log.info("Successfully authenticated token: {}", authorisation);
+            return true;
+        } catch (FeignException.Unauthorized ex) {
+            log.error(ex.getMessage(),ex);
+            throw new InvalidAuthorisationToken("Authorisation token is invalid or expired");
+        } catch (Exception ex) {
+            log.error("Unexpected error while validating Authorisation token", ex);
+            return false;
+        }
+    }
+
+    public User retrieveUser(String authorisation) {
+        final String bearerToken = getBearerToken(authorisation);
+        final var userDetails = idamClient.getUserInfo(bearerToken);
+
+        return new User(bearerToken, userDetails);
+    }
+
+
+    private String getBearerToken(String token) {
+        if (StringUtils.isBlank(token)) {
+            return token;
+        }
+        return token.startsWith(BEARER_PREFIX) ? token : BEARER_PREFIX.concat(token);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/idam/User.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/idam/User.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.reform.pcs.idam;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import uk.gov.hmcts.reform.idam.client.models.UserInfo;
+
+@Getter
+@AllArgsConstructor
+public class User {
+    private String authToken;
+    private UserInfo userDetails;
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/postcodecourt/exception/InvalidPostCodeException.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/postcodecourt/exception/InvalidPostCodeException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.pcs.postcodecourt.exception;
+
+public class InvalidPostCodeException extends RuntimeException {
+    public InvalidPostCodeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/postcodecourt/exception/PostCodeCourtExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/postcodecourt/exception/PostCodeCourtExceptionHandler.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.pcs.postcodecourt.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice(basePackages = "uk.gov.hmcts.reform.pcs.postcodecourt")
+public class PostCodeCourtExceptionHandler {
+
+    @ExceptionHandler(InvalidPostCodeException.class)
+    public ResponseEntity<Error> handleInvalidPostCodeException(InvalidPostCodeException ex) {
+        log.error("Invalid postcode {}", ex.getMessage(), ex);
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(new Error(ex.getMessage()));
+    }
+
+    public record Error(String message) {}
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/postcodecourt/service/PostCodeCourtService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/postcodecourt/service/PostCodeCourtService.java
@@ -25,7 +25,7 @@ public class PostCodeCourtService {
     private final LocationReferenceService locationReferenceService;
 
     public List<Court> getCountyCourtsByPostCode(String postcode, String authorisation) {
-        if (postcode == null || postcode.isEmpty()) {
+        if (postcode == null || postcode.isBlank()) {
             throw new InvalidPostCodeException("Postcode cannot be empty or null");
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/postcodecourt/service/PostCodeCourtService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/postcodecourt/service/PostCodeCourtService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.pcs.location.service.LocationReferenceService;
 import uk.gov.hmcts.reform.pcs.location.model.CourtVenue;
 import uk.gov.hmcts.reform.pcs.postcodecourt.entity.PostCodeCourtEntity;
+import uk.gov.hmcts.reform.pcs.postcodecourt.exception.InvalidPostCodeException;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.Court;
 import uk.gov.hmcts.reform.pcs.postcodecourt.repository.PostCodeCourtRepository;
 
@@ -24,6 +25,9 @@ public class PostCodeCourtService {
     private final LocationReferenceService locationReferenceService;
 
     public List<Court> getCountyCourtsByPostCode(String postcode, String authorisation) {
+        if (postcode == null || postcode.isEmpty()) {
+            throw new InvalidPostCodeException("Postcode cannot be empty or null");
+        }
 
         List<Integer> epimIds = getPostcodeCourtMappings(postcode).stream()
             .map(postCodeCourt -> {
@@ -45,10 +49,6 @@ public class PostCodeCourtService {
     }
 
     private List<PostCodeCourtEntity> getPostcodeCourtMappings(String postcode) {
-        if (postcode == null) {
-            log.warn("Returning empty list of postcode court mappings for null postcode.");
-            return List.of();
-        }
 
         postcode = postcode.replaceAll("\\s", "").toUpperCase(Locale.ROOT);
         return postCodeCourtRepository.findByIdPostCode(postcode);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,6 +82,13 @@ idam:
     microservice: ${S2S_SERVICE_NAME:pcs_api}
   s2s-authorised:
     services: ${S2S_NAMES_WHITELIST:pcs_api,pcs_frontend,ccd_data}
+  systemupdate:
+    username: ${IDAM_SYSTEM_UPDATE_USERNAME:dummysystemupdate@test.com}
+    password: ${IDAM_SYSTEM_UPDATE_PASSWORD:dummy}
+  client:
+    id: 'pcs'
+    secret: ${IDAM_CLIENT_SECRET:123456}
+    redirect_uri: ${IDAM_API_REDIRECT_URL:http://localhost:3001/oauth2/callback}
 
 azure:
   application-insights:

--- a/src/test/java/uk/gov/hmcts/reform/pcs/dashboard/service/endpoint/DashboardControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/dashboard/service/endpoint/DashboardControllerTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.pcs.dashboard.model.TaskGroup;
 import uk.gov.hmcts.reform.pcs.dashboard.service.DashboardNotificationService;
 import uk.gov.hmcts.reform.pcs.dashboard.service.DashboardTaskService;
 import uk.gov.hmcts.reform.pcs.exception.CaseNotFoundException;
+import uk.gov.hmcts.reform.pcs.idam.IdamService;
 
 import java.util.List;
 
@@ -30,6 +31,9 @@ class DashboardControllerTest {
 
     @MockitoBean
     private DashboardNotificationService dashboardNotificationService;
+
+    @MockitoBean
+    private IdamService idamService;
 
     @Test
     @WithMockUser

--- a/src/test/java/uk/gov/hmcts/reform/pcs/postcodecourt/controller/PostCodeCourtControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/postcodecourt/controller/PostCodeCourtControllerTest.java
@@ -8,6 +8,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.reform.pcs.idam.IdamService;
+import uk.gov.hmcts.reform.pcs.exception.InvalidAuthorisationToken;
+import uk.gov.hmcts.reform.pcs.postcodecourt.exception.InvalidPostCodeException;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.Court;
 import uk.gov.hmcts.reform.pcs.postcodecourt.service.PostCodeCourtService;
 
@@ -15,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,16 +33,19 @@ class PostCodeCourtControllerTest {
     @Mock
     private PostCodeCourtService postCodeCourtService;
 
+    @Mock
+    private IdamService idamService;
+
     @Test
     @DisplayName("Should return list of courts with Http200 for valid postcode")
     void shouldHandlePostcodesRequestWithCourtsInResponse() {
         List<Court> courts = List.of(new Court(40827, "Central London County Court", 20262));
         when(postCodeCourtService.getCountyCourtsByPostCode(POST_CODE, AUTH_TOKEN))
-                .thenReturn(courts);
+            .thenReturn(courts);
         ResponseEntity<List<Court>> response = underTest.getCourts(
-                AUTH_TOKEN,
+            AUTH_TOKEN,
             "ServiceAuthToken",
-                POST_CODE
+            POST_CODE
         );
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(courts);
@@ -49,16 +56,39 @@ class PostCodeCourtControllerTest {
     @DisplayName("Should return empty list of courts with Http200 for valid postcode")
     void shouldHandlePostcodesRequestWithEmptyListOfCourtsInResponse() {
         when(postCodeCourtService.getCountyCourtsByPostCode(POST_CODE, AUTH_TOKEN))
-                .thenReturn(Collections.emptyList());
+            .thenReturn(Collections.emptyList());
         ResponseEntity<List<Court>> response = underTest.getCourts(
-                AUTH_TOKEN,
-                "ServiceAuthToken",
-                POST_CODE
+            AUTH_TOKEN,
+            "ServiceAuthToken",
+            POST_CODE
         );
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(Collections.emptyList());
         verify(postCodeCourtService).getCountyCourtsByPostCode(POST_CODE, AUTH_TOKEN);
     }
+
+    @Test
+    @DisplayName("Should throw InvalidPostCode exception when postcode is null")
+    void shouldThrowInvalidPostCodeExceptionWhenPostCodeIsNull() {
+        when(postCodeCourtService.getCountyCourtsByPostCode(null, AUTH_TOKEN))
+            .thenThrow(new InvalidPostCodeException("Postcode cannot be empty or null"));
+        assertThatThrownBy(() -> underTest.getCourts(AUTH_TOKEN, "ServiceAuthToken", null))
+            .isInstanceOf(InvalidPostCodeException.class)
+            .hasMessage("Postcode cannot be empty or null");
+    }
+
+    @Test
+    @DisplayName("Should throw InvalidPostCode exception when postcode is empty")
+    void shouldThrowInvalidPostCodeExceptionWhenPostCodeIsEmpty() {
+        String emptyPostcode = "";
+        when(postCodeCourtService.getCountyCourtsByPostCode(emptyPostcode, AUTH_TOKEN))
+            .thenThrow(new InvalidPostCodeException("Postcode cannot be empty or null"));
+        assertThatThrownBy(() -> underTest.getCourts(AUTH_TOKEN, "ServiceAuthToken", emptyPostcode))
+            .isInstanceOf(InvalidPostCodeException.class)
+            .hasMessage("Postcode cannot be empty or null");
+    }
+
 }
+
 
 

--- a/src/test/java/uk/gov/hmcts/reform/pcs/postcodecourt/controller/PostCodeCourtControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/postcodecourt/controller/PostCodeCourtControllerTest.java
@@ -9,7 +9,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.pcs.idam.IdamService;
-import uk.gov.hmcts.reform.pcs.exception.InvalidAuthorisationToken;
 import uk.gov.hmcts.reform.pcs.postcodecourt.exception.InvalidPostCodeException;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.Court;
 import uk.gov.hmcts.reform.pcs.postcodecourt.service.PostCodeCourtService;

--- a/src/test/java/uk/gov/hmcts/reform/pcs/postcodecourt/exception/PostCodeCourtExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/postcodecourt/exception/PostCodeCourtExceptionHandlerTest.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.pcs.postcodecourt.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PostCodeCourtExceptionHandlerTest {
+
+    private final PostCodeCourtExceptionHandler handler = new PostCodeCourtExceptionHandler();
+
+    @Test
+    void shouldReturnInvalidPostcodeException() {
+        InvalidPostCodeException ex = mock(InvalidPostCodeException.class);
+
+        when(ex.getMessage()).thenReturn("Postcode cannot be null or empty");
+        ResponseEntity<PostCodeCourtExceptionHandler.Error> response = handler.handleInvalidPostCodeException(ex);
+
+        assertThat(HttpStatus.BAD_REQUEST).isEqualTo(response.getStatusCode());
+        assertThat(response.getBody()).isNotNull();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/postcodecourt/service/PostCodeCourtServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/postcodecourt/service/PostCodeCourtServiceTest.java
@@ -10,12 +10,14 @@ import uk.gov.hmcts.reform.pcs.postcodecourt.entity.PostCodeCourtEntity;
 import uk.gov.hmcts.reform.pcs.postcodecourt.entity.PostCodeCourtKey;
 import uk.gov.hmcts.reform.pcs.location.service.LocationReferenceService;
 import uk.gov.hmcts.reform.pcs.location.model.CourtVenue;
+import uk.gov.hmcts.reform.pcs.postcodecourt.exception.InvalidPostCodeException;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.Court;
 import uk.gov.hmcts.reform.pcs.postcodecourt.repository.PostCodeCourtRepository;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -75,14 +77,23 @@ class PostCodeCourtServiceTest {
     }
 
     @Test
-    @DisplayName("Should return an empty list of CountyCourts for a null postcode")
-    void shouldReturnEmptyListOfCountyCourtsForNullPostCode() {
-        String nullPostcode = null;
-
-        final List<Court> response = underTest.getCountyCourtsByPostCode(nullPostcode, null);
-
-        assertThat(response).isEmpty();
+    @DisplayName("Should throw InvalidPostCode exception when postcode empty")
+    void shouldThrowInvalidPostCodeExceptionWhenPostcodeIsEmpty() {
+        String emptyPostCode = "";
+        assertThatThrownBy(() -> underTest.getCountyCourtsByPostCode(emptyPostCode, null)).isInstanceOf(
+                InvalidPostCodeException.class)
+            .hasMessage("Postcode cannot be empty or null");
         verify(postCodeCourtRepository, never()).findByIdPostCode(any());
     }
+
+    @Test
+    @DisplayName("Should throw InvalidPostCode exception when postcode null")
+    void shouldThrowInvalidPostCodeExceptionWhenPostcodeIsNull() {
+        assertThatThrownBy(() -> underTest.getCountyCourtsByPostCode(null, null)).isInstanceOf(
+                InvalidPostCodeException.class)
+            .hasMessage("Postcode cannot be empty or null");
+        verify(postCodeCourtRepository, never()).findByIdPostCode(any());
+    }
+
 
 }


### PR DESCRIPTION
[HDPI-753](https://tools.hmcts.net/jira/browse/HDPI-753)

### Change description

Added validation for IDAM token and postcode param on /courts endpoints.
- Returns 401 when IDAM token is invalid, expired, or missing.
- Returns 400 when postcode is null, empty, or not provided.
- Ensures valid tokens and postcodes return 200 when matched.

### Testing done

- Unit and Integration tests were added.
- Manual testing done for IDAM tokens and postcodes via postman.

### Checklist

- [x] tests have been updated / new tests has been added (if needed)

