### PR TITLE
Hdpi 3859

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/DefendantResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/DefendantResponse.java
@@ -12,4 +12,13 @@ import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 @AllArgsConstructor
 public class DefendantResponse {
     private YesOrNo contactByPhone;
+    private YesOrNo contactByEmail;
+    private YesOrNo contactByText;
+    private YesOrNo contactByPost;
+
+    private String email;
+
+    private String address;
+
+    private String phoneNumber;
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/entity/party/ContactPreferencesEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/entity/party/ContactPreferencesEntity.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.reform.pcs.ccd.entity.party;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "contact_preferences")
+public class ContactPreferencesEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "party_id", nullable = false)
+    private PartyEntity party;
+
+    private Boolean contactByEmail;
+    private Boolean contactByText;
+    private Boolean contactByPost;
+    private Boolean contactByPhone;
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/SubmitDefendantResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/SubmitDefendantResponse.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.pcs.ccd.event;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.DecentralisedConfigBuilder;
@@ -14,8 +15,17 @@ import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
 import uk.gov.hmcts.reform.pcs.ccd.domain.DefendantResponse;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 import uk.gov.hmcts.reform.pcs.ccd.domain.State;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.ContactPreferencesEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
+import uk.gov.hmcts.reform.pcs.ccd.repository.ContactPreferencesRepository;
+import uk.gov.hmcts.reform.pcs.ccd.repository.PartyRepository;
 import uk.gov.hmcts.reform.pcs.ccd.service.DraftCaseDataService;
 import uk.gov.hmcts.reform.pcs.ccd.service.PcsCaseService;
+import uk.gov.hmcts.reform.pcs.ccd.util.YesOrNoConverter;
+import uk.gov.hmcts.reform.pcs.security.SecurityContextService;
+
+import java.util.Optional;
+import java.util.UUID;
 
 import static uk.gov.hmcts.reform.pcs.ccd.event.EventId.submitDefendantResponse;
 
@@ -25,6 +35,10 @@ import static uk.gov.hmcts.reform.pcs.ccd.event.EventId.submitDefendantResponse;
 public class SubmitDefendantResponse implements CCDConfig<PCSCase, State, UserRole> {
     private final DraftCaseDataService draftCaseDataService;
     private final PcsCaseService pcsCaseService;
+    private final PartyRepository partyRepository;
+    private final ContactPreferencesRepository contactPreferencesRepository;
+    private final SecurityContextService securityContextService;
+
 
     @Override
     public void configureDecentralised(final DecentralisedConfigBuilder<PCSCase, State, UserRole> configBuilder) {
@@ -49,6 +63,8 @@ public class SubmitDefendantResponse implements CCDConfig<PCSCase, State, UserRo
                 //Store defendant response to database
                 //This will be implemented in a future ticket.
                 //Note that defendants will be stored in a list
+                saveDefendantContactPreferences(caseReference, defendantResponse);
+
             } else {
                 draftCaseDataService.patchUnsubmittedEventData(
                     caseReference, defendantResponse, EventId.submitDefendantResponse);
@@ -56,4 +72,63 @@ public class SubmitDefendantResponse implements CCDConfig<PCSCase, State, UserRo
         }
         return SubmitResponse.defaultResponse();
     }
