### PR TITLE
Setting tomcat embed core & websocket to remove CVE's

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,6 +303,7 @@ ext {
   lombokVersion = "1.18.38"
   springSecurityVersion = "6.5.2"
   pactVersion = "4.6.17"
+  tomcatCoreVersion = "10.1.44"
 }
 
 ext['snakeyaml.version'] = '2.0'
@@ -342,8 +343,8 @@ dependencies {
   implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
   implementation group: 'io.vavr', name: 'vavr', version: '0.10.7'
   implementation group: 'com.github.kagkarlsson', name: 'db-scheduler-spring-boot-starter', version: '16.0.0'
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.1.44'
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.1.44'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: tomcatCoreVersion
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: tomcatCoreVersion
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
 
   testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.6'

--- a/build.gradle
+++ b/build.gradle
@@ -342,6 +342,8 @@ dependencies {
   implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
   implementation group: 'io.vavr', name: 'vavr', version: '0.10.7'
   implementation group: 'com.github.kagkarlsson', name: 'db-scheduler-spring-boot-starter', version: '16.0.0'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.1.44'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.1.44'
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
 
   testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.6'

--- a/build.gradle
+++ b/build.gradle
@@ -344,7 +344,7 @@ dependencies {
   implementation group: 'com.github.kagkarlsson', name: 'db-scheduler-spring-boot-starter', version: '16.0.0'
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
 
-  testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.5'
+  testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.6'
   testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.10', classifier: 'all'
 
   implementation(group: 'com.github.hmcts', name: 'befta-fw', version: '9.2.4') {

--- a/build.gradle
+++ b/build.gradle
@@ -303,7 +303,7 @@ ext {
   lombokVersion = "1.18.38"
   springSecurityVersion = "6.5.2"
   pactVersion = "4.6.17"
-  tomcatCoreVersion = "10.1.44"
+  tomcatEmbedVersion = "10.1.44"
 }
 
 ext['snakeyaml.version'] = '2.0'
@@ -343,8 +343,8 @@ dependencies {
   implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
   implementation group: 'io.vavr', name: 'vavr', version: '0.10.7'
   implementation group: 'com.github.kagkarlsson', name: 'db-scheduler-spring-boot-starter', version: '16.0.0'
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: tomcatCoreVersion
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: tomcatCoreVersion
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: tomcatEmbedVersion
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: tomcatEmbedVersion
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
 
   testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.6'


### PR DESCRIPTION
### Jira link

N/A

### Change description

Setting tomcat embed core & web socket to remove CVE's, please note this is a minor package upgrade as they are a sub dependency of spring-boot-starter-web@3.5.4 and ccd-config-generator@0.20.0-alpha.37, where they are set to version 10.1.43.

### Testing done

Automated tests

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
