### PR TITLE
HDPI-865: Create a document via Doc Assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 !gradle/wrapper/gradle-wrapper.jar
 *.class
 bin/main/application.yaml
+bin/
+BOOT-INF/
 
 ### STS ###
 .apt_generated

--- a/src/main/java/uk/gov/hmcts/reform/pcs/config/RestTemplateConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/config/RestTemplateConfiguration.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.pcs.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfiguration {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+} 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/document/service/DocAssemblyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/document/service/DocAssemblyService.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.pcs.document.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.pcs.testingsupport.model.DocAssemblyRequest;
+
+@Slf4j
+@Service
+public class DocAssemblyService {
+    private final RestTemplate restTemplate;
+    private final String docAssemblyUrl;
+    private static final String TEMPLATE_ID = "CV-SPC-CLM-ENG-01356.docx";
+
+    public DocAssemblyService(
+        RestTemplate restTemplate,
+        @Value("${doc-assembly.url}") String docAssemblyUrl
+    ) {
+        this.restTemplate = restTemplate;
+        this.docAssemblyUrl = docAssemblyUrl;
+    }
+
+    public String generateDocument(DocAssemblyRequest request, String authorization, String serviceAuthorization) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", authorization);
+        headers.set("ServiceAuthorization", serviceAuthorization);
+
+        request.setTemplateId(TEMPLATE_ID);
+        request.setOutputType("PDF");
+
+        HttpEntity<DocAssemblyRequest> requestEntity = new HttpEntity<>(request, headers);
+        
+        return restTemplate.postForObject(
+            docAssemblyUrl + "/api/template-renditions",
+            requestEntity,
+            String.class
+        );
+    }
+} 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/document/service/DocAssemblyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/document/service/DocAssemblyService.java
@@ -14,7 +14,7 @@ import uk.gov.hmcts.reform.pcs.testingsupport.model.DocAssemblyRequest;
 public class DocAssemblyService {
     private final RestTemplate restTemplate;
     private final String docAssemblyUrl;
-    private static final String TEMPLATE_ID = "CV-SPC-CLM-ENG-01356.docx";
+    private static final String DEFAULT_TEMPLATE_ID = "CV-SPC-CLM-ENG-01356.docx";
 
     public DocAssemblyService(
         RestTemplate restTemplate,
@@ -30,8 +30,15 @@ public class DocAssemblyService {
         headers.set("Authorization", authorization);
         headers.set("ServiceAuthorization", serviceAuthorization);
 
-        request.setTemplateId(TEMPLATE_ID);
-        request.setOutputType("PDF");
+        // Use templateId from request, or default if not provided
+        if (request.getTemplateId() == null || request.getTemplateId().trim().isEmpty()) {
+            request.setTemplateId(DEFAULT_TEMPLATE_ID);
+        }
+        
+        // Set output type if not provided
+        if (request.getOutputType() == null || request.getOutputType().trim().isEmpty()) {
+            request.setOutputType("PDF");
+        }
 
         HttpEntity<DocAssemblyRequest> requestEntity = new HttpEntity<>(request, headers);
         

--- a/src/main/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportController.java
@@ -2,16 +2,21 @@ package uk.gov.hmcts.reform.pcs.testingsupport.endpoint;
 
 import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.task.Task;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.pcs.document.service.DocAssemblyService;
+import uk.gov.hmcts.reform.pcs.testingsupport.model.DocAssemblyRequest;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -27,13 +32,16 @@ public class TestingSupportController {
 
     private final SchedulerClient schedulerClient;
     private final Task<Void> helloWorldTask;
+    private final DocAssemblyService docAssemblyService;
 
     public TestingSupportController(
         SchedulerClient schedulerClient,
-        @Qualifier("helloWorldTask") Task<Void> helloWorldTask
+        @Qualifier("helloWorldTask") Task<Void> helloWorldTask,
+        DocAssemblyService docAssemblyService
     ) {
         this.schedulerClient = schedulerClient;
         this.helloWorldTask = helloWorldTask;
+        this.docAssemblyService = docAssemblyService;
     }
 
     @PostMapping("/db-scheduler-test")
@@ -58,6 +66,27 @@ public class TestingSupportController {
             log.error("Failed to schedule Hello World task", e);
             return ResponseEntity.internalServerError()
                 .body("Failed to schedule Hello World task: " + e.getMessage());
+        }
+    }
+
+    @Operation(summary = "Generate a document using Doc Assembly API")
+    @PostMapping(value = "/generate-document", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> generateDocument(
+        @RequestHeader(value = AUTHORIZATION) String authorisation,
+        @RequestHeader(value = "ServiceAuthorization") String serviceAuthorization,
+        @RequestBody DocAssemblyRequest request
+    ) {
+        try {
+            if (request.getFormPayload() == null) {
+                return ResponseEntity.badRequest().body("formPayload is required");
+            }
+            
+            String documentUrl = docAssemblyService.generateDocument(request, authorisation, serviceAuthorization);
+            return ResponseEntity.ok(documentUrl);
+        } catch (Exception e) {
+            log.error("Failed to generate document", e);
+            return ResponseEntity.internalServerError()
+                .body("Failed to generate document: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/testingsupport/model/DocAssemblyRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/testingsupport/model/DocAssemblyRequest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.pcs.testingsupport.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DocAssemblyRequest {
+    private String templateId;
+    private Map<String, Object> formPayload;
+    private String outputType;
+} 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -122,3 +122,8 @@ db-scheduler:
   executor-enabled: ${DB_SCHEDULER_EXECUTOR_ENABLED:true}
   polling-interval-seconds: 10
   threads: 10
+
+doc-assembly:
+  url: ${DOC_ASSEMBLY_URL:http://localhost:8081}
+  s2s-authorised:
+    services: pcs_api,ccd_data,ccd_gw,ccd_case_document_am_api,ccd_definition,ccd_admin,ccd_ps,ccd

--- a/src/test/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportControllerTest.java
@@ -3,15 +3,20 @@ package uk.gov.hmcts.reform.pcs.testingsupport.endpoint;
 import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.task.Task;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.pcs.document.service.DocAssemblyService;
+import uk.gov.hmcts.reform.pcs.testingsupport.model.DocAssemblyRequest;
 
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -30,8 +35,18 @@ class TestingSupportControllerTest {
     @Mock
     private Task<Void> helloWorldTask;
 
-    @InjectMocks
+    @Mock
+    private DocAssemblyService docAssemblyService;
+
+    @Mock
+    private RestTemplate restTemplate;
+
     private TestingSupportController underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new TestingSupportController(schedulerClient, helloWorldTask, docAssemblyService);
+    }
 
     @SuppressWarnings("unchecked")
     @Test
@@ -40,8 +55,8 @@ class TestingSupportControllerTest {
         when(helloWorldTask.instance(anyString())).thenReturn(mockTaskInstance);
 
         ResponseEntity<String> response = underTest.scheduleHelloWorldTask(5,
-                                                                           "Bearer token",
-                                                                           "ServiceAuthToken");
+                                                                        "Bearer token",
+                                                                        "ServiceAuthToken");
 
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -70,12 +85,101 @@ class TestingSupportControllerTest {
             .scheduleIfNotExists(any(TaskInstance.class), any(Instant.class));
 
         ResponseEntity<String> response = underTest.scheduleHelloWorldTask(2,
-                                                                           "Bearer token",
-                                                                           "ServiceAuthToken");
+                                                                        "Bearer token",
+                                                                        "ServiceAuthToken");
 
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode().is5xxServerError()).isTrue();
         assertThat(response.getBody()).contains("Failed to schedule Hello World task");
         assertThat(response.getBody()).contains("Scheduler failure");
+    }
+
+    @Test
+    void testGenerateDocument_WithBasicCaseInformation() {
+        final DocAssemblyRequest request = new DocAssemblyRequest();
+        Map<String, Object> formPayload = new HashMap<>();
+        
+        // Basic case information only
+        formPayload.put("ccdCaseReference", "PCS-123456789");
+        formPayload.put("referenceNumber", "REF-2024-001");
+        formPayload.put("caseName", "Smith v Jones");
+        formPayload.put("applicantExternalReference", "APP-REF-001");
+        formPayload.put("respondentExternalReference", "RESP-REF-001");
+        formPayload.put("issueDate", "2024-01-15");
+        formPayload.put("submittedOn", "2024-01-10");
+        formPayload.put("descriptionOfClaim", 
+            "The claimant seeks possession of the property due to non-payment of rent.");
+        
+        request.setFormPayload(formPayload);
+        
+        String expectedDocumentUrl = "http://dm-store/documents/123";
+        when(docAssemblyService.generateDocument(any(DocAssemblyRequest.class), anyString(), anyString()))
+            .thenReturn(expectedDocumentUrl);
+
+        ResponseEntity<String> response = underTest.generateDocument(
+            "Bearer token",
+            "ServiceAuthToken",
+            request
+        );
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).isEqualTo(expectedDocumentUrl);
+        
+        // Verify the request was passed correctly
+        ArgumentCaptor<DocAssemblyRequest> requestCaptor = ArgumentCaptor.forClass(DocAssemblyRequest.class);
+        verify(docAssemblyService).generateDocument(requestCaptor.capture(), anyString(), anyString());
+        
+        DocAssemblyRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.getFormPayload()).containsKey("ccdCaseReference");
+        assertThat(capturedRequest.getFormPayload()).containsKey("caseName");
+        assertThat(capturedRequest.getFormPayload()).containsKey("descriptionOfClaim");
+    }
+
+    @Test
+    void testGenerateDocument_Success() {
+        final DocAssemblyRequest request = new DocAssemblyRequest();
+        Map<String, Object> formPayload = new HashMap<>();
+        formPayload.put("ccdCaseReference", "PCS-123456789");
+        formPayload.put("caseName", "Test Case");
+        formPayload.put("descriptionOfClaim", "Test claim description");
+        request.setFormPayload(formPayload);
+
+        String expectedDocumentUrl = "http://dm-store/documents/123";
+        when(docAssemblyService.generateDocument(any(DocAssemblyRequest.class), anyString(), anyString()))
+            .thenReturn(expectedDocumentUrl);
+
+        ResponseEntity<String> response = underTest.generateDocument(
+            "Bearer token",
+            "ServiceAuthToken",
+            request
+        );
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).isEqualTo(expectedDocumentUrl);
+        verify(docAssemblyService).generateDocument(request, "Bearer token", "ServiceAuthToken");
+    }
+
+    @Test
+    void testGenerateDocument_Failure() {
+        final DocAssemblyRequest request = new DocAssemblyRequest();
+        Map<String, Object> formPayload = new HashMap<>();
+        formPayload.put("field1", "value1");
+        request.setFormPayload(formPayload);
+
+        when(docAssemblyService.generateDocument(any(DocAssemblyRequest.class), anyString(), anyString()))
+            .thenThrow(new RuntimeException("Document generation failed"));
+
+        ResponseEntity<String> response = underTest.generateDocument(
+            "Bearer token",
+            "ServiceAuthToken",
+            request
+        );
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode().is5xxServerError()).isTrue();
+        assertThat(response.getBody()).contains("Failed to generate document");
+        assertThat(response.getBody()).contains("Document generation failed");
     }
 }


### PR DESCRIPTION
### Jira link

See [HDPI-865](https://tools.hmcts.net/jira/browse/HDPI-865)

### Change description

This PR integrates the PCS API with the Doc Assembly service to enable document generation functionality. The integration includes:

• Core Doc Assembly service integration with configuration and service layer
• Testing support endpoint (`/testing-support/generate-document`) for document generation, during development
• Comprehensive unit tests, for newly added testing-support endpoint

The integration allows PCS API to communicate with Doc Assembly service, pass authentication tokens, and generate documents using templates with dynamic data.

### Testing done

**Automated Testing:**
• Unit tests for newly added testing-support endpoint, covering document generation scenarios and various payload formats

**Manual Testing:**
• Validated PCS API successfully communicating with Doc Assembly service, on port 8081
• Tested document generation endpoint with proper request/response handling

**Local Development Validation:**
• PCS API running on port 3206 and healthy
• Doc Assembly service running on port 8081 and healthy
• Mock services (S2S, template, Docmosis) all operational

The main integration point (PCS correctly communicating with Doc Assembly) works as expected. In higher environments, the mock services won't be needed as real services will be available.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change