### PR TITLE
HDPI-1893: Tighten up `ccd` package code coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,7 +256,6 @@ sonarqube {
       "**/*Constants.java," +
       "**/model/*.java," +
       "**/uk/gov/hmcts/reform/pcs/Application.java," +
-      "**/uk/gov/hmcts/reform/pcs/ccd/**/*.java," +
       "**/uk/gov/hmcts/reform/pcs/config/*.java," +
       "**/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/**/*.java," +
       "**/uk/gov/hmcts/reform/pcs/ccd/config/HighLevelDataSetupApp.java," +


### PR DESCRIPTION
### Jira link

See [HDPI-1893](https://tools.hmcts.net/jira/browse/HDPI-1893)

### Change description

Currently the whole `ccd` sub-package in pcs-api is excluded from code coverage, but ideally we only want to exclude the configuration related classes / packages. This PR removes the blanket exclusion for that `ccd` sub-package.

### Testing done

I ran the same changes in a draft PR with all the classes in the `ccd` sub-package changed very slightly, so that the coverage would run on them. (It only runs on changed files in PR builds).

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
