### PR TITLE
HDPI-5438: Extract case name formatter code to make it re-usable

### DIFF
--- a/src/e2eTest/tests/createCase.spec.ts
+++ b/src/e2eTest/tests/createCase.spec.ts
@@ -108,6 +108,7 @@ test.describe('[Create Case - England] @nightly', async () => {
       year: tenancyLicenceDetails.yearTextInput,
       question: tenancyLicenceDetails.doYouHaveACopyOftenancyQuestion,
       option: tenancyLicenceDetails.yesRadioOption,
+      files: ['tenancyLicence.docx']
     });
     await performAction('selectGroundsForPossession',{groundsRadioInput: groundsForPossession.yesRadioOption});
     await performAction('selectRentArrearsPossessionGround', {
@@ -366,8 +367,7 @@ test.describe('[Create Case - England] @nightly', async () => {
       tenancyOrLicenceType: tenancyLicenceDetails.assuredTenancyRadioOption,
       question: tenancyLicenceDetails.doYouHaveACopyOftenancyQuestion,
       option: tenancyLicenceDetails.noRadioOption,
-      reason: tenancyLicenceDetails.reasonForNoCopyInputText,
-      files: ['tenancyLicence.docx']
+      reason: tenancyLicenceDetails.reasonForNoCopyInputText
     });
     await performAction('selectGroundsForPossession', {groundsRadioInput: groundsForPossession.noRadioOption});
     await performValidation('mainHeader', whatAreYourGroundsForPossession.groundsForPossessionMainHeader);

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/CaseNameFormatter.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/CaseNameFormatter.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.reform.pcs.ccd.service;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.domain.Party;
+import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
+
+import java.util.List;
+
+import static uk.gov.hmcts.reform.pcs.ccd.util.ListValueUtils.unwrapListItems;
+
+@Service
+@AllArgsConstructor
+public class CaseNameFormatter {
+
+    /**
+     * Builds a formatted string for the case name hmcts field based on certain rules.
+     *
+     * @param pcsCase The current case data
+     */
+    public String formatCaseName(PCSCase pcsCase) {
+        final List<Party> claimants = unwrapListItems(pcsCase.getAllClaimants());
+        final List<Party> defendants = unwrapListItems(pcsCase.getAllDefendants());
+
+        return formatCaseName(claimants, defendants);
+    }
+
+    /**
+     * Builds a formatted string for the case name hmcts field based on certain rules.
+     *
+     * @param claimants List of claimant {@link Party}
+     * @param defendants List of defendant {@link Party}
+     */
+    public String formatCaseName(List<Party> claimants, List<Party> defendants) {
+        return getFormattedClaimantName(claimants)
+            + " vs " + getFormattedDefendantName(defendants);
+    }
+
+    private String getFormattedClaimantName(final List<Party> claimants) {
+        String formattedClaimantName = null;
+        if (claimants != null && !claimants.isEmpty()) {
+            var claimant = claimants.getFirst();
+            formattedClaimantName = claimant.getOrgName() != null
+                ? claimant.getOrgName() :
+                claimant.getLastName();
+        }
+        return formattedClaimantName;
+    }
+
+    private String getFormattedDefendantName(final List<Party> defendants) {
+        StringBuilder formattedDefendantName = new StringBuilder();
+        if (defendants != null && !defendants.isEmpty() && isDefendantNameKnown(defendants)) {
+            formattedDefendantName.append(defendants.getFirst().getLastName());
+            if (defendants.size() > 1) {
+                formattedDefendantName.append(" and Others");
+            }
+        } else {
+            formattedDefendantName.append("persons unknown");
+        }
+        return formattedDefendantName.toString();
+    }
+
+    private boolean isDefendantNameKnown(final List<Party> defendants) {
+        return defendants.getFirst().getNameKnown() == VerticalYesNo.YES;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/globalsearch/CaseFieldsView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/globalsearch/CaseFieldsView.java
@@ -1,21 +1,22 @@
 package uk.gov.hmcts.reform.pcs.ccd.view.globalsearch;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.type.CaseLocation;
 import uk.gov.hmcts.ccd.sdk.type.DynamicList;
 import uk.gov.hmcts.ccd.sdk.type.DynamicListElement;
-import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
-import uk.gov.hmcts.reform.pcs.ccd.domain.Party;
-import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
+import uk.gov.hmcts.reform.pcs.ccd.service.CaseNameFormatter;
 
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
 @Component
+@RequiredArgsConstructor
 public class CaseFieldsView {
+
+    private final CaseNameFormatter caseNameFormatter;
 
     @Value("${globalsearch.caseManagementCategory}")
     private String caseManagementCategory;
@@ -30,19 +31,8 @@ public class CaseFieldsView {
         setCaseManagementCategory(pcsCase);
     }
 
-    /**
-     * Builds a formatted string for the case name hmcts field based on certain rules and sets the internal, restricted
-     * and public field accordingly.
-     *
-     * @param pcsCase The current case data
-     */
     private void setCaseNameHmctsField(final PCSCase pcsCase) {
-
-        final List<ListValue<Party>> defendants = pcsCase.getAllDefendants();
-        final List<ListValue<Party>> claimants = pcsCase.getAllClaimants();
-
-        final String formattedCaseName = getFormattedClaimantName(claimants)
-            + " vs " + getFormattedDefendantName(defendants);
+        final String formattedCaseName = caseNameFormatter.formatCaseName(pcsCase);
 
         pcsCase.setCaseNameHmctsRestricted(formattedCaseName);
         pcsCase.setCaseNameHmctsInternal(formattedCaseName);
@@ -73,33 +63,5 @@ public class CaseFieldsView {
             .value(listElement)
             .listItems(caseManagementCategoryList)
             .build());
-    }
-
-    private String getFormattedClaimantName(final List<ListValue<Party>> claimants) {
-        String  formattedClaimantName = null;
-        if (claimants != null && !claimants.isEmpty()) {
-            var claimant = claimants.getFirst().getValue();
-            formattedClaimantName = claimant.getOrgName() != null
-                                             ? claimant.getOrgName() :
-                                             claimant.getLastName();
-        }
-        return formattedClaimantName;
-    }
-
-    private String getFormattedDefendantName(final List<ListValue<Party>> defendants) {
-        StringBuilder formattedDefendantName = new StringBuilder();
-        if (defendants != null && !defendants.isEmpty() && isDefendantNameKnown(defendants)) {
-            formattedDefendantName.append(defendants.getFirst().getValue().getLastName());
-            if (defendants.size() > 1) {
-                formattedDefendantName.append(" and Others");
-            }
-        } else {
-            formattedDefendantName.append("persons unknown");
-        }
-        return formattedDefendantName.toString();
-    }
-
-    private boolean isDefendantNameKnown(final List<ListValue<Party>> defendants) {
-        return defendants.getFirst().getValue().getNameKnown() == VerticalYesNo.YES;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/CaseNameFormatterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/CaseNameFormatterTest.java
@@ -1,0 +1,181 @@
+package uk.gov.hmcts.reform.pcs.ccd.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.domain.Party;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo.NO;
+import static uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo.YES;
+
+@ExtendWith(MockitoExtension.class)
+class CaseNameFormatterTest {
+
+    private static final String CLAIMANT_NAME = "Freeman";
+    private static final String DEFENDANT_LAST_NAME = "Jackson";
+    private static final String CLAIMANT_ORGANISATION_NAME = "Treetops Housing";
+
+    @Mock
+    private PCSCase pcsCase;
+    @Mock
+    private ListValue<Party> defendantPartyListValue;
+    @Mock
+    private ListValue<Party> claimantListValue;
+    @Mock
+    private Party defendantParty;
+    @Mock
+    private Party claimantParty;
+
+    private CaseNameFormatter underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new CaseNameFormatter();
+    }
+
+    @Nested
+    @DisplayName("Format case name from PcsCase")
+    class FormatFromPcsCaseTests {
+
+        @Test
+        void shouldFormatCaseNameWhenClaimantIsOrgAndDefendantIsKnown() {
+            // Given
+            when(pcsCase.getAllClaimants()).thenReturn(List.of(claimantListValue));
+            when(pcsCase.getAllDefendants()).thenReturn(List.of(defendantPartyListValue));
+            when(defendantPartyListValue.getValue()).thenReturn(defendantParty);
+            when(claimantListValue.getValue()).thenReturn(claimantParty);
+            when(claimantParty.getOrgName()).thenReturn(CLAIMANT_ORGANISATION_NAME);
+            when(defendantParty.getNameKnown()).thenReturn(YES);
+            when(defendantParty.getLastName()).thenReturn(DEFENDANT_LAST_NAME);
+
+            // When
+            String caseName = underTest.formatCaseName(pcsCase);
+
+            // Then
+            assertThat(caseName).isEqualTo("Treetops Housing vs Jackson");
+        }
+
+        @Test
+        void shouldFormatCaseNameWhenClaimantIsCitizenAndDefendantIsKnown() {
+            // Given
+            when(pcsCase.getAllClaimants()).thenReturn(List.of(claimantListValue));
+            when(pcsCase.getAllDefendants()).thenReturn(List.of(defendantPartyListValue));
+            when(defendantPartyListValue.getValue()).thenReturn(defendantParty);
+            when(claimantListValue.getValue()).thenReturn(claimantParty);
+            when(claimantParty.getLastName()).thenReturn(CLAIMANT_NAME);
+            when(defendantParty.getNameKnown()).thenReturn(YES);
+            when(defendantParty.getLastName()).thenReturn(DEFENDANT_LAST_NAME);
+
+            // When
+            String caseName = underTest.formatCaseName(pcsCase);
+
+            // Then
+            assertThat(caseName).isEqualTo("Freeman vs Jackson");
+        }
+
+        @Test
+        void shouldFormatCaseNameWhenClaimantIsOrgAndMultipleDefendants() {
+            // Given
+            when(pcsCase.getAllClaimants()).thenReturn(List.of(claimantListValue));
+            when(pcsCase.getAllDefendants()).thenReturn(List.of(defendantPartyListValue, defendantPartyListValue));
+            when(defendantPartyListValue.getValue()).thenReturn(defendantParty);
+            when(claimantListValue.getValue()).thenReturn(claimantParty);
+            when(claimantParty.getOrgName()).thenReturn(CLAIMANT_ORGANISATION_NAME);
+            when(defendantParty.getNameKnown()).thenReturn(YES);
+            when(defendantParty.getLastName()).thenReturn(DEFENDANT_LAST_NAME);
+
+            // When
+            String caseName = underTest.formatCaseName(pcsCase);
+
+            // Then
+            assertThat(caseName).isEqualTo("Treetops Housing vs Jackson and Others");
+        }
+
+        @Test
+        void shouldFormatCaseNameWhenClaimantIsCitizenAndDefendantUnknown() {
+            // Given
+            when(pcsCase.getAllClaimants()).thenReturn(List.of(claimantListValue));
+            when(pcsCase.getAllDefendants()).thenReturn(List.of(defendantPartyListValue));
+            when(claimantListValue.getValue()).thenReturn(claimantParty);
+            when(defendantPartyListValue.getValue()).thenReturn(defendantParty);
+            when(claimantParty.getLastName()).thenReturn(CLAIMANT_NAME);
+            when(defendantParty.getNameKnown()).thenReturn(NO);
+
+            // When
+            String caseName = underTest.formatCaseName(pcsCase);
+
+            // Then
+            assertThat(caseName).isEqualTo("Freeman vs persons unknown");
+        }
+    }
+
+    @Nested
+    @DisplayName("Format case name from lists of Party")
+    class FormatFromListOfPartyTests {
+
+        @Test
+        void shouldFormatCaseNameWhenClaimantIsOrgAndDefendantIsKnown() {
+            // Given
+            when(claimantParty.getOrgName()).thenReturn(CLAIMANT_ORGANISATION_NAME);
+            when(defendantParty.getNameKnown()).thenReturn(YES);
+            when(defendantParty.getLastName()).thenReturn(DEFENDANT_LAST_NAME);
+
+            // When
+            String caseName = underTest.formatCaseName(List.of(claimantParty), List.of(defendantParty));
+
+            // Then
+            assertThat(caseName).isEqualTo("Treetops Housing vs Jackson");
+        }
+
+        @Test
+        void shouldFormatCaseNameWhenClaimantIsCitizenAndDefendantIsKnown() {
+            //Given
+            when(claimantParty.getLastName()).thenReturn(CLAIMANT_NAME);
+            when(defendantParty.getNameKnown()).thenReturn(YES);
+            when(defendantParty.getLastName()).thenReturn(DEFENDANT_LAST_NAME);
+
+            //When
+            String caseName = underTest.formatCaseName(List.of(claimantParty), List.of(defendantParty));
+
+            // Then
+            assertThat(caseName).isEqualTo("Freeman vs Jackson");
+        }
+
+        @Test
+        void shouldFormatCaseNameWhenClaimantIsOrgAndMultipleDefendants() {
+            //Given
+            when(claimantParty.getOrgName()).thenReturn(CLAIMANT_ORGANISATION_NAME);
+            when(defendantParty.getNameKnown()).thenReturn(YES);
+            when(defendantParty.getLastName()).thenReturn(DEFENDANT_LAST_NAME);
+
+            //When
+            String caseName = underTest.formatCaseName(List.of(claimantParty), List.of(defendantParty, defendantParty));
+
+            // Then
+            assertThat(caseName).isEqualTo("Treetops Housing vs Jackson and Others");
+        }
+
+        @Test
+        void shouldFormatCaseNameWhenClaimantIsCitizenAndDefendantUnknown() {
+            //Given
+            when(claimantParty.getLastName()).thenReturn(CLAIMANT_NAME);
+            when(defendantParty.getNameKnown()).thenReturn(NO);
+
+            //When
+            String caseName = underTest.formatCaseName(List.of(claimantParty), List.of(defendantParty, defendantParty));
+
+            // Then
+            assertThat(caseName).isEqualTo("Freeman vs persons unknown");
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/globalsearch/CaseFieldsViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/globalsearch/CaseFieldsViewTest.java
@@ -1,140 +1,56 @@
 package uk.gov.hmcts.reform.pcs.ccd.view.globalsearch;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo.NO;
-import static uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo.YES;
-
-import uk.gov.hmcts.ccd.sdk.type.CaseLocation;
-import uk.gov.hmcts.ccd.sdk.type.DynamicList;
-import uk.gov.hmcts.ccd.sdk.type.ListValue;
-import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
-import uk.gov.hmcts.reform.pcs.ccd.domain.Party;
-
-import java.util.List;
-
-import org.mockito.ArgumentCaptor;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.hmcts.ccd.sdk.type.CaseLocation;
+import uk.gov.hmcts.ccd.sdk.type.DynamicList;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.service.CaseNameFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CaseFieldsViewTest {
 
-    private static final String CLAIMANT_NAME = "Freeman";
-    private static final String DEFENDANT_LAST_NAME = "Jackson";
-    private static final String CLAIMANT_ORGANISATION_NAME = "Treetops Housing";
     private static final int CASE_MANAGEMENT_LOCATION_NUMBER = 29096;
 
     @Mock
     private PCSCase pcsCase;
+    @Mock
+    private CaseNameFormatter caseNameFormatter;
+
     private CaseFieldsView underTest;
-
-    @Mock
-    private ListValue<Party> defendantPartyListValue;
-
-    @Mock
-    private ListValue<Party> claimantListValue;
-
-    @Mock
-    private Party defendantParty;
-
-    @Mock
-    private Party claimantParty;
 
     @BeforeEach
     void setUp() {
-        underTest = new CaseFieldsView();
+        underTest = new CaseFieldsView(caseNameFormatter);
         ReflectionTestUtils.setField(underTest, "caseManagementCategory", "Property Possession Claims");
     }
 
-
     @Test
-    void shouldSetCaseNameWhenClaimantIsOrgAndDefendantIsKnown() {
-        //Given
-        when(pcsCase.getAllClaimants()).thenReturn(List.of(claimantListValue));
-        when(pcsCase.getAllDefendants()).thenReturn(List.of(defendantPartyListValue));
-        when(defendantPartyListValue.getValue()).thenReturn(defendantParty);
-        when(claimantListValue.getValue()).thenReturn(claimantParty);
-        when(claimantParty.getOrgName()).thenReturn(CLAIMANT_ORGANISATION_NAME);
-        when(defendantParty.getNameKnown()).thenReturn(YES);
-        when(defendantParty.getLastName()).thenReturn(DEFENDANT_LAST_NAME);
+    void shouldSetCaseName() {
+        // Given
+        String expectedCaseName = "formatted case name";
+        when(caseNameFormatter.formatCaseName(pcsCase)).thenReturn(expectedCaseName);
 
         //When
         underTest.setCaseFields(pcsCase);
 
         // Then
-        verify(pcsCase).setCaseNameHmctsRestricted("Treetops Housing vs Jackson");
-        verify(pcsCase).setCaseNameHmctsInternal("Treetops Housing vs Jackson");
-        verify(pcsCase).setCaseNamePublic("Treetops Housing vs Jackson");
-    }
-
-    @Test
-    void shouldSetCaseNameWhenClaimantIsCitizenAndDefendantIsKnown() {
-        //Given
-        when(pcsCase.getAllClaimants()).thenReturn(List.of(claimantListValue));
-        when(pcsCase.getAllDefendants()).thenReturn(List.of(defendantPartyListValue));
-        when(defendantPartyListValue.getValue()).thenReturn(defendantParty);
-        when(claimantListValue.getValue()).thenReturn(claimantParty);
-        when(claimantParty.getLastName()).thenReturn(CLAIMANT_NAME);
-        when(defendantParty.getNameKnown()).thenReturn(YES);
-        when(defendantParty.getLastName()).thenReturn(DEFENDANT_LAST_NAME);
-
-        //When
-        underTest.setCaseFields(pcsCase);
-
-        // Then
-        verify(pcsCase).setCaseNameHmctsRestricted("Freeman vs Jackson");
-        verify(pcsCase).setCaseNameHmctsInternal("Freeman vs Jackson");
-        verify(pcsCase).setCaseNamePublic("Freeman vs Jackson");
-    }
-
-    @Test
-    void shouldSetCaseNameWhenClaimantIsOrgAndMultipleDefendants() {
-        //Given
-        when(pcsCase.getAllClaimants()).thenReturn(List.of(claimantListValue));
-        when(pcsCase.getAllDefendants()).thenReturn(List.of(defendantPartyListValue, defendantPartyListValue));
-        when(defendantPartyListValue.getValue()).thenReturn(defendantParty);
-        when(claimantListValue.getValue()).thenReturn(claimantParty);
-        when(claimantParty.getOrgName()).thenReturn(CLAIMANT_ORGANISATION_NAME);
-        when(defendantParty.getNameKnown()).thenReturn(YES);
-        when(defendantParty.getLastName()).thenReturn(DEFENDANT_LAST_NAME);
-
-        //When
-        underTest.setCaseFields(pcsCase);
-
-        // Then
-        verify(pcsCase).setCaseNameHmctsRestricted("Treetops Housing vs Jackson and Others");
-        verify(pcsCase).setCaseNameHmctsInternal("Treetops Housing vs Jackson and Others");
-        verify(pcsCase).setCaseNamePublic("Treetops Housing vs Jackson and Others");
-    }
-
-    @Test
-    void shouldSetCaseNameWhenClaimantIsCitizenAndDefendantUnkown() {
-        //Given
-        when(pcsCase.getAllClaimants()).thenReturn(List.of(claimantListValue));
-        when(pcsCase.getAllDefendants()).thenReturn(List.of(defendantPartyListValue));
-        when(claimantListValue.getValue()).thenReturn(claimantParty);
-        when(defendantPartyListValue.getValue()).thenReturn(defendantParty);
-        when(claimantParty.getLastName()).thenReturn(CLAIMANT_NAME);
-        when(defendantParty.getNameKnown()).thenReturn(NO);
-
-        //When
-        underTest.setCaseFields(pcsCase);
-
-        // Then
-        verify(pcsCase).setCaseNameHmctsRestricted("Freeman vs persons unknown");
-        verify(pcsCase).setCaseNameHmctsInternal("Freeman vs persons unknown");
-        verify(pcsCase).setCaseNamePublic("Freeman vs persons unknown");
+        verify(pcsCase).setCaseNameHmctsRestricted(expectedCaseName);
+        verify(pcsCase).setCaseNameHmctsInternal(expectedCaseName);
+        verify(pcsCase).setCaseNamePublic(expectedCaseName);
     }
 
     @Test


### PR DESCRIPTION
### Jira link

See [HDPI-5438](https://tools.hmcts.net/jira/browse/HDPI-5438)

### Change description

Extract the case name formatter logic from the global search code to make it available to other services that need it, specifically the gen apps document generation for this ticket.

### Testing done

Full build run with e2e tests.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
