### PR TITLE
TestAutomation HDPI-1917 Demotion of tenancy

### DIFF
--- a/src/e2eTest/data/page-data/alternativesToPossession.page.data.ts
+++ b/src/e2eTest/data/page-data/alternativesToPossession.page.data.ts
@@ -1,0 +1,8 @@
+export const alternativesToPossession = {
+  title: 'Create a case - HM Courts & Tribunals Service - GOV.UK',
+  mainHeader: 'Alternatives to possession',
+  suspensionOrDemotionQuestion: 'In the alternative to possession,would you like to claim suspension of right to but or demotion of tenancy?(Optional)',
+  suspensionOfRightToBuy: 'Suspension of right to buy',
+  demotionOfTenancy: 'Demotion of tenancy',
+  continue: 'Continue'
+};

--- a/src/e2eTest/data/page-data/housingAct.page.data.ts
+++ b/src/e2eTest/data/page-data/housingAct.page.data.ts
@@ -1,0 +1,9 @@
+export const housingAct = {
+  title: 'Create a case - HM Courts & Tribunals Service - GOV.UK',
+  mainHeader: 'Housing Act',
+  suspensionOfRightToBuyHousingActQuestion: 'Which section of the Housing Act is the suspension of right to buy claim made under?',
+  section82AHousingAct1985: 'Section 82A(2) of the Housing Act 1985',
+  section6AHousingAct1988: 'Section 6A(2) of the Housing Act 1988',
+  section121AHousingAct1985: 'Section 121A of the Housing Act 1985',
+  continue: 'Continue'
+};

