### PR TITLE
Adding daily deletion of nightly-dev branch via GitHub workflows

### DIFF
--- a/.github/workflows/delete-nightly-dev-branch.yml
+++ b/.github/workflows/delete-nightly-dev-branch.yml
@@ -1,0 +1,26 @@
+name: Delete nightly-dev branch
+
+on:
+  schedule:
+    - cron: '0 7 * * 1-5'
+  workflow_dispatch: # Optional: allows manual triggering
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Delete 'nightly-dev' branch if it exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if the branch exists on origin
+          if git ls-remote --exit-code --heads origin nightly-dev > /dev/null; then
+            echo "Branch 'nightly-dev' exists. Deleting..."
+            # Delete the branch on origin
+            git push origin --delete nightly-dev
+          else
+            echo "Branch 'nightly-dev' does not exist. Nothing to delete."
+          fi


### PR DESCRIPTION
### Jira link

N/A

### Change description

This change adds a GitHub action to run daily to delete our nightly-dev branch if it exists. This branch should only be used for testing, with no code being stored in there long term.

### Testing done

N/A

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
