### PR TITLE
Change admin approval to QA for e2e tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@ build.gradle
 charts/**/Chart.yaml
 .github/workflows/*.yaml
 
-src/e2eTest
+src/e2eTest @hmcts/possession-claim-service-qa-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,5 @@ Dockerfile
 build.gradle
 charts/**/Chart.yaml
 .github/workflows/*.yaml
+
+src/e2eTest


### PR DESCRIPTION
Discussed on slack that e2e tests are owned by QA and to remove bottleneck from dev leads.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