+
+    private void saveDefendantContactPreferences(long caseReference, DefendantResponse defendantResponse) {
+
+        try {
+            // Get the current user's IDAM ID (the defendant submitting the response)
+            UUID currentUserIdamId = securityContextService.getCurrentUserId();
+
+            if (currentUserIdamId == null) {
+                log.error("Cannot save contact preferences: current user IDAM ID is null");
+                return;
+            }
+
+            // Find the defendant party by their IDAM ID
+            PartyEntity defendant = partyRepository.findByIdamId(currentUserIdamId)
+                .orElseThrow(() -> new IllegalStateException(
+                    "No party found for IDAM ID: " + currentUserIdamId));
+
+            // Update phone number
+            if (StringUtils.isNotBlank(defendantResponse.getPhoneNumber())){
+                defendant.setPhoneNumber(defendantResponse.getPhoneNumber());
+            }
+
+            // Update email address
+            if (StringUtils.isNotBlank(defendantResponse.getEmail())){
+                defendant.setEmailAddress(defendantResponse.getEmail());
+            }
+
+            // Save the updated party entity
+            partyRepository.save(defendant);
+
+            // Create contact preferences
+            ContactPreferencesEntity contactPrefs = ContactPreferencesEntity.builder()
+                .party(defendant)
+                .contactByEmail(toBooleanOrFalse(defendantResponse.getContactByEmail()))
+                .contactByText(toBooleanOrFalse(defendantResponse.getContactByText()))
+                .contactByPost(toBooleanOrFalse(defendantResponse.getContactByPost()))
+                .contactByPhone(toBooleanOrFalse(defendantResponse.getContactByPhone()))
+                .build();
+
+            // Create contact preferences
+            contactPreferencesRepository.save(contactPrefs);
+
+            log.info("Successfully saved contact preferences for defendant with IDAM ID: {} in case: {}",
+                     currentUserIdamId, caseReference);
+
+        } catch (Exception ex) {
+            log.error("Error saving defendant contact preferences for case: {}", caseReference, ex);
+        }
+    }
+
+    /**
+     * Converts YesOrNo to boolean with safe null handling
+     * returns false if input is null
+     */
+    private Boolean toBooleanOrFalse(YesOrNo yesOrNo) {
+        return Optional.ofNullable(YesOrNoConverter.toBoolean(yesOrNo))
+            .orElse(false);
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/SubmitDefendantResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/SubmitDefendantResponse.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.pcs.ccd.event;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
 import uk.gov.hmcts.ccd.sdk.api.DecentralisedConfigBuilder;
@@ -15,17 +14,8 @@ import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
 import uk.gov.hmcts.reform.pcs.ccd.domain.DefendantResponse;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 import uk.gov.hmcts.reform.pcs.ccd.domain.State;
-import uk.gov.hmcts.reform.pcs.ccd.entity.party.ContactPreferencesEntity;
-import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
-import uk.gov.hmcts.reform.pcs.ccd.repository.ContactPreferencesRepository;
-import uk.gov.hmcts.reform.pcs.ccd.repository.PartyRepository;
+import uk.gov.hmcts.reform.pcs.ccd.service.DefendantContactPreferencesService;
 import uk.gov.hmcts.reform.pcs.ccd.service.DraftCaseDataService;
-import uk.gov.hmcts.reform.pcs.ccd.service.PcsCaseService;
-import uk.gov.hmcts.reform.pcs.ccd.util.YesOrNoConverter;
-import uk.gov.hmcts.reform.pcs.security.SecurityContextService;
-
-import java.util.Optional;
-import java.util.UUID;
 
 import static uk.gov.hmcts.reform.pcs.ccd.event.EventId.submitDefendantResponse;
 
@@ -34,10 +24,7 @@ import static uk.gov.hmcts.reform.pcs.ccd.event.EventId.submitDefendantResponse;
 @RequiredArgsConstructor
 public class SubmitDefendantResponse implements CCDConfig<PCSCase, State, UserRole> {
     private final DraftCaseDataService draftCaseDataService;
-    private final PcsCaseService pcsCaseService;
-    private final PartyRepository partyRepository;
-    private final ContactPreferencesRepository contactPreferencesRepository;
-    private final SecurityContextService securityContextService;
+    private final DefendantContactPreferencesService defendantContactPreferencesService;
 
 
     @Override
@@ -61,74 +48,14 @@ public class SubmitDefendantResponse implements CCDConfig<PCSCase, State, UserRo
         if (defendantResponse != null && submitDraft != null) {
             if (submitDraft.toBoolean()) {
                 //Store defendant response to database
-                //This will be implemented in a future ticket.
-                //Note that defendants will be stored in a list
-                saveDefendantContactPreferences(caseReference, defendantResponse);
-
+                defendantContactPreferencesService.saveContactPreferences(defendantResponse);
+                log.info("Successfully saved defendant response for case: {}", caseReference);
             } else {
                 draftCaseDataService.patchUnsubmittedEventData(
                     caseReference, defendantResponse, EventId.submitDefendantResponse);
             }
         }
         return SubmitResponse.defaultResponse();
-    }
-
-    private void saveDefendantContactPreferences(long caseReference, DefendantResponse defendantResponse) {
-
-        try {
-            // Get the current user's IDAM ID (the defendant submitting the response)
-            UUID currentUserIdamId = securityContextService.getCurrentUserId();
-
-            if (currentUserIdamId == null) {
-                log.error("Cannot save contact preferences: current user IDAM ID is null");
-                return;
-            }
-
-            // Find the defendant party by their IDAM ID
-            PartyEntity defendant = partyRepository.findByIdamId(currentUserIdamId)
-                .orElseThrow(() -> new IllegalStateException(
-                    "No party found for IDAM ID: " + currentUserIdamId));
-
-            // Update phone number
-            if (StringUtils.isNotBlank(defendantResponse.getPhoneNumber())){
-                defendant.setPhoneNumber(defendantResponse.getPhoneNumber());
-            }
-
-            // Update email address
-            if (StringUtils.isNotBlank(defendantResponse.getEmail())){
-                defendant.setEmailAddress(defendantResponse.getEmail());
-            }
-
-            // Save the updated party entity
-            partyRepository.save(defendant);
-
-            // Create contact preferences
-            ContactPreferencesEntity contactPrefs = ContactPreferencesEntity.builder()
-                .party(defendant)
-                .contactByEmail(toBooleanOrFalse(defendantResponse.getContactByEmail()))
-                .contactByText(toBooleanOrFalse(defendantResponse.getContactByText()))
-                .contactByPost(toBooleanOrFalse(defendantResponse.getContactByPost()))
-                .contactByPhone(toBooleanOrFalse(defendantResponse.getContactByPhone()))
-                .build();
-
-            // Create contact preferences
-            contactPreferencesRepository.save(contactPrefs);
-
-            log.info("Successfully saved contact preferences for defendant with IDAM ID: {} in case: {}",
-                     currentUserIdamId, caseReference);
-
-        } catch (Exception ex) {
-            log.error("Error saving defendant contact preferences for case: {}", caseReference, ex);
-        }
-    }
-
-    /**
-     * Converts YesOrNo to boolean with safe null handling
-     * returns false if input is null
-     */
-    private Boolean toBooleanOrFalse(YesOrNo yesOrNo) {
-        return Optional.ofNullable(YesOrNoConverter.toBoolean(yesOrNo))
-            .orElse(false);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/repository/ContactPreferencesRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/repository/ContactPreferencesRepository.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.reform.pcs.ccd.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.ContactPreferencesEntity;
+
+import java.util.UUID;
+
+@Repository
+public interface ContactPreferencesRepository extends JpaRepository<ContactPreferencesEntity, UUID> {
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/repository/PartyRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/repository/PartyRepository.java
@@ -4,9 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface PartyRepository extends JpaRepository<PartyEntity, UUID> {
-
+    Optional<PartyEntity> findByIdamId(UUID idamId);
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/DefendantContactPreferencesService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/DefendantContactPreferencesService.java
@@ -1,0 +1,125 @@
+package uk.gov.hmcts.reform.pcs.ccd.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
+import uk.gov.hmcts.reform.pcs.ccd.domain.DefendantResponse;
+import uk.gov.hmcts.reform.pcs.ccd.entity.AddressEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.ContactPreferencesEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
+import uk.gov.hmcts.reform.pcs.ccd.repository.ContactPreferencesRepository;
+import uk.gov.hmcts.reform.pcs.ccd.repository.PartyRepository;
+import uk.gov.hmcts.reform.pcs.ccd.util.YesOrNoConverter;
+import uk.gov.hmcts.reform.pcs.security.SecurityContextService;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Service for managing defendant contact preferences.
+ * Handles saving contact preferences and updating party contact details.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class DefendantContactPreferencesService {
+
+    private final PartyRepository partyRepository;
+    private final ContactPreferencesRepository contactPreferencesRepository;
+    private final SecurityContextService securityContextService;
+    private final ModelMapper modelMapper;
+
+    /**
+     * Saves defendant's contact preferences and contact details.
+     * Finds the defendant party by the current user's IDAM ID and updates their information.
+     *
+     * @param defendantResponse The defendant's response containing contact preferences and details
+     * @throws IllegalStateException if no party found for the current user's IDAM ID
+     */
+    public void saveContactPreferences(DefendantResponse defendantResponse) {
+        UUID currentUserIdamId = securityContextService.getCurrentUserId();
+
+        if (currentUserIdamId == null) {
+            log.error("Cannot save contact preferences: current user IDAM ID is null");
+            throw new IllegalStateException("Current user IDAM ID is null");
+        }
+
+        PartyEntity defendant = findDefendantByIdamId(currentUserIdamId);
+
+        updatePartyContactDetails(defendant, defendantResponse);
+        createAndSaveContactPreferences(defendant, defendantResponse);
+
+        log.info("Successfully saved contact preferences for defendant with IDAM ID: {}", currentUserIdamId);
+    }
+
+    /**
+     * Finds a defendant party by their IDAM ID.
+     * Similar pattern to PcsCaseMergeService.setPcqIdForCurrentUser()
+     */
+    private PartyEntity findDefendantByIdamId(UUID idamId) {
+        return partyRepository.findByIdamId(idamId)
+            .orElseThrow(() -> new IllegalStateException(
+                "No party found for IDAM ID: " + idamId));
+    }
+
+    /**
+     * Updates party's contact details (phone number and email address).
+     * Only updates if the values are provided (non-blank).
+     */
+    private void updatePartyContactDetails(PartyEntity party, DefendantResponse defendantResponse) {
+        boolean updated = false;
+
+        if (StringUtils.isNotBlank(defendantResponse.getPhoneNumber())) {
+            party.setPhoneNumber(defendantResponse.getPhoneNumber());
+            updated = true;
+            log.debug("Updated phone number for party ID: {}", party.getId());
+        }
+
+        if (StringUtils.isNotBlank(defendantResponse.getEmail())) {
+            party.setEmailAddress(defendantResponse.getEmail());
+            updated = true;
+            log.debug("Updated email address for party ID: {}", party.getId());
+        }
+
+        if (StringUtils.isNotBlank(defendantResponse.getAddress())) {
+            AddressEntity address = modelMapper.map(defendantResponse.getAddress(), AddressEntity.class);
+            party.setAddress(address);
+        }
+
+        if (updated) {
+            partyRepository.save(party);
+        }
+    }
+
+    /**
+     * Creates and saves contact preferences entity with null-safe conversion.
+     * Defaults null preferences to false (no contact).
+     */
+    private void createAndSaveContactPreferences(PartyEntity party, DefendantResponse defendantResponse) {
+        ContactPreferencesEntity contactPrefs = ContactPreferencesEntity.builder()
+            .party(party)
+            .contactByEmail(toBooleanOrFalse(defendantResponse.getContactByEmail()))
+            .contactByText(toBooleanOrFalse(defendantResponse.getContactByText()))
+            .contactByPost(toBooleanOrFalse(defendantResponse.getContactByPost()))
+            .contactByPhone(toBooleanOrFalse(defendantResponse.getContactByPhone()))
+            .build();
+
+        contactPreferencesRepository.save(contactPrefs);
+        log.debug("Saved contact preferences for party ID: {}", party.getId());
+    }
+
+    /**
+     * Converts YesOrNo to Boolean with safe null handling.
+     * Returns false if the input is null (defaults to "no contact" preference).
+     *
+     * @param yesOrNo the YesOrNo value to convert
+     * @return true if YES, false if NO or null
+     */
+    private Boolean toBooleanOrFalse(YesOrNo yesOrNo) {
+        return Optional.ofNullable(YesOrNoConverter.toBoolean(yesOrNo))
+            .orElse(false);
+    }
+}

--- a/src/main/resources/db/migration/V042__party_tables.sql
+++ b/src/main/resources/db/migration/V042__party_tables.sql
@@ -33,5 +33,16 @@ CREATE TABLE public.claim_party (
   PRIMARY KEY (claim_id, party_id)
 );
 
+CREATE TABLE public.contact_preferences (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  party_id            UUID NOT NULL REFERENCES public.party (id),
+  contact_by_email    BOOLEAN DEFAULT FALSE,
+  contact_by_text     BOOLEAN DEFAULT FALSE,
+  contact_by_post     BOOLEAN DEFAULT FALSE,
+  contact_by_phone    BOOLEAN DEFAULT FALSE
+);
+
+CREATE INDEX idx_contact_preferences_party_id ON public.contact_preferences (party_id);
+
 ALTER TABLE public.pcs_case DROP COLUMN defendant_details;
 ALTER TABLE public.pcs_case DROP COLUMN underlessee_mortgagee_details;

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/SubmitDefendantResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/SubmitDefendantResponseTest.java
@@ -8,10 +8,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.reform.pcs.ccd.domain.DefendantResponse;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.service.DefendantContactPreferencesService;
 import uk.gov.hmcts.reform.pcs.ccd.service.DraftCaseDataService;
-import uk.gov.hmcts.reform.pcs.ccd.service.PcsCaseService;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class SubmitDefendantResponseTest extends BaseEventTest {
@@ -20,11 +21,14 @@ class SubmitDefendantResponseTest extends BaseEventTest {
     private DraftCaseDataService draftCaseDataService;
 
     @Mock
-    private PcsCaseService pcsCaseService;
+    private DefendantContactPreferencesService defendantContactPreferencesService;
 
     @BeforeEach
     void setUp() {
-        setEventUnderTest(new SubmitDefendantResponse(draftCaseDataService, pcsCaseService));
+        setEventUnderTest(new SubmitDefendantResponse(
+            draftCaseDataService,
+            defendantContactPreferencesService
+        ));
     }
 
     @Test
@@ -48,7 +52,68 @@ class SubmitDefendantResponseTest extends BaseEventTest {
             defendantResponse,
             EventId.submitDefendantResponse
         );
+        verifyNoInteractions(defendantContactPreferencesService);
+    }
 
+    @Test
+    void shouldSaveContactPreferencesWhenSubmitDraftIsYes() {
+        // Given
+        DefendantResponse defendantResponse = DefendantResponse.builder()
+            .contactByPhone(YesOrNo.YES)
+            .contactByEmail(YesOrNo.NO)
+            .contactByText(YesOrNo.YES)
+            .contactByPost(YesOrNo.NO)
+            .phoneNumber("07123456789")
+            .email("defendant@example.com")
+            .build();
+
+        PCSCase caseData = PCSCase.builder()
+            .defendantResponse(defendantResponse)
+            .submitDraftAnswers(YesOrNo.YES)
+            .build();
+
+        // When
+        callSubmitHandler(caseData);
+
+        // Then
+        verify(defendantContactPreferencesService).saveContactPreferences(defendantResponse);
+        verifyNoInteractions(draftCaseDataService);
+    }
+
+    @Test
+    void shouldNotCallServicesWhenDefendantResponseIsNull() {
+        // Given
+        PCSCase caseData = PCSCase.builder()
+            .defendantResponse(null)
+            .submitDraftAnswers(YesOrNo.YES)
+            .build();
+
+        // When
+        callSubmitHandler(caseData);
+
+        // Then
+        verifyNoInteractions(defendantContactPreferencesService);
+        verifyNoInteractions(draftCaseDataService);
+    }
+
+    @Test
+    void shouldNotCallServicesWhenSubmitDraftAnswersIsNull() {
+        // Given
+        DefendantResponse defendantResponse = DefendantResponse.builder()
+            .contactByPhone(YesOrNo.YES)
+            .build();
+
+        PCSCase caseData = PCSCase.builder()
+            .defendantResponse(defendantResponse)
+            .submitDraftAnswers(null)
+            .build();
+
+        // When
+        callSubmitHandler(caseData);
+
+        // Then
+        verifyNoInteractions(defendantContactPreferencesService);
+        verifyNoInteractions(draftCaseDataService);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/DefendantContactPreferencesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/DefendantContactPreferencesServiceTest.java
@@ -1,0 +1,304 @@
+package uk.gov.hmcts.reform.pcs.ccd.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
+import uk.gov.hmcts.reform.pcs.ccd.domain.DefendantResponse;
+import uk.gov.hmcts.reform.pcs.ccd.entity.AddressEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.ContactPreferencesEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
+import uk.gov.hmcts.reform.pcs.ccd.repository.ContactPreferencesRepository;
+import uk.gov.hmcts.reform.pcs.ccd.repository.PartyRepository;
+import uk.gov.hmcts.reform.pcs.security.SecurityContextService;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DefendantContactPreferencesServiceTest {
+
+    @Mock
+    private PartyRepository partyRepository;
+
+    @Mock
+    private ContactPreferencesRepository contactPreferencesRepository;
+
+    @Mock
+    private SecurityContextService securityContextService;
+
+    @Mock
+    private ModelMapper modelMapper;
+
+    @InjectMocks
+    private DefendantContactPreferencesService service;
+
+    @Captor
+    private ArgumentCaptor<PartyEntity> partyCaptor;
+
+    @Captor
+    private ArgumentCaptor<ContactPreferencesEntity> contactPrefsCaptor;
+
+    private static final UUID TEST_IDAM_ID = UUID.randomUUID();
+    private static final UUID TEST_PARTY_ID = UUID.randomUUID();
+    private PartyEntity testParty;
+
+    @BeforeEach
+    void setUp() {
+        testParty = new PartyEntity();
+        testParty.setId(TEST_PARTY_ID);
+        testParty.setIdamId(TEST_IDAM_ID);
+    }
+
+    @Test
+    void shouldSaveContactPreferencesWithAllFieldsProvided() {
+        // Given
+        DefendantResponse response = DefendantResponse.builder()
+            .contactByEmail(YesOrNo.YES)
+            .contactByPhone(YesOrNo.NO)
+            .contactByText(YesOrNo.YES)
+            .contactByPost(YesOrNo.NO)
+            .phoneNumber("07123456789")
+            .email("defendant@example.com")
+            .address("123 Test Street")
+            .build();
+
+        AddressEntity addressEntity = new AddressEntity();
+        when(securityContextService.getCurrentUserId()).thenReturn(TEST_IDAM_ID);
+        when(partyRepository.findByIdamId(TEST_IDAM_ID)).thenReturn(Optional.of(testParty));
+        when(modelMapper.map(response.getAddress(), AddressEntity.class)).thenReturn(addressEntity);
+
+        // When
+        service.saveContactPreferences(response);
+
+        // Then
+        verify(partyRepository).save(partyCaptor.capture());
+        PartyEntity savedParty = partyCaptor.getValue();
+        assertThat(savedParty.getPhoneNumber()).isEqualTo("07123456789");
+        assertThat(savedParty.getEmailAddress()).isEqualTo("defendant@example.com");
+        assertThat(savedParty.getAddress()).isEqualTo(addressEntity);
+
+        verify(contactPreferencesRepository).save(contactPrefsCaptor.capture());
+        ContactPreferencesEntity savedPrefs = contactPrefsCaptor.getValue();
+        assertThat(savedPrefs.getParty()).isEqualTo(testParty);
+        assertThat(savedPrefs.getContactByEmail()).isTrue();
+        assertThat(savedPrefs.getContactByPhone()).isFalse();
+        assertThat(savedPrefs.getContactByText()).isTrue();
+        assertThat(savedPrefs.getContactByPost()).isFalse();
+    }
+
+    @Test
+    void shouldSaveOnlyPhoneNumber() {
+        // Given
+        DefendantResponse response = DefendantResponse.builder()
+            .contactByPhone(YesOrNo.YES)
+            .phoneNumber("07123456789")
+            .build();
+
+        when(securityContextService.getCurrentUserId()).thenReturn(TEST_IDAM_ID);
+        when(partyRepository.findByIdamId(TEST_IDAM_ID)).thenReturn(Optional.of(testParty));
+
+        // When
+        service.saveContactPreferences(response);
+
+        // Then
+        verify(partyRepository).save(partyCaptor.capture());
+        PartyEntity savedParty = partyCaptor.getValue();
+        assertThat(savedParty.getPhoneNumber()).isEqualTo("07123456789");
+        assertThat(savedParty.getEmailAddress()).isNull();
+    }
+
+    @Test
+    void shouldSaveOnlyEmail() {
+        // Given
+        DefendantResponse response = DefendantResponse.builder()
+            .contactByEmail(YesOrNo.YES)
+            .email("defendant@example.com")
+            .build();
+
+        when(securityContextService.getCurrentUserId()).thenReturn(TEST_IDAM_ID);
+        when(partyRepository.findByIdamId(TEST_IDAM_ID)).thenReturn(Optional.of(testParty));
+
+        // When
+        service.saveContactPreferences(response);
+
+        // Then
+        verify(partyRepository).save(partyCaptor.capture());
+        PartyEntity savedParty = partyCaptor.getValue();
+        assertThat(savedParty.getEmailAddress()).isEqualTo("defendant@example.com");
+        assertThat(savedParty.getPhoneNumber()).isNull();
+    }
+
+    @Test
+    void shouldDefaultNullPreferencesToFalse() {
+        // Given
+        DefendantResponse response = DefendantResponse.builder()
+            .contactByEmail(null)
+            .contactByPhone(null)
+            .contactByText(YesOrNo.YES)
+            .contactByPost(null)
+            .build();
+
+        when(securityContextService.getCurrentUserId()).thenReturn(TEST_IDAM_ID);
+        when(partyRepository.findByIdamId(TEST_IDAM_ID)).thenReturn(Optional.of(testParty));
+
+        // When
+        service.saveContactPreferences(response);
+
+        // Then
+        verify(contactPreferencesRepository).save(contactPrefsCaptor.capture());
+        ContactPreferencesEntity savedPrefs = contactPrefsCaptor.getValue();
+        assertThat(savedPrefs.getContactByEmail()).isFalse();
+        assertThat(savedPrefs.getContactByPhone()).isFalse();
+        assertThat(savedPrefs.getContactByText()).isTrue();
+        assertThat(savedPrefs.getContactByPost()).isFalse();
+    }
+
+    @Test
+    void shouldNotUpdatePartyWhenContactDetailsAreBlank() {
+        // Given
+        DefendantResponse response = DefendantResponse.builder()
+            .contactByEmail(YesOrNo.YES)
+            .phoneNumber("")
+            .email("   ")
+            .address(null)
+            .build();
+
+        when(securityContextService.getCurrentUserId()).thenReturn(TEST_IDAM_ID);
+        when(partyRepository.findByIdamId(TEST_IDAM_ID)).thenReturn(Optional.of(testParty));
+
+        // When
+        service.saveContactPreferences(response);
+
+        // Then
+        verify(partyRepository, never()).save(any());
+        verify(contactPreferencesRepository).save(any(ContactPreferencesEntity.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCurrentUserIdamIdIsNull() {
+        // Given
+        DefendantResponse response = DefendantResponse.builder()
+            .contactByEmail(YesOrNo.YES)
+            .build();
+
+        when(securityContextService.getCurrentUserId()).thenReturn(null);
+
+        // When
+        assertThatThrownBy(() -> service.saveContactPreferences(response))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Current user IDAM ID is null");
+
+        // Then
+        verifyNoInteractions(partyRepository);
+        verifyNoInteractions(contactPreferencesRepository);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenPartyNotFound() {
+        // Given
+        DefendantResponse response = DefendantResponse.builder()
+            .contactByEmail(YesOrNo.YES)
+            .build();
+
+        when(securityContextService.getCurrentUserId()).thenReturn(TEST_IDAM_ID);
+        when(partyRepository.findByIdamId(TEST_IDAM_ID)).thenReturn(Optional.empty());
+
+        // When
+        assertThatThrownBy(() -> service.saveContactPreferences(response))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("No party found for IDAM ID:");
+
+        // Then
+        verify(partyRepository).findByIdamId(TEST_IDAM_ID);
+        verifyNoInteractions(contactPreferencesRepository);
+    }
+
+    @Test
+    void shouldHandleAllPreferencesSetToNo() {
+        // Given
+        DefendantResponse response = DefendantResponse.builder()
+            .contactByEmail(YesOrNo.NO)
+            .contactByPhone(YesOrNo.NO)
+            .contactByText(YesOrNo.NO)
+            .contactByPost(YesOrNo.NO)
+            .build();
+
+        when(securityContextService.getCurrentUserId()).thenReturn(TEST_IDAM_ID);
+        when(partyRepository.findByIdamId(TEST_IDAM_ID)).thenReturn(Optional.of(testParty));
+
+        // When
+        service.saveContactPreferences(response);
+
+        // Then
+        verify(contactPreferencesRepository).save(contactPrefsCaptor.capture());
+        ContactPreferencesEntity savedPrefs = contactPrefsCaptor.getValue();
+        assertThat(savedPrefs.getContactByEmail()).isFalse();
+        assertThat(savedPrefs.getContactByPhone()).isFalse();
+        assertThat(savedPrefs.getContactByText()).isFalse();
+        assertThat(savedPrefs.getContactByPost()).isFalse();
+    }
+
+    @Test
+    void shouldHandleAllPreferencesSetToYes() {
+
+        DefendantResponse response = DefendantResponse.builder()
+            .contactByEmail(YesOrNo.YES)
+            .contactByPhone(YesOrNo.YES)
+            .contactByText(YesOrNo.YES)
+            .contactByPost(YesOrNo.YES)
+            .phoneNumber("07123456789")
+            .email("test@example.com")
+            .address("123 Test Street, London, SW1A 1AA")
+            .build();
+
+        // Create a properly populated AddressEntity
+        AddressEntity addressEntity = AddressEntity.builder()
+            .addressLine1("123 Test Street")
+            .postTown("London")
+            .postcode("SW1A 1AA")
+            .build();
+
+        when(securityContextService.getCurrentUserId()).thenReturn(TEST_IDAM_ID);
+        when(partyRepository.findByIdamId(TEST_IDAM_ID)).thenReturn(Optional.of(testParty));
+        when(modelMapper.map(response.getAddress(), AddressEntity.class)).thenReturn(addressEntity);
+
+        // When
+        service.saveContactPreferences(response);
+
+        // Then
+        verify(partyRepository).save(partyCaptor.capture());
+        PartyEntity savedParty = partyCaptor.getValue();
+
+        assertThat(savedParty.getAddress()).isNotNull();
+        assertThat(savedParty.getAddress()).isEqualTo(addressEntity);
+        assertThat(savedParty.getAddress().getAddressLine1()).isEqualTo("123 Test Street");
+        assertThat(savedParty.getAddress().getPostTown()).isEqualTo("London");
+        assertThat(savedParty.getAddress().getPostcode()).isEqualTo("SW1A 1AA");
+
+        assertThat(savedParty.getPhoneNumber()).isEqualTo("07123456789");
+        assertThat(savedParty.getEmailAddress()).isEqualTo("test@example.com");
+
+        verify(contactPreferencesRepository).save(contactPrefsCaptor.capture());
+        ContactPreferencesEntity savedPrefs = contactPrefsCaptor.getValue();
+        assertThat(savedPrefs.getContactByEmail()).isTrue();
+        assertThat(savedPrefs.getContactByPhone()).isTrue();
+        assertThat(savedPrefs.getContactByText()).isTrue();
+        assertThat(savedPrefs.getContactByPost()).isTrue();
+
+    }
+}


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-3859 with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-3859](https://tools.hmcts.net/jira/browse/PROJ-3859)

### Change description


It is the feature related with CUI Respond to Claim regarding contact preferences when user chooses to be contacted by the phone, email or by post and chooses to save and continue or save for later. A new table is created for contact preferences which stores these details and also user contact details are updated if provided.


### Testing done


1. At the moment just units tests are added 
2. Planning to tests via postman request by triggering the event


### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