--- a/src/e2eTest/data/page-data/housingActDemotion.page.data.ts
+++ b/src/e2eTest/data/page-data/housingActDemotion.page.data.ts
@@ -1,9 +1,8 @@
-export const housingAct = {
+export const housingActDemotion = {
   title: 'Create a case - HM Courts & Tribunals Service - GOV.UK',
   mainHeader: 'Housing Act',
-  suspensionOfRightToBuyHousingActQuestion: 'Which section of the Housing Act is the suspension of right to buy claim made under?',
+  suspensionOfRightToBuyHousingActQuestion: 'Which section of the Housing Act is the claim for demotion of tenancy made under?',
   section82AHousingAct1985: 'Section 82A(2) of the Housing Act 1985',
   section6AHousingAct1988: 'Section 6A(2) of the Housing Act 1988',
-  section121AHousingAct1985: 'Section 121A of the Housing Act 1985',
   continue: 'Continue'
 };

--- a/src/e2eTest/data/page-data/reasonsForRequestingADemotionOrder.page.data.ts
+++ b/src/e2eTest/data/page-data/reasonsForRequestingADemotionOrder.page.data.ts
@@ -1,0 +1,7 @@
+export const reasonsForRequestingADemotionOrder = {
+  title: 'Create a case - HM Courts & Tribunals Service - GOV.UK',
+  mainHeader: 'Reasons for requesting a suspension order',
+  reason: 'Why are you requesting a suspension order?',
+  sampleTestReason: 'This is the sample text for - Why are you requesting a demotion order?',
+  continue: 'Continue'
+};

--- a/src/e2eTest/data/page-data/statementOfExpressTerms.page.data.ts
+++ b/src/e2eTest/data/page-data/statementOfExpressTerms.page.data.ts
@@ -1,0 +1,10 @@
+export const statementOfExpressTerms = {
+  title: 'Create a case - HM Courts & Tribunals Service - GOV.UK',
+  mainHeader: 'Statement of express terms',
+  statementOfExpressTermsQuestion: 'Have you served the defendants with a statement of express terms which will apply to the demoted tenancy?',
+  yes: 'Yes',
+  no: 'No',
+  giveDetailsOfTermsLabel: 'Give details of the terms',
+  sampleTestReason: 'This is the sample text for - details of the terms',
+  continue: 'Continue'
+};

--- a/src/e2eTest/tests/createCase.spec.ts
+++ b/src/e2eTest/tests/createCase.spec.ts
@@ -29,6 +29,10 @@ import {user} from '@data/user-data/permanent.user.data';
 import {claimingCosts} from '@data/page-data/claimingCosts.page.data';
 import {additionalReasonsForPossession} from '@data/page-data/additionalReasonsForPossession.page.data';
 import {underlesseeOrMortgageeEntitledToClaim} from '@data/page-data/underlesseeOrMortgageeEntitledToClaim.page.data';
+import {alternativesToPossession} from '@data/page-data/alternativesToPossession.page.data';
+import {housingAct} from "@data/page-data/housingAct.page.data";
+import {reasonsForRequestingADemotionOrder} from "@data/page-data/reasonsForRequestingADemotionOrder.page.data";
+import {statementOfExpressTerms} from "@data/page-data/statementOfExpressTerms.page.data";
 
 test.beforeEach(async ({page}, testInfo) => {
   initializeExecutor(page);
@@ -215,7 +219,7 @@ test.describe.skip('[Successful Create Case Flow]  @Master @nightly', async () =
     )
   });
 
-  test('England - Other tenancy with grounds for possession', async () => {
+  test('England - Other tenancy with grounds for possession - Demotion order', async () => {
     await performAction('selectAddress', {
       postcode: addressDetails.englandCourtAssignedPostcode,
       addressIndex: addressDetails.addressIndex
@@ -277,6 +281,13 @@ test.describe.skip('[Successful Create Case Flow]  @Master @nightly', async () =
     await performAction('selectClaimForMoney', moneyJudgment.yes);
     await performValidation('mainHeader', claimantCircumstances.mainHeader);
     await performAction('clickButton', claimantCircumstances.continue);
+    await performValidation('mainHeader', alternativesToPossession.mainHeader);
+    await performAction('selectAlternativesToPossession', [alternativesToPossession.demotionOfTenancy]);
+    await performValidation('mainHeader', housingAct.mainHeader);
+    await performAction('selectHousingAct', housingAct.section82AHousingAct1985);
+    await performAction('selectStatementOfExpressTerms', statementOfExpressTerms.yes);
+    await performValidation('mainHeader', reasonsForRequestingADemotionOrder.mainHeader);
+    await performAction('enterReasonForDemotionOrder', reasonsForRequestingADemotionOrder.reason);
     await performValidation('mainHeader', claimingCosts.mainHeader);
     await performAction('selectClaimingCosts', claimingCosts.yes);
     await performValidation('mainHeader', additionalReasonsForPossession.mainHeader);

--- a/src/e2eTest/tests/createCase.spec.ts
+++ b/src/e2eTest/tests/createCase.spec.ts
@@ -30,9 +30,9 @@ import {claimingCosts} from '@data/page-data/claimingCosts.page.data';
 import {additionalReasonsForPossession} from '@data/page-data/additionalReasonsForPossession.page.data';
 import {underlesseeOrMortgageeEntitledToClaim} from '@data/page-data/underlesseeOrMortgageeEntitledToClaim.page.data';
 import {alternativesToPossession} from '@data/page-data/alternativesToPossession.page.data';
-import {housingAct} from "@data/page-data/housingAct.page.data";
-import {reasonsForRequestingADemotionOrder} from "@data/page-data/reasonsForRequestingADemotionOrder.page.data";
-import {statementOfExpressTerms} from "@data/page-data/statementOfExpressTerms.page.data";
+import {housingActDemotion} from '@data/page-data/housingActDemotion.page.data';
+import {reasonsForRequestingADemotionOrder} from '@data/page-data/reasonsForRequestingADemotionOrder.page.data';
+import {statementOfExpressTerms} from '@data/page-data/statementOfExpressTerms.page.data';
 
 test.beforeEach(async ({page}, testInfo) => {
   initializeExecutor(page);
@@ -283,8 +283,8 @@ test.describe.skip('[Successful Create Case Flow]  @Master @nightly', async () =
     await performAction('clickButton', claimantCircumstances.continue);
     await performValidation('mainHeader', alternativesToPossession.mainHeader);
     await performAction('selectAlternativesToPossession', [alternativesToPossession.demotionOfTenancy]);
-    await performValidation('mainHeader', housingAct.mainHeader);
-    await performAction('selectHousingAct', housingAct.section82AHousingAct1985);
+    await performValidation('mainHeader', housingActDemotion.mainHeader);
+    await performAction('selectHousingAct', housingActDemotion.section82AHousingAct1985);
     await performAction('selectStatementOfExpressTerms', statementOfExpressTerms.yes);
     await performValidation('mainHeader', reasonsForRequestingADemotionOrder.mainHeader);
     await performAction('enterReasonForDemotionOrder', reasonsForRequestingADemotionOrder.reason);

--- a/src/e2eTest/utils/actions/custom-actions/createCase.action.ts
+++ b/src/e2eTest/utils/actions/custom-actions/createCase.action.ts
@@ -21,6 +21,9 @@ import {reasonsForPossession} from '@data/page-data/reasonsForPossession.page.da
 import {detailsOfRentArrears} from '@data/page-data/detailsOfRentArrears.page.data';
 import {additionalReasonsForPossession} from '@data/page-data/additionalReasonsForPossession.page.data';
 import {claimingCosts} from '@data/page-data/claimingCosts.page.data';
+import {alternativesToPossession} from "@data/page-data/alternativesToPossession.page.data";
+import {reasonsForRequestingADemotionOrder} from "@data/page-data/reasonsForRequestingADemotionOrder.page.data";
+import {statementOfExpressTerms} from "@data/page-data/statementOfExpressTerms.page.data";
 
 export let caseInfo: { id: string; fid: string; state: string };
 let caseNumber: string;
@@ -57,6 +60,10 @@ export class CreateCaseAction implements IAction {
       ['selectDailyRentAmount', () => this.selectDailyRentAmount(fieldName)],
       ['provideDetailsOfRentArrears', () => this.provideDetailsOfRentArrears(fieldName)],
       ['selectClaimForMoney', () => this.selectClaimForMoney(fieldName)],
+      ['selectAlternativesToPossession', () => this.selectAlternativesToPossession(fieldName)],
+      ['selectHousingAct', () => this.selectHousingAct(fieldName)],
+      ['selectStatementOfExpressTerms', () => this.selectStatementOfExpressTerms(fieldName)],
+      ['enterReasonForDemotionOrder', () => this.enterReasonForDemotionOrder(fieldName)],
       ['selectAdditionalReasonsForPossession', ()=> this.selectAdditionalReasonsForPossession(fieldName)],
       ['selectClaimingCosts', () => this.selectClaimingCosts(fieldName)]
     ]);
@@ -410,6 +417,31 @@ export class CreateCaseAction implements IAction {
   private async selectClaimingCosts(option: actionData) {
     await performAction('clickRadioButton', option);
     await performAction('clickButton', claimingCosts.continue);
+  }
+
+  private async selectAlternativesToPossession(alternatives: actionData) {
+    if(alternatives){
+      await performAction('check', alternatives);
+    }
+    await performAction('clickButton', alternativesToPossession.continue);
+  }
+
+  private async selectHousingAct(option: actionData) {
+    await performAction('clickRadioButton', option);
+    await performAction('clickButton', alternativesToPossession.continue);
+  }
+
+  private async selectStatementOfExpressTerms(option: actionData) {
+    await performAction('clickRadioButton', option);
+    if(option == 'Yes'){
+      await performAction('inputText', statementOfExpressTerms.giveDetailsOfTermsLabel, statementOfExpressTerms.sampleTestReason);
+    }
+    await performAction('clickButton', alternativesToPossession.continue);
+  }
+
+  private async enterReasonForDemotionOrder(reason: actionData) {
+    await performAction('inputText', reason, reasonsForRequestingADemotionOrder.reason);
+    await performAction('clickButton', reasonsForRequestingADemotionOrder.continue);
   }
 
   private async selectJurisdictionCaseTypeEvent() {

--- a/src/e2eTest/utils/registry/action.registry.ts
+++ b/src/e2eTest/utils/registry/action.registry.ts
@@ -54,6 +54,10 @@ export class ActionRegistry {
     ['selectClaimForMoney', new CreateCaseAction()],
     ['selectAdditionalReasonsForPossession', new CreateCaseAction()],
     ['searchCaseById', new searchCaseActions()],
+    ['selectAlternativesToPossession', new CreateCaseAction()],
+    ['selectHousingAct', new CreateCaseAction()],
+    ['enterReasonForDemotionOrder', new CreateCaseAction()],
+    ['selectStatementOfExpressTerms', new CreateCaseAction()],
     ['selectClaimingCosts', new CreateCaseAction()]
   ]);
 


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/HDPI-1917

### Change description
Updated e2eTests to handle Alternatives to Possession Screen - Demotion of tenancy

Scenarios included -
When Demotion of tenancy is selected, flow will lead to Housing Act (Demotion) Screen and then to Statement of express terms and selecting 'yes' or 'no' leads to Reason for requesting a demotion order screen then to Claiming Costs Screen.

### Testing done
<img width="1728" height="921" alt="Screenshot 2025-10-03 at 15 46 25" src="https://github.com/user-attachments/assets/3e92ce83-ea2e-417d-895a-25ccac9365ec" />

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
