### PR TITLE
HDPI-787: Use system user ID tokens for service calls

### DIFF
--- a/charts/pcs-api/Chart.yaml
+++ b/charts/pcs-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for pcs-api App
 name: pcs-api
 home: https://github.com/hmcts/pcs-api
-version: 0.0.29
+version: 0.0.30
 maintainers:
   - name: HMCTS pcs team
 dependencies:

--- a/charts/pcs-api/values.preview.template.yaml
+++ b/charts/pcs-api/values.preview.template.yaml
@@ -12,6 +12,13 @@ java:
           alias: PCS_NOTIFY_API_KEY
         - name: hmc-servicebus-connection-string
           alias: HEARINGS_SERVICEBUS_CONNECTION_STRING
+        - name: pcs-api-idam-secret
+          alias: IDAM_CLIENT_SECRET
+        - name: idam-system-user-name
+          alias: PCS_IDAM_SYSTEM_USERNAME
+        - name: idam-system-user-password
+          alias: PCS_IDAM_SYSTEM_PASSWORD
+
   environment:
     PCS_DB_HOST: "{{ .Release.Name }}-postgresql"
     PCS_DB_USER_NAME: "{{ .Values.postgresql.auth.username}}"

--- a/charts/pcs-api/values.yaml
+++ b/charts/pcs-api/values.yaml
@@ -26,6 +26,7 @@ java:
     DRAFT_STORE_DB_CONN_OPTIONS: "?sslmode=require&gssEncMode=disable"
     PCS_DB_HOST: "pcs-{{ .Values.global.environment }}.postgres.database.azure.com"
     IDAM_S2S_AUTH_URL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    IDAM_API_URL: "https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net"
     HMC_API_URL: "http://hmc-cft-hearing-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     LOCATION_REF_URL: "http://rd-location-ref-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     FLYWAY_NOOP_STRATEGY: "true"

--- a/charts/pcs-api/values.yaml
+++ b/charts/pcs-api/values.yaml
@@ -15,6 +15,8 @@ java:
           alias: PCS_NOTIFY_API_KEY
         - name: hmc-servicebus-connection-string
           alias: HEARINGS_SERVICEBUS_CONNECTION_STRING
+        - name: pcs-api-idam-secret
+          alias: IDAM_CLIENT_SECRET
         - name: idam-system-user-name
           alias: PCS_IDAM_SYSTEM_USERNAME
         - name: idam-system-user-password
@@ -23,9 +25,11 @@ java:
   environment:
     PCS_DB_USER_NAME: pgadmin
     PCS_DB_NAME: pcs
+    IDAM_CLIENT_ID: "pcs-api"
     DRAFT_STORE_DB_CONN_OPTIONS: "?sslmode=require&gssEncMode=disable"
     PCS_DB_HOST: "pcs-{{ .Values.global.environment }}.postgres.database.azure.com"
     IDAM_S2S_AUTH_URL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    IDAM_API_REDIRECT_URL: "https://pcs-pfe-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/authenticated"
     IDAM_API_URL: "https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net"
     HMC_API_URL: "http://hmc-cft-hearing-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     LOCATION_REF_URL: "http://rd-location-ref-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"

--- a/charts/pcs-api/values.yaml
+++ b/charts/pcs-api/values.yaml
@@ -15,6 +15,11 @@ java:
           alias: PCS_NOTIFY_API_KEY
         - name: hmc-servicebus-connection-string
           alias: HEARINGS_SERVICEBUS_CONNECTION_STRING
+        - name: idam-system-user-name
+          alias: PCS_IDAM_SYSTEM_USERNAME
+        - name: idam-system-user-password
+          alias: PCS_IDAM_SYSTEM_PASSWORD
+
   environment:
     PCS_DB_USER_NAME: pgadmin
     PCS_DB_NAME: pcs

--- a/src/cftlib/java/uk/gov/hmcts/reform/pcs/CftlibConfig.java
+++ b/src/cftlib/java/uk/gov/hmcts/reform/pcs/CftlibConfig.java
@@ -34,6 +34,9 @@ public class CftlibConfig implements CFTLibConfigurer {
             lib.createProfile(entry.getKey(), "CIVIL", "PCS", State.Open.name());
         }
 
