### PR TITLE
Applied to identify the contractual difference recieved from ccpay

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcs/controllers/PaymentCallBackControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcs/controllers/PaymentCallBackControllerIT.java
@@ -91,8 +91,7 @@ public class PaymentCallBackControllerIT extends AbstractPostgresContainerIT {
         Optional<FeePaymentEntity> byRequestReference = feePaymentRepository
             .findByRequestReference(serviceCaseReference);
         assertThat(byRequestReference.isPresent()).isTrue();
-        FeePaymentEntity feePaymentEntity = byRequestReference.get();
-        assertThat(feePaymentEntity.getPaymentStatus()).isEqualTo(PaymentStatus.PAID);
+
     }
 
     PcsCaseEntity establishTestCase(long caseReference) {

--- a/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/endpoint/PaymentCallBackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/endpoint/PaymentCallBackController.java
@@ -6,8 +6,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.hmcts.reform.pcs.feesandpay.model.ServiceRequestUpdate;
-import uk.gov.hmcts.reform.pcs.feesandpay.service.PaymentService;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -20,15 +18,13 @@ public class PaymentCallBackController {
     public static final String SERVICE_AUTHORIZATION = "ServiceAuthorization";
     public static final String PAYMENT_UPDATE_PATH = "/payment-update";
 
-    private final PaymentService paymentService;
-
     @PutMapping(path = PAYMENT_UPDATE_PATH, consumes = APPLICATION_JSON_VALUE)
     public void processPaymentCallback(
         @RequestHeader(value = AUTHORIZATION) String authorisation,
         @RequestHeader(value = SERVICE_AUTHORIZATION) String s2sToken,
-        @RequestBody ServiceRequestUpdate serviceRequestUpdate) {
-        log.info("Payment Callback Received For Case: {}", serviceRequestUpdate.getCcdCaseNumber());
-        paymentService.processPaymentResponse(serviceRequestUpdate);
+        @RequestBody String serviceRequestUpdate) {
+        log.info("Payment Callback Received For Case: {}", serviceRequestUpdate);
+
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/feesandpay/endpoint/PaymentCallBackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/feesandpay/endpoint/PaymentCallBackControllerTest.java
@@ -3,24 +3,17 @@ package uk.gov.hmcts.reform.pcs.feesandpay.endpoint;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.pcs.feesandpay.model.ServiceRequestUpdate;
-import uk.gov.hmcts.reform.pcs.feesandpay.service.PaymentService;
-
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentCallBackControllerTest {
 
     private PaymentCallBackController underTest;
 
-    @Mock
-    private PaymentService paymentService;
-
     @BeforeEach
     void setUp() {
-        underTest = new PaymentCallBackController(paymentService);
+        underTest = new PaymentCallBackController();
     }
 
     @Test
@@ -32,9 +25,7 @@ class PaymentCallBackControllerTest {
             .build();
 
         // When
-        underTest.processPaymentCallback("auth", "s2s", serviceRequestUpdate);
+        underTest.processPaymentCallback("auth", "s2s", serviceRequestUpdate.toString());
 
-        // Then
-        verify(paymentService).processPaymentResponse(serviceRequestUpdate);
     }
 }


### PR DESCRIPTION
[### Jira link](https://tools.hmcts.net/jira/browse/HDPI-5688)

There is a contractual difference being seen in the callback from ccpay now that finally there is evidence of the calls within the AZ logs.   HTTP 400 codes.

This small temp change is to identity the message received so that we can change to it within PCS.   A @RestControllerAdvice implementation can be applied in the actual code implementation.   The "raw" request string is being used here to get visiblity.

<img width="2533" height="1258" alt="Screenshot 2026-04-27 at 09 04 10" src="https://github.com/user-attachments/assets/c42286c1-294c-4362-80ae-b871dc84f626" />


