### PR TITLE
Hdpi 1960

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/common/MultiPageLabel.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/common/MultiPageLabel.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.pcs.ccd.common;
+
+public class MultiPageLabel {
+    public static final String SAVE_AND_RETURN_HTML = """
+        <details class="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                    I want to save this application and return to it later
+                </span>
+            </summary>
+            <div class="govuk-details__text">
+                If you want to save your application and return to it later:
+                <ol class="govuk-list govuk-list--number govuk-!-margin-left-2">
+                    <li>Choose 'Continue'.</li>
+                    <li>Continue to the next page.</li>
+                    <li>Choose 'Cancel'</li>
+                </ol>
+                <p class="govuk-!-margin-top-2">
+                    This will save your progress and take you to your case list.
+                </p>
+            </div>
+        </details>
+        """;
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/CheckingNotice.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/CheckingNotice.java
@@ -4,6 +4,8 @@ import uk.gov.hmcts.reform.pcs.ccd.common.CcdPageConfiguration;
 import uk.gov.hmcts.reform.pcs.ccd.common.PageBuilder;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 public class CheckingNotice implements CcdPageConfiguration {
 
     @Override
@@ -34,6 +36,7 @@ public class CheckingNotice implements CcdPageConfiguration {
                         </div>
                         </section>
                         """)
-                .mandatory(PCSCase::getNoticeServed);
+                .mandatory(PCSCase::getNoticeServed)
+            .label("checkingNotice-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/ClaimantInformation.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/ClaimantInformation.java
@@ -5,6 +5,8 @@ import uk.gov.hmcts.reform.pcs.ccd.common.CcdPageConfiguration;
 import uk.gov.hmcts.reform.pcs.ccd.common.PageBuilder;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 @Slf4j
 public class ClaimantInformation implements CcdPageConfiguration {
 
@@ -26,7 +28,8 @@ public class ClaimantInformation implements CcdPageConfiguration {
                     null,
                     "What is the correct claimant name?",
                     UPDATED_CLAIMANT_NAME_HINT,
-                    false);
+                    false)
+            .label("claimantInformation-saveAndResume", SAVE_AND_RETURN_HTML);
 
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/ContactPreferences.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/ContactPreferences.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.pcs.ccd.service.AddressValidator;
 import java.util.List;
 
 import static uk.gov.hmcts.reform.pcs.ccd.ShowConditions.NEVER_SHOW;
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
 
 @AllArgsConstructor
 @Component
@@ -88,7 +89,8 @@ public class ContactPreferences implements CcdPageConfiguration {
                 """)
             .mandatory(PCSCase::getClaimantProvidePhoneNumber)
             .mandatory(PCSCase::getClaimantContactPhoneNumber, "claimantProvidePhoneNumber=\"YES\"")
-            .label("contactPreferences-phoneNumber-separator", "---");
+            .label("contactPreferences-phoneNumber-separator", "---")
+            .label("contactPreferences-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 
     private AboutToStartOrSubmitResponse<PCSCase, State> midEvent(CaseDetails<PCSCase, State> details,

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/DailyRentAmount.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/DailyRentAmount.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.pcs.ccd.page.resumepossessionclaim;
 
 import static uk.gov.hmcts.reform.pcs.ccd.ShowConditions.NEVER_SHOW;
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 import uk.gov.hmcts.reform.pcs.ccd.common.CcdPageConfiguration;
 import uk.gov.hmcts.reform.pcs.ccd.common.PageBuilder;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
@@ -28,6 +30,7 @@ public class DailyRentAmount implements CcdPageConfiguration {
                                 </section>
                                 """)
                 .mandatory(PCSCase::getRentPerDayCorrect)
-                .mandatory(PCSCase::getAmendedDailyRentChargeAmount, "rentPerDayCorrect=\"NO\"");
+                .mandatory(PCSCase::getAmendedDailyRentChargeAmount, "rentPerDayCorrect=\"NO\"")
+                .label("dailyRentAmount-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/DefendantsDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/DefendantsDetails.java
@@ -15,6 +15,8 @@ import uk.gov.hmcts.reform.pcs.ccd.service.AddressValidator;
 
 import java.util.List;
 
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 @AllArgsConstructor
 @Component
 public class DefendantsDetails implements CcdPageConfiguration {
@@ -48,7 +50,9 @@ public class DefendantsDetails implements CcdPageConfiguration {
 
                 .readonly(DefendantDetails::getEmailSectionLabel)
                 .mandatory(DefendantDetails::getEmailKnown)
-                .mandatory(DefendantDetails::getEmail);
+                .mandatory(DefendantDetails::getEmail)
+            .done()
+            .label("defendantsDetails-saveAndResume", SAVE_AND_RETURN_HTML);
 
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/GroundForPossessionAdditionalGrounds.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/GroundForPossessionAdditionalGrounds.java
@@ -4,6 +4,8 @@ import uk.gov.hmcts.reform.pcs.ccd.common.CcdPageConfiguration;
 import uk.gov.hmcts.reform.pcs.ccd.common.PageBuilder;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 /**
  * Page for selecting additional grounds for possession.
  */
@@ -27,6 +29,7 @@ public class GroundForPossessionAdditionalGrounds implements CcdPageConfiguratio
             """)
             .mandatory(PCSCase::getMandatoryGrounds)
             .mandatory(PCSCase::getDiscretionaryGrounds)
+            .label("groundForPossessionAdditionalGrounds-saveAndResume", SAVE_AND_RETURN_HTML)
             .done();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/GroundForPossessionRentArrears.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/GroundForPossessionRentArrears.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static uk.gov.hmcts.reform.pcs.ccd.ShowConditions.NEVER_SHOW;
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
 
 /**
  * Page for selecting rent arrears grounds for possession.
@@ -54,7 +55,8 @@ public class GroundForPossessionRentArrears implements CcdPageConfiguration {
                     rent.</p>
                 """)
                 .mandatory(PCSCase::getRentArrearsGrounds)
-                .mandatory(PCSCase::getHasOtherAdditionalGrounds);
+                .mandatory(PCSCase::getHasOtherAdditionalGrounds)
+                .label("groundForPossessionRentArrears-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 
     public AboutToStartOrSubmitResponse<PCSCase, State> midEvent(CaseDetails<PCSCase, State> details,

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/GroundsForPossession.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/GroundsForPossession.java
@@ -14,6 +14,8 @@ import uk.gov.hmcts.reform.pcs.ccd.domain.State;
 
 import java.util.Set;
 
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 
 /**
  * Page configuration for the Grounds for Possession section.
@@ -31,7 +33,8 @@ public class GroundsForPossession implements CcdPageConfiguration {
             .showCondition("typeOfTenancyLicence!=\"SECURE_TENANCY\" "
                                + "AND typeOfTenancyLicence!=\"FLEXIBLE_TENANCY\"")
                 .label("groundsForPossession-lineSeparator", "---")
-                .mandatory(PCSCase::getGroundsForPossession);
+                .mandatory(PCSCase::getGroundsForPossession)
+                .label("groundsForPossession-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 
     private AboutToStartOrSubmitResponse<PCSCase, State> midEvent(CaseDetails<PCSCase, State> details,

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/MediationAndSettlement.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/MediationAndSettlement.java
@@ -4,6 +4,8 @@ import uk.gov.hmcts.reform.pcs.ccd.common.CcdPageConfiguration;
 import uk.gov.hmcts.reform.pcs.ccd.common.PageBuilder;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 /**
  * Page configuration for the Mediation and Settlement section.
  * Allows claimants to indicate whether they're willing to try mediation or settlement
@@ -39,7 +41,8 @@ public class MediationAndSettlement implements CcdPageConfiguration {
                         </section>
                         """)
                 .mandatory(PCSCase::getSettlementAttempted)
-                .mandatory(PCSCase::getSettlementAttemptedDetails, "settlementAttempted=\"YES\"");
+                .mandatory(PCSCase::getSettlementAttemptedDetails, "settlementAttempted=\"YES\"")
+                .label("mediationAndSettlement-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/NoRentArrearsGroundsForPossessionOptions.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/NoRentArrearsGroundsForPossessionOptions.java
@@ -12,6 +12,8 @@ import uk.gov.hmcts.reform.pcs.ccd.domain.State;
 
 import java.util.List;
 
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 
 @AllArgsConstructor
 @Component
@@ -33,7 +35,8 @@ public class NoRentArrearsGroundsForPossessionOptions implements CcdPageConfigur
                     if you need to.</p>"""
             )
             .optional(PCSCase::getNoRentArrearsMandatoryGroundsOptions)
-            .optional(PCSCase::getNoRentArrearsDiscretionaryGroundsOptions);
+            .optional(PCSCase::getNoRentArrearsDiscretionaryGroundsOptions)
+            .label("noRentArrearsGroundsForPossessionOptions-saveAndResume", SAVE_AND_RETURN_HTML);
 
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/NoRentArrearsGroundsForPossessionReason.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/NoRentArrearsGroundsForPossessionReason.java
@@ -11,6 +11,8 @@ import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 import uk.gov.hmcts.reform.pcs.ccd.domain.State;
 import uk.gov.hmcts.reform.pcs.ccd.domain.model.NoRentArrearsReasonForGrounds;
 
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 @AllArgsConstructor
 @Component
 @Slf4j
@@ -297,7 +299,8 @@ public class NoRentArrearsGroundsForPossessionReason implements CcdPageConfigura
             .mandatory(
                 NoRentArrearsReasonForGrounds::getFalseStatementTextArea,
                 "noRentArrearsDiscretionaryGroundsOptionsCONTAINS\"FALSE_STATEMENT\""
-            );
+            )
+            .label("noRentArrearsOptions-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 
     private AboutToStartOrSubmitResponse<PCSCase, State> midEvent(CaseDetails<PCSCase, State> details,

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/NoticeDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/NoticeDetails.java
@@ -13,6 +13,8 @@ import uk.gov.hmcts.reform.pcs.ccd.service.NoticeDetailsService;
 
 import java.util.List;
 
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 /**
  * CCD page configuration for Notice Details.
  * Allows users to specify how they served notice to the defendant.
@@ -110,7 +112,8 @@ public class NoticeDetails implements CcdPageConfiguration {
                 Any documents you upload now will be included in the pack of documents a judge will
                 receive before the hearing (the bundle).</p>
                 """)
-              .optional(PCSCase::getNoticeDocuments);
+            .optional(PCSCase::getNoticeDocuments)
+            .label("noticeDetails-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 
     private AboutToStartOrSubmitResponse<PCSCase, State> midEvent(CaseDetails<PCSCase, State> details,

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/PreActionProtocol.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/PreActionProtocol.java
@@ -4,6 +4,8 @@ import uk.gov.hmcts.reform.pcs.ccd.common.CcdPageConfiguration;
 import uk.gov.hmcts.reform.pcs.ccd.common.PageBuilder;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 public class PreActionProtocol implements CcdPageConfiguration {
 
     @Override
@@ -41,6 +43,7 @@ public class PreActionProtocol implements CcdPageConfiguration {
 
                   """)
                 .mandatoryWithLabel(PCSCase::getPreActionProtocolCompleted,
-                        "Have you followed the pre-action protocol?");
+                        "Have you followed the pre-action protocol?")
+                .label("preActionProtocol-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/RentArrears.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/RentArrears.java
@@ -4,6 +4,8 @@ import uk.gov.hmcts.reform.pcs.ccd.common.CcdPageConfiguration;
 import uk.gov.hmcts.reform.pcs.ccd.common.PageBuilder;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 public class RentArrears implements CcdPageConfiguration {
 
     @Override
@@ -64,6 +66,7 @@ public class RentArrears implements CcdPageConfiguration {
 
                 // "Other" free text is mandatory when OTHER is selected
                 .mandatory(PCSCase::getThirdPartyPaymentSourceOther,
-                        "thirdPartyPayments=\"YES\" AND thirdPartyPaymentSources CONTAINS \"OTHER\"");
+                        "thirdPartyPayments=\"YES\" AND thirdPartyPaymentSources CONTAINS \"OTHER\"")
+                .label("rentArrears-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/RentDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/RentDetails.java
@@ -5,6 +5,8 @@ import java.math.BigDecimal;
 import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import static uk.gov.hmcts.reform.pcs.ccd.ShowConditions.NEVER_SHOW;
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 import uk.gov.hmcts.reform.pcs.ccd.common.CcdPageConfiguration;
 import uk.gov.hmcts.reform.pcs.ccd.common.PageBuilder;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
@@ -30,7 +32,8 @@ public class RentDetails implements CcdPageConfiguration {
                 .mandatory(PCSCase::getRentFrequency)
                 .mandatory(PCSCase::getOtherRentFrequency, "rentFrequency=\"OTHER\"")
                 .mandatory(PCSCase::getDailyRentChargeAmount, "rentFrequency=\"OTHER\"")
-                .readonly(PCSCase::getCalculatedDailyRentChargeAmount, NEVER_SHOW);
+                .readonly(PCSCase::getCalculatedDailyRentChargeAmount, NEVER_SHOW)
+                .label("rentDetails-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 
     private AboutToStartOrSubmitResponse<PCSCase, State> midEvent(CaseDetails<PCSCase, State> details,

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/SelectClaimType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/SelectClaimType.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.pcs.ccd.domain.State;
 import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry;
 
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
 import static uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo.YES;
 import static uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry.ENGLAND;
 import static uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry.WALES;
@@ -29,7 +30,8 @@ public class SelectClaimType implements CcdPageConfiguration {
                             target="_blank"
                             class="govuk-link">read the guidance on removing squatters (opens in a new tab)</a>.
                         """)
-            .mandatory(PCSCase::getClaimAgainstTrespassers);
+            .mandatory(PCSCase::getClaimAgainstTrespassers)
+            .label("selectClaimType-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 
     private AboutToStartOrSubmitResponse<PCSCase, State> midEvent(CaseDetails<PCSCase, State> details,

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/SelectClaimantType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/SelectClaimantType.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.pcs.ccd.domain.State;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry;
 
 import static uk.gov.hmcts.reform.pcs.ccd.ShowConditions.NEVER_SHOW;
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
 import static uk.gov.hmcts.reform.pcs.ccd.domain.ClaimantType.COMMUNITY_LANDLORD;
 import static uk.gov.hmcts.reform.pcs.ccd.domain.ClaimantType.PROVIDER_OF_SOCIAL_HOUSING;
 import static uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry.ENGLAND;
@@ -28,7 +29,8 @@ public class SelectClaimantType implements CcdPageConfiguration {
                         A claimant is the person or organisation who is making the possession claim.
                         """)
             .readonly(PCSCase::getLegislativeCountry, NEVER_SHOW, true)
-            .mandatory(PCSCase::getClaimantType);
+            .mandatory(PCSCase::getClaimantType)
+            .label("selectClaimantType-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 
     private AboutToStartOrSubmitResponse<PCSCase, State> midEvent(CaseDetails<PCSCase, State> details,

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/TenancyLicenceDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/TenancyLicenceDetails.java
@@ -16,6 +16,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
 
+import static uk.gov.hmcts.reform.pcs.ccd.common.MultiPageLabel.SAVE_AND_RETURN_HTML;
+
 @Component
 public class TenancyLicenceDetails implements CcdPageConfiguration {
 
@@ -52,7 +54,8 @@ public class TenancyLicenceDetails implements CcdPageConfiguration {
                 </p>
                """)
             .optional(PCSCase::getTenancyLicenceDocuments)
-            .label("lineSeparator", "---");
+            .label("lineSeparator", "---")
+            .label("tenancyLicenceDetails-saveAndResume", SAVE_AND_RETURN_HTML);
     }
 
     private AboutToStartOrSubmitResponse<PCSCase, State> midEvent(CaseDetails<PCSCase, State> details,


### PR DESCRIPTION
### Jira link

[HDPI-1960](https://tools.hmcts.net/jira/browse/HDPI-1960)

### Change description

This PR implements UCD-proposed hint text for the standard EXUI navigation elements (previous button, continue button, and cancel hyperlink) to clarify their purpose when business process flow prevents normal progression.
Changes include:

- Added hint text components for navigation elements
- Updated affected screens to display contextual guidance
- Maintained consistency with existing EXUI constraints

This addresses the spike requirements to visualise the design impact and assess implementation effects on previously built screens.

### Testing done

Automated testing

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
