### PR TITLE
HDPI-1252: Upgrade to CftLib 0.20.0-alpha.31 for AAT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,19 @@ with
 authMode = AuthMode.AAT
 ```
 
-Then run the service with the `bootWithCCD` task as above.
+Then set the following environment variables based on the value below or named secret
+from the PCS AAT key vault:
+
+| Environment Variable     | Value or Secret Name                                             |
+|--------------------------|------------------------------------------------------------------|
+| LOCATION_REF_URL         | http://rd-location-ref-api-aat.service.core-compute-aat.internal |
+| PCS_API_S2S_SECRET       | secret: pcs-api-s2s-secret                                       |
+| IDAM_CLIENT_SECRET       | secret: pcs-api-idam-secret                                      |
+| PCS_IDAM_SYSTEM_USERNAME | secret: idam-system-user-name                                    |
+| PCS_IDAM_SYSTEM_PASSWORD | secret: idam-system-user-password                                |
+
+
+Finally, run the service with the `bootWithCCD` task as above.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,24 @@ Above command starts PCS API + CCD & all dependencies
 Once successfully loaded open XUI at http://localhost:3000
 See CftlibConfig.java for users and login details.
 
+By default, this runs with local instance of IDAM and
+S2S services. However sometimes it may be required to run
+with the AAT instances of those services, (for example when running both pcs-frontend and pcs-api locally).
+
+To do this, edit the `build.gradle` file before running the `bootWithCCD` task and replace
+
+```
+authMode = AuthMode.Local
+```
+
+with
+
+```
+authMode = AuthMode.AAT
+```
+
+Then run the service with the `bootWithCCD` task as above.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
   id 'org.flywaydb.flyway' version "$flywayVersion"
   id 'org.sonarqube' version '6.2.0.5505'
   id 'net.serenity-bdd.serenity-gradle-plugin' version "$serenityBddVersion"
-  id 'com.github.hmcts.rse-cft-lib' version '0.20.0-alpha.29'
+  id 'com.github.hmcts.rse-cft-lib' version '0.20.0-alpha.31'
   id 'io.freefair.lombok' version '8.14'
   id 'au.com.dius.pact' version '4.6.17'
   /*

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import uk.gov.hmcts.rse.CftlibExec
 
 buildscript {
   ext {
-    flywayVersion = '11.10.1'
+    flywayVersion = '11.10.2'
     serenityBddVersion = '4.2.33'
   }
   dependencies {


### PR DESCRIPTION
### Jira link

See [HDPI-1252](https://tools.hmcts.net/jira/browse/HDPI-1252)

### Change description

 Upgrade to CftLib 0.20.0-alpha.31 to get fix for running against AAT IDAM and S2S services when running pcs-api locally

### Testing done

Manual test of login when running in AAT mode.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