+        // Create local system user
+        lib.createIdamUser("pcs-system-user@localhost");
+
         lib.createRoles(
             "caseworker",
             "caseworker-civil"

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcs/hearings/endpoint/HearingsControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcs/hearings/endpoint/HearingsControllerIT.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.pcs.hearings.endpoint;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -10,11 +11,13 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.pcs.config.AbstractPostgresContainerIT;
 import uk.gov.hmcts.reform.pcs.hearings.model.DeleteHearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.model.HearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.model.UpdateHearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.service.api.HmcHearingApi;
+import uk.gov.hmcts.reform.pcs.util.IdamHelper;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -29,20 +32,26 @@ import static uk.gov.hmcts.reform.pcs.hearings.constants.HearingConstants.SERVIC
 @ActiveProfiles("integration")
 class HearingsControllerIT extends AbstractPostgresContainerIT {
 
+    private static final String AUTH_HEADER = "Bearer token";
+    private static final String SERVICE_AUTH_HEADER = "ServiceAuthToken";
+    private static final String SYSTEM_USER_ID_TOKEN = "system-user-id-token";
+
     @Autowired
     private MockMvc mockMvc;
-
     @Autowired
     private ObjectMapper objectMapper;
 
     @MockitoBean
     private AuthTokenGenerator authTokenGenerator;
-
+    @MockitoBean
+    private IdamClient idamClient;
     @MockitoBean
     private HmcHearingApi hmcHearingApi;
 
-    private static final String AUTH_HEADER = "Bearer token";
-    private static final String SERVICE_AUTH_HEADER = "ServiceAuthToken";
+    @BeforeEach
+    void setUp() {
+        IdamHelper.stubIdamSystemUser(idamClient, SYSTEM_USER_ID_TOKEN);
+    }
 
     @Test
     void shouldCreateHearing() throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcs/postcodecourt/controller/PostCodeCourtControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcs/postcodecourt/controller/PostCodeCourtControllerIT.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.pcs.postcodecourt.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,14 +11,16 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.pcs.Application;
 import uk.gov.hmcts.reform.pcs.config.AbstractPostgresContainerIT;
+import uk.gov.hmcts.reform.pcs.location.model.CourtVenue;
 import uk.gov.hmcts.reform.pcs.location.service.api.LocationReferenceApi;
 import uk.gov.hmcts.reform.pcs.postcodecourt.entity.PostCodeCourtEntity;
-import uk.gov.hmcts.reform.pcs.location.model.CourtVenue;
 import uk.gov.hmcts.reform.pcs.postcodecourt.entity.PostCodeCourtKey;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.Court;
 import uk.gov.hmcts.reform.pcs.postcodecourt.repository.PostCodeCourtRepository;
+import uk.gov.hmcts.reform.pcs.util.IdamHelper;
 
 import java.util.Collections;
 import java.util.List;
@@ -35,6 +38,7 @@ import static uk.gov.hmcts.reform.pcs.postcodecourt.controller.PostCodeCourtCont
 class PostCodeCourtControllerIT extends AbstractPostgresContainerIT {
 
     private static final String AUTH_HEADER = "Bearer token";
+    private static final String SYSTEM_USER_ID_TOKEN = "system-user-id-token";
     private static final String PCS_SERVICE_AUTH_HEADER = "Bearer serviceToken";
     private static final String LOC_REF_SERVICE_AUTH_HEADER = "Bearer locServiceToken";
     private static final String SERVICE_AUTHORIZATION = "ServiceAuthorization";
@@ -42,15 +46,20 @@ class PostCodeCourtControllerIT extends AbstractPostgresContainerIT {
 
     @Autowired
     private WebTestClient webTestClient;
-
     @Autowired
     private PostCodeCourtRepository postCodeCourtRepository;
 
     @MockitoBean
     private AuthTokenGenerator authTokenGenerator;
-
+    @MockitoBean
+    private IdamClient idamClient;
     @MockitoBean
     private LocationReferenceApi locationReferenceApi;
+
+    @BeforeEach
+    void setUp() {
+        IdamHelper.stubIdamSystemUser(idamClient, SYSTEM_USER_ID_TOKEN);
+    }
 
     @Test
     @DisplayName("Should return valid Http OK for known postcodes. The response should be empty for all epimIds.")
@@ -59,10 +68,10 @@ class PostCodeCourtControllerIT extends AbstractPostgresContainerIT {
         when(authTokenGenerator.generate()).thenReturn(LOC_REF_SERVICE_AUTH_HEADER);
 
         all.forEach(postCodeCourtEntity -> when(locationReferenceApi.getCountyCourts(
-                AUTH_HEADER,
-                LOC_REF_SERVICE_AUTH_HEADER,
-                postCodeCourtEntity.getId().getEpimId().toString(),
-                COUNTY_COURT_TYPE_ID
+            "Bearer " + SYSTEM_USER_ID_TOKEN,
+            LOC_REF_SERVICE_AUTH_HEADER,
+            postCodeCourtEntity.getId().getEpimId().toString(),
+            COUNTY_COURT_TYPE_ID
         )).thenReturn(Collections.emptyList()));
         assertThat(all).isNotEmpty();
         assertingResponseToBeEmptyList(all);
@@ -71,10 +80,9 @@ class PostCodeCourtControllerIT extends AbstractPostgresContainerIT {
     @Test
     @DisplayName("Should return valid Http OK and correct response body for known postcodes")
     void shouldReturnHttpOkAndCorrectResponseForKnownPostCodes() {
-        // TODO: Put spaces back into postcodes once HDPI-709 is done
-        String postCode1 = "W37RX";
-        String postCode2 = "W36RS";
-        String postCode3 = "M139PL";
+        String postCode1 = "W3 7RX";
+        String postCode2 = "W3 6RS";
+        String postCode3 = "M13 9PL";
 
         final PostCodeCourtKey id1 = new PostCodeCourtKey(postCode1, 20262);
         final PostCodeCourtKey id2 = new PostCodeCourtKey(postCode2, 36791);
@@ -102,10 +110,10 @@ class PostCodeCourtControllerIT extends AbstractPostgresContainerIT {
 
     private void stubLocationReferenceApi(String epimId, List<CourtVenue> response) {
         when(locationReferenceApi.getCountyCourts(
-                AUTH_HEADER,
-                LOC_REF_SERVICE_AUTH_HEADER,
-                epimId,
-                COUNTY_COURT_TYPE_ID
+            "Bearer " + SYSTEM_USER_ID_TOKEN,
+            LOC_REF_SERVICE_AUTH_HEADER,
+            epimId,
+            COUNTY_COURT_TYPE_ID
         )).thenReturn(response);
     }
 
@@ -144,10 +152,10 @@ class PostCodeCourtControllerIT extends AbstractPostgresContainerIT {
         when(authTokenGenerator.generate()).thenReturn(LOC_REF_SERVICE_AUTH_HEADER);
 
         all.forEach(postCodeCourtEntity -> when(locationReferenceApi.getCountyCourts(
-                AUTH_HEADER,
-                LOC_REF_SERVICE_AUTH_HEADER,
-                postCodeCourtEntity.getId().getEpimId().toString(),
-                COUNTY_COURT_TYPE_ID
+            "Bearer " + SYSTEM_USER_ID_TOKEN,
+            LOC_REF_SERVICE_AUTH_HEADER,
+            postCodeCourtEntity.getId().getEpimId().toString(),
+            COUNTY_COURT_TYPE_ID
         )).thenThrow(new RuntimeException("No matching courts found for ".concat(postCode), null)));
 
         assertingResponseToBeEmptyList(all);
@@ -159,10 +167,10 @@ class PostCodeCourtControllerIT extends AbstractPostgresContainerIT {
         String postCode = "UB7 0DG";
 
         webTestClient.get()
-                .uri(uriBuilder -> uriBuilder.path(COURTS_ENDPOINT)
-                        .queryParam(POSTCODE, postCode).build())
-                .header(AUTHORIZATION, AUTH_HEADER)
-                .exchange().expectStatus().isBadRequest();
+            .uri(uriBuilder -> uriBuilder.path(COURTS_ENDPOINT)
+                .queryParam(POSTCODE, postCode).build())
+            .header(AUTHORIZATION, AUTH_HEADER)
+            .exchange().expectStatus().isBadRequest();
 
     }
 
@@ -172,27 +180,27 @@ class PostCodeCourtControllerIT extends AbstractPostgresContainerIT {
         String postCode = "UB7 0DG";
 
         webTestClient.get()
-                .uri(uriBuilder -> uriBuilder.path(COURTS_ENDPOINT)
-                        .queryParam(POSTCODE, postCode).build())
-                .header(SERVICE_AUTHORIZATION, PCS_SERVICE_AUTH_HEADER)
-                .exchange().expectStatus().isBadRequest();
+            .uri(uriBuilder -> uriBuilder.path(COURTS_ENDPOINT)
+                .queryParam(POSTCODE, postCode).build())
+            .header(SERVICE_AUTHORIZATION, PCS_SERVICE_AUTH_HEADER)
+            .exchange().expectStatus().isBadRequest();
 
     }
 
     private void assertingResponseToBeEmptyList(List<PostCodeCourtEntity> all) {
         all.forEach(postCodeCourtEntity -> webTestClient.get()
-                .uri(uriBuilder -> uriBuilder.path(COURTS_ENDPOINT)
-                        .queryParam(POSTCODE, postCodeCourtEntity.getId().getPostCode()).build())
-                .header(AUTHORIZATION, AUTH_HEADER)
-                .header(SERVICE_AUTHORIZATION, PCS_SERVICE_AUTH_HEADER)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody(List.class)
-                .consumeWith(response -> {
-                    List<?> body = response.getResponseBody();
-                    assertThat(body)
-                            .isNotNull()
-                            .isEmpty();
-                }));
+            .uri(uriBuilder -> uriBuilder.path(COURTS_ENDPOINT)
+                .queryParam(POSTCODE, postCodeCourtEntity.getId().getPostCode()).build())
+            .header(AUTHORIZATION, AUTH_HEADER)
+            .header(SERVICE_AUTHORIZATION, PCS_SERVICE_AUTH_HEADER)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(List.class)
+            .consumeWith(response -> {
+                List<?> body = response.getResponseBody();
+                assertThat(body)
+                    .isNotNull()
+                    .isEmpty();
+            }));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcs/util/IdamHelper.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcs/util/IdamHelper.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.pcs.util;
+
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.TokenResponse;
+
+import static org.mockito.Mockito.when;
+
+public class IdamHelper {
+
+    // From application-integration.yaml
+    private static final String PCS_SYSTEM_USER = "pcs-system-user-it";
+    private static final String PCS_SYSTEM_PASSWORD = "pcs-system-password-it";
+
+    public static void stubIdamSystemUser(IdamClient idamClient, String idToken) {
+        TokenResponse tokenResponse = new TokenResponse("some access token", "expires",
+                                                        idToken, "some refresh token",
+                                                        "some scope", "some token type");
+
+        when(idamClient.getAccessTokenResponse(PCS_SYSTEM_USER, PCS_SYSTEM_PASSWORD))
+            .thenReturn(tokenResponse);
+    }
+
+}

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -23,6 +23,11 @@ spring:
       hibernate.format_sql: true
       show-dql: true
 
+idam:
+  system-user:
+    username: pcs-system-user-it
+    password: pcs-system-password-it
+
 flyway:
   noop:
     strategy: false

--- a/src/main/java/uk/gov/hmcts/reform/pcs/exception/IdamException.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/exception/IdamException.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.pcs.exception;
+
+public class IdamException extends RuntimeException {
+
+    public IdamException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/hearings/endpoint/HearingsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/hearings/endpoint/HearingsController.java
@@ -1,8 +1,5 @@
 package uk.gov.hmcts.reform.pcs.hearings.endpoint;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static uk.gov.hmcts.reform.pcs.hearings.constants.HearingConstants.SERVICE_AUTHORIZATION;
-
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -20,6 +17,9 @@ import uk.gov.hmcts.reform.pcs.hearings.model.HearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.model.HearingResponse;
 import uk.gov.hmcts.reform.pcs.hearings.model.UpdateHearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.service.HmcHearingService;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static uk.gov.hmcts.reform.pcs.hearings.constants.HearingConstants.SERVICE_AUTHORIZATION;
 
 /**
  * This controller will just pass through the input to HMC currently,
@@ -41,7 +41,7 @@ public class HearingsController {
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorization,
         @RequestBody HearingRequest hearingPayload) {
-        return hmcHearingService.createHearing(authorisation, hearingPayload);
+        return hmcHearingService.createHearing(hearingPayload);
     }
 
     @PutMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -50,7 +50,7 @@ public class HearingsController {
         @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorization,
         @PathVariable("id") String id,
         @RequestBody UpdateHearingRequest hearingPayload) {
-        return hmcHearingService.updateHearing(authorisation, id, hearingPayload);
+        return hmcHearingService.updateHearing(id, hearingPayload);
     }
 
     @DeleteMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -59,7 +59,7 @@ public class HearingsController {
         @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorization,
         @PathVariable("id") String id,
         @RequestBody DeleteHearingRequest hearingDeletePayload) {
-        return hmcHearingService.deleteHearing(authorisation, id, hearingDeletePayload);
+        return hmcHearingService.deleteHearing(id, hearingDeletePayload);
     }
 
     @GetMapping(value = "/{id}")
@@ -67,6 +67,6 @@ public class HearingsController {
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorization,
         @PathVariable("id") String id) {
-        return hmcHearingService.getHearing(authorisation, id);
+        return hmcHearingService.getHearing(id);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/hearings/service/HmcHearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/hearings/service/HmcHearingService.java
@@ -1,12 +1,9 @@
 package uk.gov.hmcts.reform.pcs.hearings.service;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.pcs.hearings.model.DeleteHearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.model.GetHearingsResponse;
@@ -14,6 +11,7 @@ import uk.gov.hmcts.reform.pcs.hearings.model.HearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.model.HearingResponse;
 import uk.gov.hmcts.reform.pcs.hearings.model.UpdateHearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.service.api.HmcHearingApi;
+import uk.gov.hmcts.reform.pcs.idam.IdamService;
 
 @RequiredArgsConstructor
 @Service
@@ -21,36 +19,27 @@ public class HmcHearingService {
 
     private final HmcHearingApi hmcHearingApi;
     private final AuthTokenGenerator authTokenGenerator;
+    private final IdamService idamService;
     @Value("${hmc.deployment-id}")
     private String hmctsDeploymentId;
 
-    public HearingResponse createHearing(
-        @RequestHeader(AUTHORIZATION) String authorisation,
-        @RequestBody HearingRequest hearingPayload) {
-        return hmcHearingApi.createHearing(authorisation, authTokenGenerator.generate(),
-                                          hmctsDeploymentId, hearingPayload);
+    public HearingResponse createHearing(@RequestBody HearingRequest hearingPayload) {
+        return hmcHearingApi.createHearing(idamService.getSystemUserAuthorisation(), authTokenGenerator.generate(),
+                                           hmctsDeploymentId, hearingPayload);
     }
 
-    public HearingResponse updateHearing(
-        @RequestHeader(AUTHORIZATION) String authorisation,
-        String id,
-        @RequestBody UpdateHearingRequest hearingPayload) {
-        return hmcHearingApi.updateHearing(authorisation, authTokenGenerator.generate(),
+    public HearingResponse updateHearing(String id, @RequestBody UpdateHearingRequest hearingPayload) {
+        return hmcHearingApi.updateHearing(idamService.getSystemUserAuthorisation(), authTokenGenerator.generate(),
                                            hmctsDeploymentId, id, hearingPayload);
     }
 
-    public HearingResponse deleteHearing(
-        @RequestHeader(AUTHORIZATION) String authorisation,
-        String id,
-        @RequestBody DeleteHearingRequest hearingDeletePayload) {
-        return hmcHearingApi.deleteHearing(authorisation, authTokenGenerator.generate(),
+    public HearingResponse deleteHearing(String id, @RequestBody DeleteHearingRequest hearingDeletePayload) {
+        return hmcHearingApi.deleteHearing(idamService.getSystemUserAuthorisation(), authTokenGenerator.generate(),
                                            hmctsDeploymentId, id, hearingDeletePayload);
     }
 
-    public GetHearingsResponse getHearing(
-        @RequestHeader(AUTHORIZATION) String authorisation,
-        String id) {
-        return hmcHearingApi.getHearing(authorisation, authTokenGenerator.generate(),
-                                        hmctsDeploymentId,id, null);
+    public GetHearingsResponse getHearing(String id) {
+        return hmcHearingApi.getHearing(idamService.getSystemUserAuthorisation(), authTokenGenerator.generate(),
+                                        hmctsDeploymentId, id, null);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/idam/IdamService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/idam/IdamService.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.pcs.idam;
+
+import feign.FeignException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.TokenResponse;
+import uk.gov.hmcts.reform.pcs.exception.IdamException;
+
+@Service
+public class IdamService {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final IdamClient idamClient;
+    private final String idamSystemUsername;
+    private final String idamSystemPassword;
+
+    public IdamService(IdamClient idamClient,
+                       @Value("${idam.system-user.username}") String idamSystemUsername,
+                       @Value("${idam.system-user.password}") String idamSystemPassword) {
+
+        this.idamClient = idamClient;
+        this.idamSystemUsername = idamSystemUsername;
+        this.idamSystemPassword = idamSystemPassword;
+    }
+
+    public String getSystemUserAuthorisation() {
+        TokenResponse accessTokenResponse = getAccessTokenResponse();
+        return BEARER_PREFIX + accessTokenResponse.idToken;
+    }
+
+    private TokenResponse getAccessTokenResponse() {
+        try {
+            return idamClient.getAccessTokenResponse(idamSystemUsername, idamSystemPassword);
+        } catch (FeignException fe) {
+            throw new IdamException("Unable to get access token response", fe);
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/postcodecourt/controller/PostCodeCourtController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/postcodecourt/controller/PostCodeCourtController.java
@@ -27,7 +27,7 @@ public class PostCodeCourtController {
     public ResponseEntity<List<Court>> getCourts(@RequestHeader(AUTHORIZATION) String authorisation,
                                                  @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorization,
                                                  @QueryParam(POSTCODE) String postcode) {
-        return ResponseEntity.ok(postCodeCourtService.getCountyCourtsByPostCode(postcode, authorisation));
+        return ResponseEntity.ok(postCodeCourtService.getCountyCourtsByPostCode(postcode));
     }
 
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -85,6 +85,10 @@ idam:
   system-user:
     username: ${PCS_IDAM_SYSTEM_USERNAME:pcs-system-user@localhost}
     password: ${PCS_IDAM_SYSTEM_PASSWORD:password}
+  client:
+    id: ${IDAM_CLIENT_ID:pcs-api}
+    secret: ${IDAM_CLIENT_SECRET:123456}
+    redirect_uri: ${IDAM_API_REDIRECT_URL:http://localhost:3001/oauth2/callback}
 
 azure:
   application-insights:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,6 +82,9 @@ idam:
     microservice: ${S2S_SERVICE_NAME:pcs_api}
   s2s-authorised:
     services: ${S2S_NAMES_WHITELIST:pcs_api,pcs_frontend,ccd_data}
+  system-user:
+    username: ${PCS_IDAM_SYSTEM_USERNAME:pcs-system-user@localhost}
+    password: ${PCS_IDAM_SYSTEM_PASSWORD:password}
 
 azure:
   application-insights:

--- a/src/test/java/uk/gov/hmcts/reform/pcs/hearings/endpoint/HearingsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/hearings/endpoint/HearingsControllerTest.java
@@ -1,15 +1,10 @@
 package uk.gov.hmcts.reform.pcs.hearings.endpoint;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.pcs.hearings.model.DeleteHearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.model.GetHearingsResponse;
 import uk.gov.hmcts.reform.pcs.hearings.model.HearingRequest;
@@ -17,6 +12,11 @@ import uk.gov.hmcts.reform.pcs.hearings.model.HearingResponse;
 import uk.gov.hmcts.reform.pcs.hearings.model.UpdateHearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.service.HmcHearingService;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 class HearingsControllerTest {
 
     @Mock
@@ -28,22 +28,17 @@ class HearingsControllerTest {
     private static final String AUTH_HEADER = "Bearer token";
     private static final String SERVICE_AUTH_HEADER = "ServiceAuthToken";
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
-
     @Test
     void shouldCreateHearing() {
         HearingRequest request = new HearingRequest();
         HearingResponse response = new HearingResponse();
 
-        when(hmcHearingService.createHearing(AUTH_HEADER, request)).thenReturn(response);
+        when(hmcHearingService.createHearing(request)).thenReturn(response);
 
         HearingResponse result = hearingsController.createHearing(AUTH_HEADER, SERVICE_AUTH_HEADER, request);
 
         assertThat(result).isEqualTo(response);
-        verify(hmcHearingService, times(1)).createHearing(AUTH_HEADER, request);
+        verify(hmcHearingService).createHearing(request);
     }
 
     @Test
@@ -51,12 +46,12 @@ class HearingsControllerTest {
         UpdateHearingRequest request = new UpdateHearingRequest();
         HearingResponse response = new HearingResponse();
 
-        when(hmcHearingService.updateHearing(AUTH_HEADER, "123", request)).thenReturn(response);
+        when(hmcHearingService.updateHearing("123", request)).thenReturn(response);
 
         HearingResponse result = hearingsController.updateHearing(AUTH_HEADER, SERVICE_AUTH_HEADER, "123", request);
 
         assertThat(result).isEqualTo(response);
-        verify(hmcHearingService, times(1)).updateHearing(AUTH_HEADER, "123", request);
+        verify(hmcHearingService).updateHearing("123", request);
     }
 
     @Test
@@ -64,23 +59,23 @@ class HearingsControllerTest {
         DeleteHearingRequest request = new DeleteHearingRequest();
         HearingResponse response = new HearingResponse();
 
-        when(hmcHearingService.deleteHearing(AUTH_HEADER, "123", request)).thenReturn(response);
+        when(hmcHearingService.deleteHearing("123", request)).thenReturn(response);
 
         HearingResponse result = hearingsController.deleteHearing(AUTH_HEADER, SERVICE_AUTH_HEADER, "123", request);
 
         assertThat(result).isEqualTo(response);
-        verify(hmcHearingService, times(1)).deleteHearing(AUTH_HEADER, "123", request);
+        verify(hmcHearingService).deleteHearing("123", request);
     }
 
     @Test
     void shouldGetHearing() {
         GetHearingsResponse response = new GetHearingsResponse();
 
-        when(hmcHearingService.getHearing(AUTH_HEADER, "123")).thenReturn(response);
+        when(hmcHearingService.getHearing("123")).thenReturn(response);
 
         GetHearingsResponse result = hearingsController.getHearing(AUTH_HEADER, SERVICE_AUTH_HEADER, "123");
 
         assertThat(result).isEqualTo(response);
-        verify(hmcHearingService, times(1)).getHearing(AUTH_HEADER, "123");
+        verify(hmcHearingService).getHearing("123");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/hearings/service/HmcHearingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/hearings/service/HmcHearingServiceTest.java
@@ -1,14 +1,10 @@
 package uk.gov.hmcts.reform.pcs.hearings.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.pcs.hearings.model.DeleteHearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.model.GetHearingsResponse;
@@ -16,14 +12,21 @@ import uk.gov.hmcts.reform.pcs.hearings.model.HearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.model.HearingResponse;
 import uk.gov.hmcts.reform.pcs.hearings.model.UpdateHearingRequest;
 import uk.gov.hmcts.reform.pcs.hearings.service.api.HmcHearingApi;
+import uk.gov.hmcts.reform.pcs.idam.IdamService;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 class HmcHearingServiceTest {
 
     @Mock
     private HmcHearingApi hmcHearingApi;
-
     @Mock
     private AuthTokenGenerator authTokenGenerator;
+    @Mock
+    private IdamService idamService;
 
     private HmcHearingService hmcHearingService;
 
@@ -34,9 +37,9 @@ class HmcHearingServiceTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
         when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTH_HEADER);
-        hmcHearingService = new HmcHearingService(hmcHearingApi, authTokenGenerator);
+        when(idamService.getSystemUserAuthorisation()).thenReturn(AUTH_HEADER);
+        hmcHearingService = new HmcHearingService(hmcHearingApi, authTokenGenerator, idamService);
     }
 
     @Test
@@ -47,11 +50,10 @@ class HmcHearingServiceTest {
         when(hmcHearingApi.createHearing(AUTH_HEADER,
                                          SERVICE_AUTH_HEADER, DEPLOYMENT_ID, request)).thenReturn(response);
 
-        HearingResponse result = hmcHearingService.createHearing(AUTH_HEADER, request);
+        HearingResponse result = hmcHearingService.createHearing(request);
 
         assertThat(result).isNotNull().isEqualTo(response);
-        verify(hmcHearingApi, times(1)).createHearing(AUTH_HEADER,
-                SERVICE_AUTH_HEADER, DEPLOYMENT_ID, request);
+        verify(hmcHearingApi).createHearing(AUTH_HEADER, SERVICE_AUTH_HEADER, DEPLOYMENT_ID, request);
     }
 
     @Test
@@ -62,11 +64,10 @@ class HmcHearingServiceTest {
         when(hmcHearingApi.updateHearing(AUTH_HEADER,
             SERVICE_AUTH_HEADER, DEPLOYMENT_ID, HEARING_ID, request)).thenReturn(response);
 
-        HearingResponse result = hmcHearingService.updateHearing(AUTH_HEADER, HEARING_ID, request);
+        HearingResponse result = hmcHearingService.updateHearing(HEARING_ID, request);
 
         assertThat(result).isNotNull().isEqualTo(response);
-        verify(hmcHearingApi, times(1)).updateHearing(AUTH_HEADER,
-            SERVICE_AUTH_HEADER, DEPLOYMENT_ID, HEARING_ID, request);
+        verify(hmcHearingApi).updateHearing(AUTH_HEADER, SERVICE_AUTH_HEADER, DEPLOYMENT_ID, HEARING_ID, request);
     }
 
     @Test
@@ -79,8 +80,7 @@ class HmcHearingServiceTest {
                                          SERVICE_AUTH_HEADER, DEPLOYMENT_ID, HEARING_ID, request)).thenReturn(response);
 
         // Call the service method that triggers the API method
-        HearingResponse result = hmcHearingService.deleteHearing(AUTH_HEADER,
-                                                                 HEARING_ID, request);
+        HearingResponse result = hmcHearingService.deleteHearing(HEARING_ID, request);
 
         // Debugging output to check if the result is null
         System.out.println("Delete Hearing Response: " + result);
@@ -90,8 +90,7 @@ class HmcHearingServiceTest {
         assertThat(result).isNotNull().isEqualTo(response);
 
         // Verify that the deleteHearing method was called once with the correct arguments
-        verify(hmcHearingApi, times(1)).deleteHearing(AUTH_HEADER,
-                                                      SERVICE_AUTH_HEADER, DEPLOYMENT_ID, HEARING_ID, request);
+        verify(hmcHearingApi).deleteHearing(AUTH_HEADER, SERVICE_AUTH_HEADER, DEPLOYMENT_ID, HEARING_ID, request);
     }
 
     @Test
@@ -101,10 +100,9 @@ class HmcHearingServiceTest {
         when(hmcHearingApi.getHearing(AUTH_HEADER,
                                       SERVICE_AUTH_HEADER, DEPLOYMENT_ID, HEARING_ID, null)).thenReturn(response);
 
-        GetHearingsResponse result = hmcHearingService.getHearing(AUTH_HEADER, HEARING_ID);
+        GetHearingsResponse result = hmcHearingService.getHearing(HEARING_ID);
 
         assertThat(result).isNotNull().isEqualTo(response);
-        verify(hmcHearingApi, times(1)).getHearing(AUTH_HEADER,
-                                                   SERVICE_AUTH_HEADER, DEPLOYMENT_ID, HEARING_ID, null);
+        verify(hmcHearingApi).getHearing(AUTH_HEADER, SERVICE_AUTH_HEADER, DEPLOYMENT_ID, HEARING_ID, null);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/idam/IdamServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/idam/IdamServiceTest.java
@@ -1,0 +1,62 @@
+package uk.gov.hmcts.reform.pcs.idam;
+
+import feign.FeignException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.TokenResponse;
+import uk.gov.hmcts.reform.pcs.exception.IdamException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class IdamServiceTest {
+
+    private static final String SYSTEM_USERNAME = "system-user@test.com";
+    private static final String SYSTEM_PASSWORD = "top-secret";
+
+    @Mock
+    private IdamClient idamClient;
+
+    private IdamService underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new IdamService(idamClient, SYSTEM_USERNAME, SYSTEM_PASSWORD);
+    }
+
+    @Test
+    @DisplayName("Should get the ID token for the system user")
+    void shouldGetSystemUserToken() {
+        String expectedIdToken = "some id token";
+        TokenResponse tokenResponse = new TokenResponse("some access token", "expires",
+                                                        expectedIdToken, "some refresh token",
+                                                        "some scope", "some token type");
+
+        given(idamClient.getAccessTokenResponse(SYSTEM_USERNAME, SYSTEM_PASSWORD)).willReturn(tokenResponse);
+        String systemUserToken = underTest.getSystemUserAuthorisation();
+
+        assertThat(systemUserToken).isEqualTo("Bearer %s", expectedIdToken);
+    }
+
+    @Test
+    @DisplayName("Should wrap Feign exceptions thrown by the IDAM client")
+    void shouldWrapIdamClientExceptionGettingSystemUserToken() {
+        FeignException feignException = mock(FeignException.class);
+        given(idamClient.getAccessTokenResponse(SYSTEM_USERNAME, SYSTEM_PASSWORD)).willThrow(feignException);
+
+        Throwable throwable = catchThrowable(() -> underTest.getSystemUserAuthorisation());
+
+        assertThat(throwable)
+            .isInstanceOf(IdamException.class)
+            .hasCause(feignException);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/postcodecourt/controller/PostCodeCourtControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/postcodecourt/controller/PostCodeCourtControllerTest.java
@@ -23,6 +23,7 @@ class PostCodeCourtControllerTest {
 
     private static final String POST_CODE = "W3 7RX";
     private static final String AUTH_TOKEN = "Bearer token";
+
     @InjectMocks
     private PostCodeCourtController underTest;
 
@@ -33,7 +34,7 @@ class PostCodeCourtControllerTest {
     @DisplayName("Should return list of courts with Http200 for valid postcode")
     void shouldHandlePostcodesRequestWithCourtsInResponse() {
         List<Court> courts = List.of(new Court(40827, "Central London County Court", 20262));
-        when(postCodeCourtService.getCountyCourtsByPostCode(POST_CODE, AUTH_TOKEN))
+        when(postCodeCourtService.getCountyCourtsByPostCode(POST_CODE))
                 .thenReturn(courts);
         ResponseEntity<List<Court>> response = underTest.getCourts(
                 AUTH_TOKEN,
@@ -42,13 +43,13 @@ class PostCodeCourtControllerTest {
         );
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(courts);
-        verify(postCodeCourtService).getCountyCourtsByPostCode(POST_CODE, AUTH_TOKEN);
+        verify(postCodeCourtService).getCountyCourtsByPostCode(POST_CODE);
     }
 
     @Test
     @DisplayName("Should return empty list of courts with Http200 for valid postcode")
     void shouldHandlePostcodesRequestWithEmptyListOfCourtsInResponse() {
-        when(postCodeCourtService.getCountyCourtsByPostCode(POST_CODE, AUTH_TOKEN))
+        when(postCodeCourtService.getCountyCourtsByPostCode(POST_CODE))
                 .thenReturn(Collections.emptyList());
         ResponseEntity<List<Court>> response = underTest.getCourts(
                 AUTH_TOKEN,
@@ -57,7 +58,7 @@ class PostCodeCourtControllerTest {
         );
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(Collections.emptyList());
-        verify(postCodeCourtService).getCountyCourtsByPostCode(POST_CODE, AUTH_TOKEN);
+        verify(postCodeCourtService).getCountyCourtsByPostCode(POST_CODE);
     }
 }
 


### PR DESCRIPTION
### Jira link

See [HDPI-787](https://tools.hmcts.net/jira/browse/HDPI-787)

### Change description

Use an ID token for the PCS System User when calling other internal services, as opposed to the ID token that was passed in the Authorization header in the client request.

### Testing done

Unit tests added and full build run with all tests.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
