### PR TITLE
HDPI-1712: Revert Sonarqube plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
   id 'org.springframework.boot' version '3.5.5'
   id 'com.github.ben-manes.versions' version '0.52.0'
   id 'org.flywaydb.flyway' version "$flywayVersion"
-  id 'org.sonarqube' version '6.3.0.5676'
+  id 'org.sonarqube' version '6.2.0.5505'
   id 'net.serenity-bdd.serenity-gradle-plugin' version "$serenityBddVersion"
   id 'com.github.hmcts.rse-cft-lib' version '0.20.0-alpha.37'
   id 'io.freefair.lombok' version '8.14.2'


### PR DESCRIPTION
It looks like the recent latest release has been removed from the plugin repo, so builds are failing

### Jira link

See [HDPI-1712](https://tools.hmcts.net/jira/browse/HDPI-1712)

### Change description

The Sonarqube Gradle plugin was recently upgraded by the Renovate bot but it looks like that version is no longer available in the plugin repo, so the pcs-api builds are failing now. This PR reverts to the latest advertised version, (5505):

https://plugins.gradle.org/plugin/org.sonarqube


### Testing done

Full build run

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
