### PR TITLE
HDPI-2220: Pinning ccd-data-store image to previous working version

### DIFF
--- a/charts/pcs-api/values.ccd.preview.template.yaml
+++ b/charts/pcs-api/values.ccd.preview.template.yaml
@@ -86,7 +86,7 @@ ccd:
               alias: DEFINITION_STORE_IDAM_KEY
   ccd-data-store-api:
     java:
-      image: 'hmctspublic.azurecr.io/ccd/data-store-api:pr-2496'
+      image: 'hmctspublic.azurecr.io/ccd/data-store-api:pr-2496-3d224a7-20250925055806'
       imagePullPolicy: Always
       devmemoryRequests: '1524Mi'
       devmemoryLimits: '2048Mi'


### PR DESCRIPTION
### Jira link

See [HDPI-2220](https://tools.hmcts.net/jira/browse/HDPI-2220)

### Change description

Pin the docker image tag used for decentralised CCD data store, until the pcs-api code is updated for the breaking changes.

### Testing done

Full build run.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
