### PR TITLE
Small fix to after always call on fortify-scan

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -16,12 +16,12 @@ properties([
     ),
     booleanParam(
       name: 'CHROME_TESTS',
-      defaultValue: true,
+      defaultValue: false,
       description: 'Tick the checkbox to run E2E tests in Chrome.'
     ),
     booleanParam(
       name: 'FIREFOX_TESTS',
-      defaultValue: true,
+      defaultValue: false,
       description: 'Tick the checkbox to run E2E tests in Firefox.'
     ),
   ])
@@ -58,11 +58,8 @@ withNightlyPipeline(type, product, component) {
   loadVaultSecrets(secrets)
   handleEnvironmentSetting()
   enableFortifyScan()
-  afterSuccess('fortify-scan') {
-    steps.archiveArtifacts allowEmptyArchive: true,
-      artifacts: '**/Fortify Scan/**/*'
-  }
-  afterAlways('FortifyScan') {
+  afterAlways('fortify-scan') {
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
     runE2eTests()
     publishE2EReport()
   }


### PR DESCRIPTION
### Jira link

N/A

### Change description

This PR handles three issues:

- Fortify scan results are changed to always be saved on each run, not just when it is passing.
- Corrects the naming of fortify-scan in the call so things are called properly.
- Defaults the E2E tests to be off in AAT due to decentralised not being present yet.

### Testing done

N?A

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
