### PR TITLE
HDPI-6064: Exclude "event DTOs" from ES indexing

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/PCSCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/PCSCase.java
@@ -503,7 +503,8 @@ public class PCSCase {
     private ASBQuestionsDetailsWales asbQuestionsWales;
 
     @CCD(
-        access = {DefendantAccess.class}
+        access = {DefendantAccess.class},
+        searchable = false
     )
     private PossessionClaimResponse possessionClaimResponse;
 
@@ -523,7 +524,10 @@ public class PCSCase {
     @CCD(access = {ClaimantAccess.class, DefendantAccess.class})
     private List<ListValue<ClaimGroundSummary>> claimGroundSummaries;
 
-    @CCD(access = DefendantAccess.class)
+    @CCD(
+        access = DefendantAccess.class,
+        searchable = false
+    )
     private CitizenGenAppRequest citizenGenAppRequest;
 
     @CCD(


### PR DESCRIPTION
### Jira link

See [HDPI-6064](https://tools.hmcts.net/jira/browse/HDPI-6064)

### Change description

Sections of the CCD case model that are used for pcs-frontend events don't need to be indexed as they aren't populated  when CCD fetches the latest case data from the `PCSCaseView`.

This change excludes them from indexing, which also means that we can change the types of a given field without having ES issues during deployment to AAT.

### Testing done

Build pipeline run with e2e tests

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
