### PR TITLE
HDPI-1737: Use vertical Yes/No options for claimant name check

### DIFF
--- a/src/cftlibTest/java/uk/gov/hmcts/reform/pcs/CitizenCreateApplicationTest.java
+++ b/src/cftlibTest/java/uk/gov/hmcts/reform/pcs/CitizenCreateApplicationTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import uk.gov.hmcts.ccd.sdk.type.AddressUK;
-import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -23,6 +22,7 @@ import uk.gov.hmcts.reform.pcs.ccd.CaseType;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PaymentStatus;
 import uk.gov.hmcts.reform.pcs.ccd.domain.State;
+import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
 import uk.gov.hmcts.reform.pcs.ccd.event.EventId;
 import uk.gov.hmcts.rse.ccd.lib.test.CftlibTest;
 
@@ -61,7 +61,7 @@ class CitizenCreateApplicationTest extends CftlibTest {
 
         PCSCase caseData = PCSCase.builder()
             .claimantName("Wrong Name")
-            .isClaimantNameCorrect(YesOrNo.NO)
+            .isClaimantNameCorrect(VerticalYesNo.NO)
             .overriddenClaimantName("New Name")
             .propertyAddress(AddressUK.builder()
                                  .addressLine1("123 Baker Street")

--- a/src/cftlibTest/java/uk/gov/hmcts/reform/pcs/TestWithCCD.java
+++ b/src/cftlibTest/java/uk/gov/hmcts/reform/pcs/TestWithCCD.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import uk.gov.hmcts.ccd.sdk.type.AddressUK;
-import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -16,6 +15,7 @@ import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.pcs.ccd.CaseType;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PaymentStatus;
+import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
 import uk.gov.hmcts.rse.ccd.lib.test.CftlibTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +47,7 @@ public class TestWithCCD extends CftlibTest {
         var r = ccdApi.startCase(idamToken, s2sToken, CaseType.getCaseType(), "createPossessionClaim");
         PCSCase caseData = PCSCase.builder()
             .claimantName("Wrong Name")
-            .isClaimantNameCorrect(YesOrNo.NO)
+            .isClaimantNameCorrect(VerticalYesNo.NO)
             .overriddenClaimantName("Updated Name")
             .propertyAddress(AddressUK.builder()
                                  .addressLine1("123 Baker Street")

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/PCSCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/PCSCase.java
@@ -40,7 +40,7 @@ public class PCSCase {
         searchable = false,
         access = {CitizenAccess.class, CaseworkerAccess.class}
     )
-    private YesOrNo isClaimantNameCorrect;
+    private VerticalYesNo isClaimantNameCorrect;
 
     @CCD(
         access = {CitizenAccess.class, CaseworkerAccess.class}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/ClaimantInformation.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/ClaimantInformation.java
@@ -25,7 +25,7 @@ public class ClaimantInformation implements CcdPageConfiguration {
             .readonlyWithLabel(PCSCase::getClaimantName, "Your claimant name registered with My HMCTS is:")
             .mandatoryWithLabel(PCSCase::getIsClaimantNameCorrect,"Is this the correct claimant name?")
             .mandatory(PCSCase::getOverriddenClaimantName,
-                    "isClaimantNameCorrect=\"No\"",
+                    "isClaimantNameCorrect=\"NO\"",
                     null,
                     "What is the correct claimant name?",
                     UPDATED_CLAIMANT_NAME_HINT,


### PR DESCRIPTION
### Jira link


See [HDPI-1737](https://tools.hmcts.net/jira/browse/HDPI-1737)

### Change description

Change the horizontally aligned Yes/No buttons to be vertical on the claimant name page

**Before:**
<img width="1810" height="1282" alt="image-2025-08-29-16-32-56-712" src="https://github.com/user-attachments/assets/9090c1a6-a62e-4a5f-aa8b-32cb013fe3ee" />

**After:**
<img width="2480" height="2136" alt="image-2025-08-29-16-32-19-496" src="https://github.com/user-attachments/assets/940b1731-5a2f-49a9-bf5c-04b93b512e06" />


### Testing done

Manual testing locally

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
