### PR TITLE
HDPI-1810: Add Wales postcode and eligibility to test data

### DIFF
--- a/src/main/resources/db/testdata/V017.2__add_wales_postcodes_and_courts.sql
+++ b/src/main/resources/db/testdata/V017.2__add_wales_postcodes_and_courts.sql
@@ -1,0 +1,5 @@
+INSERT INTO postcode_court_mapping (postcode, epims_id, legislative_country, effective_from, effective_to, audit)
+VALUES ('CF116QX', 30100, 'Wales', '2025-08-29', NULL, '{"created_by": "admin", "change_reason": "initial insert"}');
+
+INSERT INTO eligibility_whitelisted_epim (epims_id, eligible_from, audit) VALUES
+    (30100, '2025-01-01', '{"generated, R1, V1": "2025-09-01T08:00:00.000Z"}'::jsonb);


### PR DESCRIPTION
### Jira link

See [HDPI-1810](https://tools.hmcts.net/jira/browse/HDPI-1810)

### Change description

Now that the legislative country for the claim is derived from the property postcode, we need a Wales postcode in the test data, linked to an eligible test court.

This migration has been picked from another one of my PRs that is going through QA, but has been separated out so it can be deployed more quickly for the benefit of other PRs

### Testing done

Full build run locally

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
