### PR TITLE
HDPI-1750: Fix local DB name, Mockito warning and add test postcode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -431,6 +431,12 @@ project.tasks.named("processSmokeTestResources") {
   duplicatesStrategy = 'include'
 }
 
+tasks.named('test') {
+  doFirst {
+    jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
+  }
+}
+
 tasks.withType(CftlibExec).configureEach {
   group = 'ccd tasks'
   authMode = AuthMode.Local

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,7 +40,7 @@ spring:
     name: pcs api
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${PCS_DB_HOST:localhost}:${PCS_DB_PORT:6432}/${PCS_DB_NAME:postgres}${PCS_DB_OPTIONS:}
+    url: jdbc:postgresql://${PCS_DB_HOST:localhost}:${PCS_DB_PORT:6432}/${PCS_DB_NAME:pcs}${PCS_DB_OPTIONS:}
     username: ${PCS_DB_USER_NAME:postgres}
     password: ${PCS_DB_PASSWORD:}
     properties:

--- a/src/main/resources/db/testdata/V017.1__add_postcodes_for_local_test_address.sql
+++ b/src/main/resources/db/testdata/V017.1__add_postcodes_for_local_test_address.sql
@@ -1,0 +1,6 @@
+/* Insert the postcode used by the fake address lookup when running locally with CftLib */
+INSERT INTO postcode_court_mapping (postcode, epims_id, legislative_country, effective_from, effective_to, audit) VALUES
+    ('SW111PD', 20264, 'England', '2025-01-01', '2035-04-01', '{"created_by": "admin", "change_reason": "initial insert"}'::jsonb);
+
+INSERT INTO eligibility_whitelisted_epim (epims_id, eligible_from, audit) VALUES
+    (20264, '2025-01-01', '{"generated, R1, V1": "2025-09-01T08:00:00.000Z"}'::jsonb);


### PR DESCRIPTION
…or local

### Jira link

See [HDPI-1750](https://tools.hmcts.net/jira/browse/HDPI-1750)

### Change description

* Fix DB name used locally to be "pcs" instead of "postgres"
* Fix a Mockito warning about attaching the inline mockmaker
* Add the test postcode used by the CftLib address search when running ExUI locally, as a valid postcode to use the service

### Testing done

Full build run

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
