### PR TITLE
Fix - Updating Sonar excluded Open API work flows file path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,7 +252,7 @@ sonarqube {
   properties {
     property "sonar.projectName", "Reform :: pcs-api"
     property "sonar.projectKey", "uk.gov.hmcts.reform:pcs-api"
-    property "sonar.exclusions", ".github/workflows/publish-openapi.yml"
+    property "sonar.exclusions", ".github/workflows/publish-openapi.yaml"
     property "sonar.coverage.exclusions", "**/config/**/*Configuration.java," +
       "**/*Constants.java," +
       "**/model/*.java," +


### PR DESCRIPTION
### Change description
Fixing master build failure by updating the excluded sonar file path.

