### PR TITLE
HDPI-1457: Upgrade Spring Boot and spring-cloud-starter-openfeign

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
   id 'application'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.7'
-  id 'org.springframework.boot' version '3.4.7'
+  id 'org.springframework.boot' version '3.5.4'
   id 'com.github.ben-manes.versions' version '0.52.0'
   id 'org.flywaydb.flyway' version "$flywayVersion"
   id 'org.sonarqube' version '6.2.0.5505'
@@ -293,7 +293,7 @@ ext {
   log4JVersion = "2.25.1"
   logbackVersion = "1.5.18"
   testcontainersVersion = "1.21.3"
-  springFrameworkBootVersion = "3.4.7"
+  springFrameworkBootVersion = "3.5.4"
   lombokVersion = "1.18.38"
   springSecurityVersion = "6.5.2"
   pactVersion = "4.6.17"
@@ -330,7 +330,7 @@ dependencies {
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.7'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.3'
   implementation group: 'io.pebbletemplates', name: 'pebble', version: '3.2.4'
-  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.2.1'
+  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.3.0'
   implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.6.0'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
   implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion


### PR DESCRIPTION
### Jira link

See [HDPI-1457](https://tools.hmcts.net/jira/browse/HDPI-1457)

### Change description

Upgrade Spring Boot and spring-cloud-starter-openfeign together

Upgrading either independently causes the build to fail, so they both need to be done at the same time

### Testing done

Build run locally

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
