### PR TITLE
HDPI-1024:Eligibility Checks: Ineligible Properties

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/PCSCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/PCSCase.java
@@ -45,6 +45,9 @@ public class PCSCase {
     @CCD(searchable = false, access = {CitizenAccess.class, CaseworkerAccess.class})
     private YesOrNo showCrossBorderPage;
 
+    @CCD(searchable = false, access = {CitizenAccess.class, CaseworkerAccess.class})
+    private YesOrNo showPropertyNotEligiblePage;
+
     @CCD(
         typeOverride = DynamicRadioList,
         access = {CitizenAccess.class, CaseworkerAccess.class}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/CreateTestCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/CreateTestCase.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
 import uk.gov.hmcts.reform.pcs.ccd.page.createtestcase.ClaimantInformation;
 import uk.gov.hmcts.reform.pcs.ccd.page.createtestcase.CrossBorderPostcodeSelection;
 import uk.gov.hmcts.reform.pcs.ccd.page.createtestcase.MakeAClaim;
+import uk.gov.hmcts.reform.pcs.ccd.page.createtestcase.PropertyNotEligible;
 import uk.gov.hmcts.reform.pcs.ccd.page.createtestcase.StartTheService;
 import uk.gov.hmcts.reform.pcs.ccd.service.PcsCaseService;
 
@@ -26,6 +27,7 @@ public class CreateTestCase implements CCDConfig<PCSCase, State, UserRole> {
 
     private final PcsCaseService pcsCaseService;
     private final MakeAClaim makeAClaim;
+    private final PropertyNotEligible propertyNotEligible;
     private final CrossBorderPostcodeSelection crossBorderPostcodeSelection;
 
     @Override
@@ -41,6 +43,7 @@ public class CreateTestCase implements CCDConfig<PCSCase, State, UserRole> {
             .add(new StartTheService())
             .add(makeAClaim)
             .add(crossBorderPostcodeSelection)
+            .add(propertyNotEligible)
             .add(new ClaimantInformation());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createtestcase/MakeAClaim.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createtestcase/MakeAClaim.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.reform.pcs.ccd.type.DynamicStringList;
 import uk.gov.hmcts.reform.pcs.ccd.type.DynamicStringListElement;
 import uk.gov.hmcts.reform.pcs.postcodecourt.exception.EligibilityCheckException;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.EligibilityResult;
-import uk.gov.hmcts.reform.pcs.postcodecourt.model.EligibilityStatus;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry;
 import uk.gov.hmcts.reform.pcs.postcodecourt.service.EligibilityService;
 
@@ -31,45 +30,109 @@ public class MakeAClaim implements CcdPageConfiguration {
     public void addTo(PageBuilder pageBuilder) {
         pageBuilder
             .page("Make a claim", this::midEvent)
-            .pageLabel("What is the address of the property you're claiming possession of?")
+            .pageLabel(
+                "What is the address of the property you're claiming "
+                    + "possession of?"
+            )
             .label("lineSeparator", "---")
             .mandatory(PCSCase::getPropertyAddress);
     }
 
-    private AboutToStartOrSubmitResponse<PCSCase, State> midEvent(CaseDetails<PCSCase, State> details,
-                                                                  CaseDetails<PCSCase, State> detailsBefore) {
+    private AboutToStartOrSubmitResponse<PCSCase, State> midEvent(
+        CaseDetails<PCSCase, State> details,
+        CaseDetails<PCSCase, State> detailsBefore
+    ) {
+        log.info("MakeAClaim midEvent started for case ID: {}", details.getId());
+
         PCSCase caseData = details.getData();
         String postcode = caseData.getPropertyAddress().getPostCode();
-        EligibilityResult eligibilityResult = eligibilityService.checkEligibility(postcode, null);
 
-        if (eligibilityResult.getStatus() == EligibilityStatus.LEGISLATIVE_COUNTRY_REQUIRED) {
-            validateLegislativeCountries(eligibilityResult.getLegislativeCountries(), postcode);
-            setupCrossBorderData(caseData, eligibilityResult.getLegislativeCountries());
-        } else {
-            caseData.setShowCrossBorderPage(YesOrNo.NO);
+        log.debug("Processing MakeAClaim for postcode: {}", postcode);
+
+        log.info("Performing initial eligibility check for postcode: {}", postcode);
+        EligibilityResult eligibilityResult =
+            eligibilityService.checkEligibility(postcode, null);
+
+        log.debug(
+            "Initial eligibility check completed - Status: {}, Legislative Countries: {}",
+            eligibilityResult.getStatus(),
+            eligibilityResult.getLegislativeCountries()
+        );
+
+        // Reset flags every run
+        caseData.setShowCrossBorderPage(YesOrNo.NO);
+        caseData.setShowPropertyNotEligiblePage(YesOrNo.NO);
+        log.debug("Reset eligibility flags - showCrossBorderPage: NO, showPropertyNotEligiblePage: NO");
+
+        switch (eligibilityResult.getStatus()) {
+            case LEGISLATIVE_COUNTRY_REQUIRED -> {
+                log.info("MakeAClaim eligibility check: LEGISLATIVE_COUNTRY_REQUIRED for postcode {}. "
+                        + "Setting up cross-border selection", postcode);
+                validateLegislativeCountries(
+                    eligibilityResult.getLegislativeCountries(), postcode
+                );
+                setupCrossBorderData(
+                    caseData, eligibilityResult.getLegislativeCountries()
+                );
+                log.debug(
+                    "Cross-border data configured - Country1: {}, Country2: {}",
+                    caseData.getCrossBorderCountry1(),
+                    caseData.getCrossBorderCountry2()
+                );
+            }
+            case NOT_ELIGIBLE -> {
+                log.info("MakeAClaim eligibility check: NOT_ELIGIBLE for postcode {}. "
+                        + "Redirecting to PropertyNotEligible page", postcode);
+                caseData.setShowPropertyNotEligiblePage(YesOrNo.YES);
+            }
+            case ELIGIBLE -> {
+                log.info("MakeAClaim eligibility check: ELIGIBLE for postcode {}. "
+                        + "Proceeding with normal claim flow", postcode);
+            }
+            case NO_MATCH_FOUND -> {
+                log.info("MakeAClaim eligibility check: NO_MATCH_FOUND for postcode {}. "
+                        + "Proceeding with default flow", postcode);
+            }
+            case MULTIPLE_MATCHES_FOUND -> {
+                log.info("MakeAClaim eligibility check: MULTIPLE_MATCHES_FOUND for postcode {}. "
+                        + "Proceeding with default flow", postcode);
+            }
         }
 
+        log.info("MakeAClaim midEvent completed for case ID: {}", details.getId());
         return AboutToStartOrSubmitResponse.<PCSCase, State>builder()
             .data(caseData)
             .build();
     }
 
-    private void validateLegislativeCountries(List<LegislativeCountry> legislativeCountries, String postcode) {
+
+    private void validateLegislativeCountries(
+        List<LegislativeCountry> legislativeCountries,
+        String postcode
+    ) {
         if (legislativeCountries == null || legislativeCountries.size() < 2) {
-            throw new EligibilityCheckException(String.format(
-                "Expected at least 2 legislative countries when status is LEGISLATIVE_COUNTRY_REQUIRED, "
-                    + "but got %d for postcode: %s",
-                legislativeCountries == null ? 0 : legislativeCountries.size(),
-                postcode
-            ));
+            throw new EligibilityCheckException(
+                String.format(
+                    "Expected at least 2 legislative countries when status is "
+                        + "LEGISLATIVE_COUNTRY_REQUIRED, but got %d for "
+                        + "postcode: %s",
+                    legislativeCountries == null ? 0
+                        : legislativeCountries.size(),
+                    postcode
+                )
+            );
         }
     }
 
-    private void setupCrossBorderData(PCSCase caseData, List<LegislativeCountry> legislativeCountries) {
+    private void setupCrossBorderData(
+        PCSCase caseData,
+        List<LegislativeCountry> legislativeCountries
+    ) {
         caseData.setShowCrossBorderPage(YesOrNo.YES);
 
         List<DynamicStringListElement> crossBorderCountries =
             createCrossBorderCountriesList(legislativeCountries);
+
         DynamicStringList crossBorderCountriesList = DynamicStringList.builder()
             .listItems(crossBorderCountries)
             .build();
@@ -77,12 +140,17 @@ public class MakeAClaim implements CcdPageConfiguration {
         caseData.setCrossBorderCountriesList(crossBorderCountriesList);
 
         // Set individual cross border countries
-        caseData.setCrossBorderCountry1(crossBorderCountries.get(0).getLabel());
-        caseData.setCrossBorderCountry2(crossBorderCountries.get(1).getLabel());
+        caseData.setCrossBorderCountry1(
+            crossBorderCountries.get(0).getLabel()
+        );
+        caseData.setCrossBorderCountry2(
+            crossBorderCountries.get(1).getLabel()
+        );
     }
 
     private List<DynamicStringListElement> createCrossBorderCountriesList(
-        List<LegislativeCountry> legislativeCountries) {
+        List<LegislativeCountry> legislativeCountries
+    ) {
         return legislativeCountries.stream()
             .map(value -> DynamicStringListElement.builder()
                 .code(value.name())

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createtestcase/PropertyNotEligible.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createtestcase/PropertyNotEligible.java
@@ -1,0 +1,84 @@
+package uk.gov.hmcts.reform.pcs.ccd.page.createtestcase;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.reform.pcs.ccd.common.CcdPageConfiguration;
+import uk.gov.hmcts.reform.pcs.ccd.common.PageBuilder;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.domain.State;
+
+import java.util.List;
+
+import static uk.gov.hmcts.reform.pcs.ccd.ShowConditions.NEVER_SHOW;
+
+/**
+ * CCD page configuration for postcode not eligible.
+ * This page is shown when a postcode is not eligible for the Possessions Service.
+ */
+@AllArgsConstructor
+@Component
+@Slf4j
+public class PropertyNotEligible implements CcdPageConfiguration {
+
+    @Override
+    public void addTo(PageBuilder pageBuilder) {
+        pageBuilder
+            .page("propertyNotEligible-info", this::midEvent)
+            .pageLabel("Property not eligible for this online service")
+            .showCondition("showPropertyNotEligiblePage=\"Yes\"")
+            .readonly(PCSCase::getShowPropertyNotEligiblePage, NEVER_SHOW)
+            .label("postcodeNotEligible-info", """
+
+                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                <h2 class="govuk-heading-m">What to do next</h2>
+                <p class="govuk-body">
+                  This service is currently only available for claimants claiming possession of a property
+                  in Bedfordshire.
+                </p>
+                <p class="govuk-body">If you’re making a claim in another area:</p>
+
+                <ul class="govuk-list govuk-list--bullet">
+                 <li class="govuk-list govuk-!-font-size-19">
+                    <span class="govuk-!-font-weight-bold">For rental or mortgage arrears claims in England</span> –
+                    use the <a class="govuk-link" href="https://www.gov.uk/possession-claim-online-recover-property" target="_blank" rel="noopener noreferrer">
+                    Possession Claim Online (PCOL) service (opens in new tab)</a>.
+                  </li>
+                 <li class="govuk-list govuk-!-font-size-19">
+                    <span class="govuk-!-font-weight-bold">For other types of claims in England</span> –
+                    use form N5 and the correct particulars of claim form.
+                  </li>
+                 <li class="govuk-list govuk-!-font-size-19">
+                    <span class="govuk-!-font-weight-bold">For claims in Wales</span> –
+                    use form N5 Wales and the correct particulars of claim form.
+                  </li>
+                </ul>
+
+                <p class="govuk-body">
+                  <a class="govuk-link" href="https://www.gov.uk/government/collections/property-possession-forms" target="_blank" rel="noopener noreferrer">
+                    View the full list of property possessions forms (opens in new tab)
+                  </a>
+                </p>
+
+                <div class="govuk-warning-text">
+                  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                  <strong class="govuk-warning-text__text">
+                    <span class="govuk-visually-hidden">Warning</span>
+                      To exit back to the case list, select 'Cancel'
+                  </strong>
+                </div>
+                """);
+    }
+
+    private AboutToStartOrSubmitResponse<PCSCase, State> midEvent(
+        CaseDetails<PCSCase, State> details,
+        CaseDetails<PCSCase, State> detailsBefore) {
+
+        return AboutToStartOrSubmitResponse.<PCSCase, State>builder()
+            .errors(List.of("Property not eligible for this online service"))
+            .build();
+    }
+
+}


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/HDPI-1024

### Change description

1. Make a Claim – If the eligibility check result is NOT_ELIGIBLE, display the Property Not Eligible page.
2.Cross-Border Postcode Selection – If the selected country is NOT_ELIGIBLE, keep the cross-border page visible for “Previous” navigation, and also display the Property Not Eligible page.
3.Added Test 

### Testing done

Locally tested both the flow.
<img width="1160" height="808" alt="image" src="https://github.com/user-attachments/assets/e70f59cc-86bc-4155-9e44-3ae4a5a19ef2" />

### Security Vulnerability Assessment ###



**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
