### PR TITLE
HDPI-1722: Validate address fields

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CCDCaseRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CCDCaseRepository.java
@@ -59,18 +59,18 @@ public class CCDCaseRepository extends DecentralisedCaseRepository<PCSCase> {
             .preActionProtocolCompleted(pcsCaseEntity.getPreActionProtocolCompleted() != null
                 ? VerticalYesNo.from(pcsCaseEntity.getPreActionProtocolCompleted())
                 : null)
-            .currentRent(pcsCaseEntity.getTenancyLicence() != null 
+            .currentRent(pcsCaseEntity.getTenancyLicence() != null
                 && pcsCaseEntity.getTenancyLicence().getRentAmount() != null
                 ? pcsCaseEntity.getTenancyLicence().getRentAmount().toPlainString() : null)
-            .rentFrequency(pcsCaseEntity.getTenancyLicence() != null 
+            .rentFrequency(pcsCaseEntity.getTenancyLicence() != null
                 ? pcsCaseEntity.getTenancyLicence().getRentPaymentFrequency() : null)
-            .otherRentFrequency(pcsCaseEntity.getTenancyLicence() != null 
+            .otherRentFrequency(pcsCaseEntity.getTenancyLicence() != null
                 ? pcsCaseEntity.getTenancyLicence().getOtherRentFrequency() : null)
-            .dailyRentChargeAmount(pcsCaseEntity.getTenancyLicence() != null 
+            .dailyRentChargeAmount(pcsCaseEntity.getTenancyLicence() != null
                 && pcsCaseEntity.getTenancyLicence().getDailyRentChargeAmount() != null
                 ? pcsCaseEntity.getTenancyLicence().getDailyRentChargeAmount().toPlainString() : null)
-            .noticeServed(pcsCaseEntity.getTenancyLicence() != null 
-                && pcsCaseEntity.getTenancyLicence().getNoticeServed() != null 
+            .noticeServed(pcsCaseEntity.getTenancyLicence() != null
+                && pcsCaseEntity.getTenancyLicence().getNoticeServed() != null
                 ? YesOrNo.from(pcsCaseEntity.getTenancyLicence().getNoticeServed()) : null)
             .defendants(pcsCaseService.mapToDefendantDetails(pcsCaseEntity.getDefendants()))
             .build();

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/CreatePossessionClaim.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/CreatePossessionClaim.java
@@ -68,6 +68,8 @@ public class CreatePossessionClaim implements CCDConfig<PCSCase, State, UserRole
     private final EnterPropertyAddress enterPropertyAddress;
     private final CrossBorderPostcodeSelection crossBorderPostcodeSelection;
     private final PropertyNotEligible propertyNotEligible;
+    private final ContactPreferences contactPreferences;
+    private final DefendantsDetails defendantsDetails;
 
 
     @Override
@@ -94,8 +96,8 @@ public class CreatePossessionClaim implements CCDConfig<PCSCase, State, UserRole
             .add(new ClaimTypeNotEligibleEngland())
             .add(new ClaimTypeNotEligibleWales())
             .add(new ClaimantInformation())
-            .add(new ContactPreferences())
-            .add(new DefendantsDetails())
+            .add(contactPreferences)
+            .add(defendantsDetails)
             .add(new GroundsForPossession())
             .add(new PreActionProtocol())
             .add(new MediationAndSettlement())

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/ContactPreferences.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/ContactPreferences.java
@@ -1,18 +1,31 @@
 package uk.gov.hmcts.reform.pcs.ccd.page.createpossessionclaim;
 
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.AddressUK;
 import uk.gov.hmcts.reform.pcs.ccd.common.CcdPageConfiguration;
 import uk.gov.hmcts.reform.pcs.ccd.common.PageBuilder;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.domain.State;
+import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
+import uk.gov.hmcts.reform.pcs.ccd.service.AddressValidator;
+
+import java.util.List;
 
 import static uk.gov.hmcts.reform.pcs.ccd.ShowConditions.NEVER_SHOW;
 
-
+@AllArgsConstructor
+@Component
 public class ContactPreferences implements CcdPageConfiguration {
+
+    private final AddressValidator addressValidator;
 
     @Override
     public void addTo(PageBuilder pageBuilder) {
         pageBuilder
-            .page("contactPreferences")
+            .page("contactPreferences", this::midEvent)
             .pageLabel("Contact preferences")
 
             // Email section
@@ -68,6 +81,28 @@ public class ContactPreferences implements CcdPageConfiguration {
             .mandatory(PCSCase::getClaimantProvidePhoneNumber)
             .mandatory(PCSCase::getClaimantContactPhoneNumber, "claimantProvidePhoneNumber=\"YES\"")
             .label("contactPreferences-phoneNumber-separator", "---");
+    }
+
+    private AboutToStartOrSubmitResponse<PCSCase, State> midEvent(CaseDetails<PCSCase, State> details,
+                                                                  CaseDetails<PCSCase, State> detailsBefore) {
+
+        PCSCase caseData = details.getData();
+
+        VerticalYesNo isCorrectClaimantContactAddress = caseData.getIsCorrectClaimantContactAddress();
+        if (isCorrectClaimantContactAddress == VerticalYesNo.NO) {
+            AddressUK contactAddress = caseData.getOverriddenClaimantContactAddress();
+            List<String> validationErrors = addressValidator.validateAddressFields(contactAddress);
+            if (!validationErrors.isEmpty()) {
+                return AboutToStartOrSubmitResponse.<PCSCase, State>builder()
+                    .errors(validationErrors)
+                    .build();
+            }
+        }
+
+        return AboutToStartOrSubmitResponse.<PCSCase, State>builder()
+            .data(caseData)
+            .build();
+
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/DefendantsDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/DefendantsDetails.java
@@ -1,16 +1,56 @@
 package uk.gov.hmcts.reform.pcs.ccd.page.createpossessionclaim;
 
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.type.AddressUK;
 import uk.gov.hmcts.reform.pcs.ccd.common.CcdPageConfiguration;
 import uk.gov.hmcts.reform.pcs.ccd.common.PageBuilder;
+import uk.gov.hmcts.reform.pcs.ccd.domain.DefendantDetails;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.domain.State;
+import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
+import uk.gov.hmcts.reform.pcs.ccd.service.AddressValidator;
 
+import java.util.List;
+
+@AllArgsConstructor
+@Component
 public class DefendantsDetails implements CcdPageConfiguration {
+
+    private final AddressValidator addressValidator;
 
     @Override
     public void addTo(PageBuilder pageBuilder) {
         pageBuilder
-            .page("defendantsDetails")
+            .page("defendantsDetails", this::midEvent)
             .pageLabel("Defendant 1 details")
             .mandatory(PCSCase::getDefendant1);
     }
+
+    private AboutToStartOrSubmitResponse<PCSCase, State> midEvent(CaseDetails<PCSCase, State> details,
+                                                                  CaseDetails<PCSCase, State> detailsBefore) {
+
+        PCSCase caseData = details.getData();
+        DefendantDetails defendantDetails = caseData.getDefendant1();
+
+        if (defendantDetails.getAddressSameAsPossession() == VerticalYesNo.NO
+            && defendantDetails.getAddressKnown() == VerticalYesNo.YES) {
+
+            AddressUK correspondenceAddress = defendantDetails.getCorrespondenceAddress();
+            List<String> validationErrors = addressValidator.validateAddressFields(correspondenceAddress);
+            if (!validationErrors.isEmpty()) {
+                return AboutToStartOrSubmitResponse.<PCSCase, State>builder()
+                    .errors(validationErrors)
+                    .build();
+            }
+        }
+
+        return AboutToStartOrSubmitResponse.<PCSCase, State>builder()
+            .data(caseData)
+            .build();
+
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/AddressValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/AddressValidator.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.pcs.ccd.service;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.ccd.sdk.type.AddressUK;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class AddressValidator {
+
+    public List<String> validateAddressFields(AddressUK address) {
+        List<String> validationErrors = new ArrayList<>();
+        if (StringUtils.isBlank(address.getPostTown())) {
+            validationErrors.add("Town or City is required");
+        }
+        if (StringUtils.isBlank(address.getPostCode())) {
+            validationErrors.add("Postcode/Zipcode is required");
+        }
+        return validationErrors;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/ContactPreferencesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/ContactPreferencesTest.java
@@ -1,0 +1,62 @@
+package uk.gov.hmcts.reform.pcs.ccd.page.createpossessionclaim;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.api.callback.MidEvent;
+import uk.gov.hmcts.ccd.sdk.type.AddressUK;
+import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.domain.State;
+import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
+import uk.gov.hmcts.reform.pcs.ccd.page.BasePageTest;
+import uk.gov.hmcts.reform.pcs.ccd.service.AddressValidator;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ContactPreferencesTest extends BasePageTest {
+
+    @Mock
+    private AddressValidator addressValidator;
+
+    private Event<PCSCase, UserRole, State> event;
+
+    @BeforeEach
+    void setUp() {
+        event = buildPageInTestEvent(new ContactPreferences(addressValidator));
+    }
+
+    @Test
+    void shouldReturnValidationErrorsWhenAddressInvalid() {
+        // Given
+        AddressUK contactAddress = mock(AddressUK.class);
+        PCSCase caseData = PCSCase.builder()
+            .isCorrectClaimantContactAddress(VerticalYesNo.NO)
+            .overriddenClaimantContactAddress(contactAddress)
+            .build();
+
+        List<String> expectedValidationErrors = List.of("error 1", "error 2");
+        when(addressValidator.validateAddressFields(contactAddress)).thenReturn(expectedValidationErrors);
+
+        CaseDetails<PCSCase, State> caseDetails = CaseDetails.<PCSCase, State>builder()
+            .data(caseData)
+            .build();
+
+        // When
+        MidEvent<PCSCase, State> midEvent = getMidEventForPage(event, "contactPreferences");
+        AboutToStartOrSubmitResponse<PCSCase, State> response = midEvent.handle(caseDetails, null);
+
+        // Then
+        assertThat(response.getErrors()).isEqualTo(expectedValidationErrors);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/DefendantsDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/page/createpossessionclaim/DefendantsDetailsTest.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.reform.pcs.ccd.page.createpossessionclaim;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.api.callback.MidEvent;
+import uk.gov.hmcts.ccd.sdk.type.AddressUK;
+import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
+import uk.gov.hmcts.reform.pcs.ccd.domain.DefendantDetails;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.domain.State;
+import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
+import uk.gov.hmcts.reform.pcs.ccd.page.BasePageTest;
+import uk.gov.hmcts.reform.pcs.ccd.service.AddressValidator;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DefendantsDetailsTest extends BasePageTest {
+
+    @Mock
+    private AddressValidator addressValidator;
+
+    private Event<PCSCase, UserRole, State> event;
+
+    @BeforeEach
+    void setUp() {
+        event = buildPageInTestEvent(new DefendantsDetails(addressValidator));
+    }
+
+    @Test
+    void shouldReturnValidationErrorsWhenAddressInvalid() {
+        // Given
+        AddressUK correspondenceAddress = mock(AddressUK.class);
+
+        DefendantDetails defendantsDetails = DefendantDetails.builder()
+            .addressSameAsPossession(VerticalYesNo.NO)
+            .addressKnown(VerticalYesNo.YES)
+            .correspondenceAddress(correspondenceAddress)
+            .build();
+
+        PCSCase caseData = PCSCase.builder()
+            .defendant1(defendantsDetails)
+            .build();
+
+        List<String> expectedValidationErrors = List.of("error 1", "error 2");
+        when(addressValidator.validateAddressFields(correspondenceAddress)).thenReturn(expectedValidationErrors);
+
+        CaseDetails<PCSCase, State> caseDetails = CaseDetails.<PCSCase, State>builder()
+            .data(caseData)
+            .build();
+
+        // When
+        MidEvent<PCSCase, State> midEvent = getMidEventForPage(event, "defendantsDetails");
+        AboutToStartOrSubmitResponse<PCSCase, State> response = midEvent.handle(caseDetails, null);
+
+        // Then
+        assertThat(response.getErrors()).isEqualTo(expectedValidationErrors);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/AddressValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/AddressValidatorTest.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.pcs.ccd.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.hmcts.ccd.sdk.type.AddressUK;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class AddressValidatorTest {
+
+    private static final String TEST_TOWN = "some town";
+    private static final String TEST_POSTCODE = "some postcode";
+    private AddressValidator underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new AddressValidator();
+    }
+
+    @ParameterizedTest
+    @MethodSource("addressScenarios")
+    void shouldReturnNoErrorsWhenTownAndPostcodeNotBlank(String postTown,
+                                                         String postcode,
+                                                         List<String> expectedValidationErrors) {
+        // Given
+        AddressUK address = AddressUK.builder()
+            .postTown(postTown)
+            .postCode(postcode)
+            .build();
+
+        // When
+        List<String> actualValidationErrors = underTest.validateAddressFields(address);
+
+        // Then
+        assertThat(actualValidationErrors).isEqualTo(expectedValidationErrors);
+    }
+
+    private static Stream<Arguments> addressScenarios() {
+        return Stream.of(
+            // Town, postcode, expected validation errors
+            arguments(TEST_TOWN, TEST_POSTCODE, List.of()),
+            arguments(null, null, List.of("Town or City is required", "Postcode/Zipcode is required")),
+            arguments("", "", List.of("Town or City is required", "Postcode/Zipcode is required")),
+            arguments(" ", " ", List.of("Town or City is required", "Postcode/Zipcode is required")),
+            arguments(null, TEST_POSTCODE, List.of("Town or City is required")),
+            arguments("", TEST_POSTCODE, List.of("Town or City is required")),
+            arguments(" ", TEST_POSTCODE, List.of("Town or City is required")),
+            arguments(TEST_TOWN, null, List.of("Postcode/Zipcode is required")),
+            arguments(TEST_TOWN, "", List.of("Postcode/Zipcode is required")),
+            arguments(TEST_TOWN, " ", List.of("Postcode/Zipcode is required"))
+        );
+    }
+
+}


### PR DESCRIPTION
### Jira link

See [HDPI-1722](https://tools.hmcts.net/jira/browse/HDPI-1722)

### Change description

Validate that the town and postcode are set in the address fields for the claim property, the claimant contact address and the defendant address. This complements the validation on "Building and Street" which is built into ExUI.

The validation is performed in the midEvent callback, so only simple validation errors can be shown.

<img width="1031" height="773" alt="address-validation-error" src="https://github.com/user-attachments/assets/34f92b56-40d6-4966-bc91-36c4d6a3ef7f" />


### Testing done

Manual testing locally

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
