### PR TITLE
HDPI-1571: Rename creation event and add unit test

### DIFF
--- a/src/cftlibTest/java/uk/gov/hmcts/reform/pcs/TestWithCCD.java
+++ b/src/cftlibTest/java/uk/gov/hmcts/reform/pcs/TestWithCCD.java
@@ -42,8 +42,8 @@ public class TestWithCCD extends CftlibTest {
     }
 
     @Test
-    public void createsTestCase() {
-        var r = ccdApi.startCase(idamToken, s2sToken, CaseType.getCaseType(), "createTestApplication");
+    public void createsPossessionClaim() {
+        var r = ccdApi.startCase(idamToken, s2sToken, CaseType.getCaseType(), "createPossessionClaim");
         PCSCase caseData = PCSCase.builder()
             .applicantForename("Foo")
             .propertyAddress(AddressUK.builder()
@@ -57,7 +57,7 @@ public class TestWithCCD extends CftlibTest {
             .build();
         var content = CaseDataContent.builder()
             .data(caseData)
-            .event(Event.builder().id("createTestApplication").build())
+            .event(Event.builder().id("createPossessionClaim").build())
             .eventToken(r.getToken())
             .build();
         caseDetails = ccdApi.submitForCaseworker(idamToken, s2sToken, userId,

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/common/PageBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/common/PageBuilder.java
@@ -15,7 +15,7 @@ public class PageBuilder {
         this.eventBuilder = eventBuilder;
     }
 
-    public FieldCollectionBuilder<PCSCase, State, EventBuilder<PCSCase, UserRole, State>> page(final String id) {
+    public FieldCollectionBuilder<PCSCase, State, EventBuilder<PCSCase, UserRole, State>> page(String id) {
         return eventBuilder.fields().page(id);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/CreatePossessionClaim.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/CreatePossessionClaim.java
@@ -8,38 +8,38 @@ import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import uk.gov.hmcts.ccd.sdk.api.Event.EventBuilder;
 import uk.gov.hmcts.ccd.sdk.api.EventPayload;
 import uk.gov.hmcts.ccd.sdk.api.Permission;
+import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
 import uk.gov.hmcts.reform.pcs.ccd.common.PageBuilder;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PaymentStatus;
 import uk.gov.hmcts.reform.pcs.ccd.domain.State;
-import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
-import uk.gov.hmcts.reform.pcs.ccd.page.createtestcase.ClaimantInformation;
-import uk.gov.hmcts.reform.pcs.ccd.page.createtestcase.CrossBorderPostcodeSelection;
-import uk.gov.hmcts.reform.pcs.ccd.page.createtestcase.MakeAClaim;
+import uk.gov.hmcts.reform.pcs.ccd.page.createpossessionclaim.ClaimantInformation;
+import uk.gov.hmcts.reform.pcs.ccd.page.createpossessionclaim.CrossBorderPostcodeSelection;
+import uk.gov.hmcts.reform.pcs.ccd.page.createpossessionclaim.EnterPropertyAddress;
 import uk.gov.hmcts.reform.pcs.ccd.service.PcsCaseService;
 
-import static uk.gov.hmcts.reform.pcs.ccd.event.EventId.createTestApplication;
+import static uk.gov.hmcts.reform.pcs.ccd.event.EventId.createPossessionClaim;
 
 @Component
 @AllArgsConstructor
 @Slf4j
-public class CreateTestCase implements CCDConfig<PCSCase, State, UserRole> {
+public class CreatePossessionClaim implements CCDConfig<PCSCase, State, UserRole> {
 
     private final PcsCaseService pcsCaseService;
-    private final MakeAClaim makeAClaim;
+    private final EnterPropertyAddress enterPropertyAddress;
     private final CrossBorderPostcodeSelection crossBorderPostcodeSelection;
 
     @Override
     public void configure(ConfigBuilder<PCSCase, State, UserRole> configBuilder) {
         EventBuilder<PCSCase, UserRole, State> eventBuilder =
             configBuilder
-                .decentralisedEvent(createTestApplication.name(), this::submit, this::start)
+                .decentralisedEvent(createPossessionClaim.name(), this::submit, this::start)
                 .initialState(State.CASE_ISSUED)
                 .name("Make a claim")
                 .grant(Permission.CRUD, UserRole.PCS_CASE_WORKER);
 
         new PageBuilder(eventBuilder)
-            .add(makeAClaim)
+            .add(enterPropertyAddress)
             .add(crossBorderPostcodeSelection)
             .add(new ClaimantInformation());
     }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/EventId.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/EventId.java
@@ -6,7 +6,7 @@ public enum EventId {
     citizenCreateApplication,
     citizenSubmitApplication,
     citizenUpdateApplication,
-    createTestApplication,
+    createPossessionClaim,
     processClaimPayment,
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/ClaimantInformation.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/ClaimantInformation.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.pcs.ccd.page.createtestcase;
+package uk.gov.hmcts.reform.pcs.ccd.page.createpossessionclaim;
 
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/CrossBorderPostcodeSelection.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/CrossBorderPostcodeSelection.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.pcs.ccd.page.createtestcase;
+package uk.gov.hmcts.reform.pcs.ccd.page.createpossessionclaim;
 
 import static uk.gov.hmcts.reform.pcs.ccd.ShowConditions.NEVER_SHOW;
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/EnterPropertyAddress.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/EnterPropertyAddress.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.pcs.ccd.page.createtestcase;
+package uk.gov.hmcts.reform.pcs.ccd.page.createpossessionclaim;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.AllArgsConstructor;
@@ -23,16 +23,16 @@ import java.util.List;
 @AllArgsConstructor
 @Component
 @Slf4j
-public class MakeAClaim implements CcdPageConfiguration {
+public class EnterPropertyAddress implements CcdPageConfiguration {
 
     private final EligibilityService eligibilityService;
 
     @Override
     public void addTo(PageBuilder pageBuilder) {
         pageBuilder
-            .page("Make a claim", this::midEvent)
+            .page("enterPropertyAddress", this::midEvent)
             .pageLabel("What is the address of the property you're claiming possession of?")
-            .label("lineSeparator", "---")
+            .label("enterPropertyAddress-lineSeparator", "---")
             .mandatory(PCSCase::getPropertyAddress);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/page/BasePageTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/page/BasePageTest.java
@@ -51,7 +51,13 @@ public class BasePageTest {
     @SuppressWarnings("unchecked")
     protected static MidEvent<PCSCase, State> getMidEventForPage(Event<PCSCase, UserRole, State> event,
                                                                  String pageId) {
-        return event.getFields().getPagesToMidEvent().get(pageId);
+        MidEvent<PCSCase, State> midEvent = event.getFields().getPagesToMidEvent().get(pageId);
+
+        assertThat(midEvent)
+            .withFailMessage("No mid event found for page with ID %s", pageId)
+            .isNotNull();
+
+        return midEvent;
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/CrossBorderPostcodeSelectionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/CrossBorderPostcodeSelectionTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.pcs.ccd.page.createtestcase;
+package uk.gov.hmcts.reform.pcs.ccd.page.createpossessionclaim;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,10 +32,10 @@ import static org.mockito.Mockito.when;
 class CrossBorderPostcodeSelectionTest extends BasePageTest {
 
     private static final String SOME_POSTCODE = "TX1 1TX";
-    
+
     @Mock
     private EligibilityService eligibilityService;
-    
+
     private Event<PCSCase, UserRole, State> event;
 
     @BeforeEach
@@ -70,7 +70,7 @@ class CrossBorderPostcodeSelectionTest extends BasePageTest {
         when(eligibilityService.checkEligibility(postcode, selectedCountry)).thenReturn(eligibilityResult);
 
         // When
-        AboutToStartOrSubmitResponse<PCSCase, State> response = 
+        AboutToStartOrSubmitResponse<PCSCase, State> response =
             getMidEventForPage(event, "crossBorderPostcodeSelection")
                 .handle(caseDetails, null);
 

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/EnterPropertyAddressTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/EnterPropertyAddressTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.pcs.ccd.page.createtestcase;
+package uk.gov.hmcts.reform.pcs.ccd.page.createpossessionclaim;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.Event;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.api.callback.MidEvent;
 import uk.gov.hmcts.ccd.sdk.type.AddressUK;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
@@ -29,10 +30,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.NO;
+import static uk.gov.hmcts.ccd.sdk.type.YesOrNo.YES;
 
-class MakeAClaimTest extends BasePageTest {
+class EnterPropertyAddressTest extends BasePageTest {
 
     private EligibilityService eligibilityService;
     private Event<PCSCase, UserRole, State> event;
@@ -40,7 +41,7 @@ class MakeAClaimTest extends BasePageTest {
     @BeforeEach
     void setUp() {
         eligibilityService = mock(EligibilityService.class);
-        event = buildPageInTestEvent(new MakeAClaim(eligibilityService));
+        event = buildPageInTestEvent(new EnterPropertyAddress(eligibilityService));
     }
 
     @ParameterizedTest
@@ -73,13 +74,13 @@ class MakeAClaimTest extends BasePageTest {
         when(eligibilityService.checkEligibility(postcode, null)).thenReturn(eligibilityResult);
 
         // When
-        AboutToStartOrSubmitResponse<PCSCase, State> response = getMidEventForPage(event, "Make a claim")
+        AboutToStartOrSubmitResponse<PCSCase, State> response = getMidEventForPage(event, "enterPropertyAddress")
             .handle(caseDetails, null);
 
         // Then
         PCSCase resultData = response.getData();
         assertThat(resultData.getShowCrossBorderPage()).isEqualTo(expectedShowCrossBorder);
-        
+
         if (expectedShowCrossBorder == YES) {
             assertThat(resultData.getCrossBorderCountriesList()).isNotNull();
             assertThat(resultData.getCrossBorderCountry1()).isEqualTo(expectedCountry1);
@@ -113,9 +114,10 @@ class MakeAClaimTest extends BasePageTest {
 
         when(eligibilityService.checkEligibility(postcode, null)).thenReturn(eligibilityResult);
 
+        MidEvent<PCSCase, State> midEvent = getMidEventForPage(event, "enterPropertyAddress");
+
         // When & Then
-        assertThatThrownBy(() -> getMidEventForPage(event, "Make a claim")
-            .handle(caseDetails, null))
+        assertThatThrownBy(() -> midEvent.handle(caseDetails, null))
             .isInstanceOf(EligibilityCheckException.class)
             .hasMessageContaining("Expected at least 2 legislative countries")
             .hasMessageContaining(expectedMessageFragment)
@@ -130,14 +132,14 @@ class MakeAClaimTest extends BasePageTest {
                 Collections.emptyList(),
                 "but got 0"
             ),
-            
-            // Single country case  
+
+            // Single country case
             arguments(
                 "BT1 1AA",
                 Collections.singletonList(LegislativeCountry.NORTHERN_IRELAND),
                 "but got 1"
             ),
-            
+
             // Null list case
             arguments(
                 "NULL_CASE",
@@ -158,7 +160,7 @@ class MakeAClaimTest extends BasePageTest {
                 null,
                 null
             ),
-            
+
             // Not eligible postcode
             arguments(
                 "M1 1AA",
@@ -168,7 +170,7 @@ class MakeAClaimTest extends BasePageTest {
                 null,
                 null
             ),
-            
+
             // No match found
             arguments(
                 "INVALID",
@@ -178,7 +180,7 @@ class MakeAClaimTest extends BasePageTest {
                 null,
                 null
             ),
-            
+
             // Cross-border England/Scotland
             arguments(
                 "TD9 0TU",
@@ -188,7 +190,7 @@ class MakeAClaimTest extends BasePageTest {
                 "England",
                 "Scotland"
             ),
-            
+
             // Cross-border Wales/England
             arguments(
                 "LL65 1AA",

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/type/DynamicStringListElementTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/type/DynamicStringListElementTest.java
@@ -10,13 +10,13 @@ class DynamicStringListElementTest {
     void shouldCreateElementWithNoArgsConstructor() {
         // When
         DynamicStringListElement element = new DynamicStringListElement();
-        
+
         // Then
         assertThat(element).isNotNull();
         assertThat(element.getCode()).isNull();
         assertThat(element.getLabel()).isNull();
     }
-    
+
     @Test
     void shouldCreateElementWithBuilder() {
         // When
@@ -24,45 +24,45 @@ class DynamicStringListElementTest {
             .code("code1")
             .label("label1")
             .build();
-        
+
         // Then
         assertThat(element).isNotNull();
         assertThat(element.getCode()).isEqualTo("code1");
         assertThat(element.getLabel()).isEqualTo("label1");
     }
-    
+
     @Test
     void shouldCreateElementWithJsonCreator() {
         // When
         DynamicStringListElement element = new DynamicStringListElement("code1", "label1");
-        
+
         // Then
         assertThat(element).isNotNull();
         assertThat(element.getCode()).isEqualTo("code1");
         assertThat(element.getLabel()).isEqualTo("label1");
     }
-    
+
     @Test
     void shouldSetAndGetProperties() {
         // Given
         DynamicStringListElement element = new DynamicStringListElement();
-        
+
         // When
         element.setCode("newCode");
         element.setLabel("newLabel");
-        
+
         // Then
         assertThat(element.getCode()).isEqualTo("newCode");
         assertThat(element.getLabel()).isEqualTo("newLabel");
     }
-    
+
     @Test
     void shouldUseDataAnnotationFunctionality() {
         // Given
         DynamicStringListElement element1 = new DynamicStringListElement("code1", "label1");
         DynamicStringListElement element2 = new DynamicStringListElement("code1", "label1");
         DynamicStringListElement element3 = new DynamicStringListElement("code2", "label2");
-        
+
         // When & Then
         assertThat(element1).isEqualTo(element2);
         assertThat(element1).isNotEqualTo(element3);
@@ -71,4 +71,4 @@ class DynamicStringListElementTest {
         assertThat(element1.toString()).isEqualTo(element2.toString());
         assertThat(element1.toString()).isNotEqualTo(element3.toString());
     }
-} 
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/type/DynamicStringListTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/type/DynamicStringListTest.java
@@ -11,13 +11,13 @@ class DynamicStringListTest {
     void shouldCreateDynamicStringListWithNoArgsConstructor() {
         // When
         DynamicStringList list = new DynamicStringList();
-        
+
         // Then
         assertThat(list).isNotNull();
         assertThat(list.getValue()).isNull();
         assertThat(list.getListItems()).isNull();
     }
-    
+
     @Test
     void shouldCreateDynamicStringListWithBuilder() {
         // Given
@@ -26,34 +26,34 @@ class DynamicStringListTest {
             .label("label1")
             .build();
         List<DynamicStringListElement> items = List.of(element);
-        
+
         // When
         DynamicStringList list = DynamicStringList.builder()
             .value(element)
             .listItems(items)
             .build();
-        
+
         // Then
         assertThat(list).isNotNull();
         assertThat(list.getValue()).isEqualTo(element);
         assertThat(list.getListItems()).isEqualTo(items);
     }
-    
+
     @Test
     void shouldCreateDynamicStringListWithJsonCreator() {
         // Given
         DynamicStringListElement element = new DynamicStringListElement("code1", "label1");
         List<DynamicStringListElement> items = List.of(element);
-        
+
         // When
         DynamicStringList list = new DynamicStringList(element, items);
-        
+
         // Then
         assertThat(list).isNotNull();
         assertThat(list.getValue()).isEqualTo(element);
         assertThat(list.getListItems()).isEqualTo(items);
     }
-    
+
     @Test
     void shouldGetValueCode() {
         // Given
@@ -61,40 +61,40 @@ class DynamicStringListTest {
         DynamicStringList list = DynamicStringList.builder()
             .value(element)
             .build();
-        
+
         // When
         String valueCode = list.getValueCode();
-        
+
         // Then
         assertThat(valueCode).isEqualTo("code1");
     }
-    
+
     @Test
     void shouldReturnNullForValueCodeWhenValueIsNull() {
         // Given
         DynamicStringList list = DynamicStringList.builder().build();
-        
+
         // When
         String valueCode = list.getValueCode();
-        
+
         // Then
         assertThat(valueCode).isNull();
     }
-    
+
     @Test
     void shouldUseDataAnnotationFunctionality() {
         // Given
         DynamicStringListElement element1 = new DynamicStringListElement("code1", "label1");
         List<DynamicStringListElement> items1 = List.of(element1);
         DynamicStringList list1 = new DynamicStringList(element1, items1);
-        
+
         DynamicStringListElement element2 = new DynamicStringListElement("code1", "label1");
         List<DynamicStringListElement> items2 = List.of(element2);
         DynamicStringList list2 = new DynamicStringList(element2, items2);
-        
+
         // When & Then
         assertThat(list1).isEqualTo(list2);
         assertThat(list1.hashCode()).isEqualTo(list2.hashCode());
         assertThat(list1.toString()).isEqualTo(list2.toString());
     }
-} 
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/postcodecourt/model/LegislativeCountryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/postcodecourt/model/LegislativeCountryTest.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.reform.pcs.postcodecourt.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class LegislativeCountryTest {
+
+    @ParameterizedTest
+    @MethodSource("enumsWithLabels")
+    void shouldCreateEnumFromLabel(String label, LegislativeCountry expectedLegislativeCountry) {
+        LegislativeCountry actualLegislativeCountry = LegislativeCountry.fromLabel(label);
+
+        assertThat(actualLegislativeCountry).isEqualTo(expectedLegislativeCountry);
+    }
+
+    @Test
+    void shouldThrowExceptionForUnknownLabel() {
+        Throwable throwable = catchThrowable(() -> LegislativeCountry.fromLabel("unknown"));
+
+        assertThat(throwable)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("No value found with label: unknown");
+    }
+
+    private static Stream<Arguments> enumsWithLabels() {
+        return Stream.of(
+            arguments("England", LegislativeCountry.ENGLAND),
+            arguments("Northern Ireland", LegislativeCountry.NORTHERN_IRELAND),
+            arguments("Scotland", LegislativeCountry.SCOTLAND),
+            arguments("Wales", LegislativeCountry.WALES)
+        );
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportControllerTest.java
@@ -467,14 +467,14 @@ class TestingSupportControllerTest {
         String serviceAuth = "Bearer serviceToken";
         String postcode = "SW1A 1AA";
         LegislativeCountry country = LegislativeCountry.ENGLAND;
-        
+
         EligibilityResult expectedResult = mock(EligibilityResult.class);
-        
+
         when(eligibilityService.checkEligibility(postcode, country)).thenReturn(expectedResult);
-        
+
         // When
         EligibilityResult result = underTest.getPostcodeEligibility(serviceAuth, postcode, country);
-        
+
         // Then
         assertThat(result).isSameAs(expectedResult);
         verify(eligibilityService).checkEligibility(postcode, country);
@@ -485,14 +485,14 @@ class TestingSupportControllerTest {
         // Given
         String serviceAuth = "Bearer serviceToken";
         String postcode = "CH5 1AA";
-        
+
         EligibilityResult expectedResult = mock(EligibilityResult.class);
-        
+
         when(eligibilityService.checkEligibility(postcode, null)).thenReturn(expectedResult);
-        
+
         // When
         EligibilityResult result = underTest.getPostcodeEligibility(serviceAuth, postcode, null);
-        
+
         // Then
         assertThat(result).isSameAs(expectedResult);
         verify(eligibilityService).checkEligibility(postcode, null);
@@ -504,15 +504,15 @@ class TestingSupportControllerTest {
         String serviceAuth = "Bearer serviceToken";
         String postcode = "INVALID";
         RuntimeException serviceException = new RuntimeException("Service error");
-        
+
         when(eligibilityService.checkEligibility(postcode, null)).thenThrow(serviceException);
-        
+
         // When/Then
         org.assertj.core.api.Assertions.assertThatThrownBy(() ->
             underTest.getPostcodeEligibility(serviceAuth, postcode, null)
         ).isInstanceOf(RuntimeException.class)
          .hasMessageContaining("Service error");
-        
+
         verify(eligibilityService).checkEligibility(postcode, null);
     }
 }


### PR DESCRIPTION
### Jira link

See [HDPI-1571](https://tools.hmcts.net/jira/browse/HDPI-1571)

### Change description

Small refactoring PR to tidy up the code as it grows.

- Rename the case creation event from `CreateTestCase` to `CreatePossessionClaim`
- Rename the `MakeAClaim` page to `EnterPropertyAddress` as that is a better description of what the page is.
- Add unit test coverage for LegislativeCountry
- Clean up some whitespace 

### Testing done

Full build has been run

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
