### PR TITLE
Allow this build to be used in a Gradle composite build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -428,18 +428,18 @@ tasks.register('highLevelDataSetup', JavaExec) {
 // Ensure we cover Cftlib dev & test with our CI checks
 check.dependsOn cftlibTest
 
-rootProject.tasks.named("processIntegrationTestResources") {
+tasks.named("processIntegrationTestResources") {
   duplicatesStrategy = 'include'
 }
 
-rootProject.tasks.named("processContractTestResources") {
+tasks.named("processContractTestResources") {
   duplicatesStrategy = 'include'
 }
 
-rootProject.tasks.named("processFunctionalTestResources") {
+tasks.named("processFunctionalTestResources") {
   duplicatesStrategy = 'include'
 }
 
-wrapper {
+tasks.withType(Wrapper) {
   distributionType = Wrapper.DistributionType.ALL
 }


### PR DESCRIPTION
This will help with the development of the CCD SDK which can reference the pcs-api as a git submodule.