### PR TITLE
HDPI-5407: Sectional CYA (BE)

### DIFF
--- a/src/functionalTest/resources/responses/dashboardView-startEventCallbackResponse.json
+++ b/src/functionalTest/resources/responses/dashboardView-startEventCallbackResponse.json
@@ -62,20 +62,44 @@
             "tasks": [
               {
                 "value": {
-                  "templateId": "Defendant.RespondToClaim",
-                  "status": "NOT_STARTED"
+                  "templateId": "Defendant.RTC.StartNowAndDetails",
+                  "status": "AVAILABLE"
                 }
               },
               {
                 "value": {
-                  "templateId": "Defendant.ReviewResponse",
-                  "status": "IN_PROGRESS"
+                  "templateId": "Defendant.RTC.PersonalDetails",
+                  "status": "AVAILABLE"
                 }
               },
               {
                 "value": {
-                  "templateId": "Defendant.SubmitResponse",
-                  "status": "COMPLETED"
+                  "templateId": "Defendant.RTC.DisputeAndTenancy",
+                  "status": "AVAILABLE"
+                }
+              },
+              {
+                "value": {
+                  "templateId": "Defendant.RTC.SituationAndCircumstances",
+                  "status": "AVAILABLE"
+                }
+              },
+              {
+                "value": {
+                  "templateId": "Defendant.RTC.IncomeAndExpenditure",
+                  "status": "AVAILABLE"
+                }
+              },
+              {
+                "value": {
+                  "templateId": "Defendant.RTC.UploadFiles",
+                  "status": "AVAILABLE"
+                }
+              },
+              {
+                "value": {
+                  "templateId": "Defendant.RTC.CheckYourAnswersAndSubmit",
+                  "status": "NOT_AVAILABLE"
                 }
               }
             ]

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/respondpossessionclaim/DefendantResponses.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/respondpossessionclaim/DefendantResponses.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.ccd.sdk.api.CCD;
 import uk.gov.hmcts.ccd.sdk.type.FieldType;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.CitizenAccess;
 import uk.gov.hmcts.reform.pcs.ccd.annotation.JacksonMoneyGBP;
 import uk.gov.hmcts.reform.pcs.ccd.domain.LanguageUsed;
@@ -15,6 +16,7 @@ import uk.gov.hmcts.reform.pcs.ccd.domain.YesNoPreferNotToSay;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 
 
 @Builder
@@ -110,4 +112,11 @@ public class DefendantResponses {
 
     @CCD(max = 6400)
     private String otherConsiderationsDetails;
+
+    @CCD(
+        access = {CitizenAccess.class},
+        typeOverride = FieldType.Collection,
+        typeParameterOverride = "SectionStatusEntry"
+    )
+    private List<ListValue<SectionStatusEntry>> sectionStatuses;
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/respondpossessionclaim/SectionStatusEntry.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/respondpossessionclaim/SectionStatusEntry.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.pcs.ccd.domain.respondpossessionclaim;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.ccd.sdk.api.CCD;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SectionStatusEntry {
+
+    @CCD
+    private String sectionId;
+
+    @CCD
+    private String status;
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/DashboardContext.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/DashboardContext.java
@@ -1,11 +1,9 @@
 package uk.gov.hmcts.reform.pcs.ccd.service.dashboard;
 
-import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
-import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 
 
 public record DashboardContext(
     long caseReference,
-    PcsCaseEntity caseEntity,
-    PartyEntity defendant
+    PCSCase submittedCaseData
 ) {}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/DashboardJourneyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/DashboardJourneyService.java
@@ -1,17 +1,16 @@
 package uk.gov.hmcts.reform.pcs.ccd.service.dashboard;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.DashboardData;
 import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.DashboardNotification;
-import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.Task;
 import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.TaskGroup;
-import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.TaskGroupId;
-import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.TaskStatus;
 import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.TemplateValue;
 import uk.gov.hmcts.reform.pcs.ccd.service.dashboard.task.ClaimTaskGroupEvaluator;
+import uk.gov.hmcts.reform.pcs.ccd.service.dashboard.task.ResponseTaskGroupEvaluator;
 import uk.gov.hmcts.reform.pcs.ccd.util.ListValueUtils;
 
 import java.util.List;
@@ -26,15 +25,19 @@ import java.util.Map;
 public class DashboardJourneyService {
 
     private final ClaimTaskGroupEvaluator claimTaskGroupEvaluator;
+    private final ResponseTaskGroupEvaluator responseTaskGroupEvaluator;
 
-    public DashboardJourneyService(ClaimTaskGroupEvaluator claimTaskGroupEvaluator) {
+    @Autowired
+    public DashboardJourneyService(ClaimTaskGroupEvaluator claimTaskGroupEvaluator,
+                                   ResponseTaskGroupEvaluator responseTaskGroupEvaluator) {
         this.claimTaskGroupEvaluator = claimTaskGroupEvaluator;
+        this.responseTaskGroupEvaluator = responseTaskGroupEvaluator;
     }
 
 
     public DashboardData computeDashboardData(long caseReference, PCSCase submittedCaseData) {
         List<ListValue<DashboardNotification>> notifications = computeNotifications();
-        List<ListValue<TaskGroup>> taskGroups = computeTaskGroups();
+        List<ListValue<TaskGroup>> taskGroups = computeTaskGroups(caseReference, submittedCaseData);
 
         log.info("DashboardJourneyService computed {} notification(s) and {} taskGroup(s) for case={}",
                  notifications.size(), taskGroups.size(), caseReference);
@@ -65,27 +68,12 @@ public class DashboardJourneyService {
         ));
     }
 
-    private List<ListValue<TaskGroup>> computeTaskGroups() {
-        return ListValueUtils.wrapListItems(List.of(
-            claimTaskGroupEvaluator.evaluate(null),
+    private List<ListValue<TaskGroup>> computeTaskGroups(long caseReference, PCSCase submittedCaseData) {
+        DashboardContext context = new DashboardContext(caseReference, submittedCaseData);
 
-            TaskGroup.builder()
-                .groupId(TaskGroupId.RESPONSE)
-                .tasks(ListValueUtils.wrapListItems(List.of(
-                    Task.builder()
-                        .templateId("Defendant.RespondToClaim")
-                        .status(TaskStatus.NOT_STARTED)
-                        .build(),
-                    Task.builder()
-                        .templateId("Defendant.ReviewResponse")
-                        .status(TaskStatus.IN_PROGRESS)
-                        .build(),
-                    Task.builder()
-                        .templateId("Defendant.SubmitResponse")
-                        .status(TaskStatus.COMPLETED)
-                        .build()
-                )))
-                .build()
+        return ListValueUtils.wrapListItems(List.of(
+            claimTaskGroupEvaluator.evaluate(context),
+            responseTaskGroupEvaluator.evaluate(context)
         ));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/task/RespondToClaimSection.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/task/RespondToClaimSection.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.reform.pcs.ccd.service.dashboard.task;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public enum RespondToClaimSection {
+    START_NOW_AND_DETAILS("startNowAndDetails", "Defendant.RTC.StartNowAndDetails", false),
+    PERSONAL_DETAILS("personalDetails", "Defendant.RTC.PersonalDetails", false),
+    DISPUTE_AND_TENANCY("disputeAndTenancy", "Defendant.RTC.DisputeAndTenancy", false),
+    PAYMENTS("payments", "Defendant.RTC.Payments", true),
+    SITUATION_AND_CIRCUMSTANCES("situationAndCircumstances", "Defendant.RTC.SituationAndCircumstances", false),
+    INCOME_AND_EXPENDITURE("incomeAndExpenditure", "Defendant.RTC.IncomeAndExpenditure", false),
+    UPLOAD_FILES("uploadFiles", "Defendant.RTC.UploadFiles", false);
+
+    private final String sectionId;
+    private final String templateId;
+    private final boolean rentArrearsOnly;
+
+    RespondToClaimSection(String sectionId, String templateId, boolean rentArrearsOnly) {
+        this.sectionId = sectionId;
+        this.templateId = templateId;
+        this.rentArrearsOnly = rentArrearsOnly;
+    }
+
+    public String sectionId() {
+        return sectionId;
+    }
+
+    public String templateId() {
+        return templateId;
+    }
+
+    public boolean isApplicable(boolean paymentsApplicable) {
+        return !rentArrearsOnly || paymentsApplicable;
+    }
+
+    public static Optional<RespondToClaimSection> fromSectionId(String rawSectionId) {
+        if (rawSectionId == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(values())
+            .filter(v -> v.sectionId.equals(rawSectionId))
+            .findFirst();
+    }
+
+    public static List<RespondToClaimSection> applicableInOrder(boolean paymentsApplicable) {
+        return Arrays.stream(values())
+            .filter(section -> section.isApplicable(paymentsApplicable))
+            .toList();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/task/ResponseTaskGroupEvaluator.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/task/ResponseTaskGroupEvaluator.java
@@ -1,0 +1,166 @@
+package uk.gov.hmcts.reform.pcs.ccd.service.dashboard.task;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.Task;
+import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.TaskGroup;
+import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.TaskGroupId;
+import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.TaskStatus;
+import uk.gov.hmcts.reform.pcs.ccd.domain.grounds.ClaimGroundSummary;
+import uk.gov.hmcts.reform.pcs.ccd.domain.respondpossessionclaim.DefendantResponses;
+import uk.gov.hmcts.reform.pcs.ccd.domain.respondpossessionclaim.PossessionClaimResponse;
+import uk.gov.hmcts.reform.pcs.ccd.domain.respondpossessionclaim.SectionStatusEntry;
+import uk.gov.hmcts.reform.pcs.ccd.repository.DefendantResponseRepository;
+import uk.gov.hmcts.reform.pcs.ccd.service.DraftCaseDataService;
+import uk.gov.hmcts.reform.pcs.ccd.service.dashboard.DashboardContext;
+import uk.gov.hmcts.reform.pcs.ccd.util.ListValueUtils;
+import uk.gov.hmcts.reform.pcs.security.SecurityContextService;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static uk.gov.hmcts.reform.pcs.ccd.event.EventId.respondPossessionClaim;
+
+@Component
+public class ResponseTaskGroupEvaluator implements TaskGroupEvaluator {
+
+    private static final String TASK_CHECK_YOUR_ANSWERS_AND_SUBMIT = "Defendant.RTC.CheckYourAnswersAndSubmit";
+
+    private final DraftCaseDataService draftCaseDataService;
+    private final DefendantResponseRepository defendantResponseRepository;
+    private final SecurityContextService securityContextService;
+
+    public ResponseTaskGroupEvaluator(DraftCaseDataService draftCaseDataService,
+                                      DefendantResponseRepository defendantResponseRepository,
+                                      SecurityContextService securityContextService) {
+        this.draftCaseDataService = draftCaseDataService;
+        this.defendantResponseRepository = defendantResponseRepository;
+        this.securityContextService = securityContextService;
+    }
+
+    @Override
+    public TaskGroupId groupId() {
+        return TaskGroupId.RESPONSE;
+    }
+
+    @Override
+    public TaskGroup evaluate(DashboardContext ctx) {
+        long caseReference = ctx.caseReference();
+        boolean responseSubmitted = hasSubmittedDefendantResponse(caseReference);
+        boolean paymentsApplicable = isPaymentsSectionApplicable(ctx.submittedCaseData());
+        Map<RespondToClaimSection, SectionStatus> sectionStatuses = getSectionStatuses(caseReference);
+
+        List<Task> sectionTasks = RespondToClaimSection.applicableInOrder(paymentsApplicable)
+            .stream()
+            .map(section -> sectionTask(section, sectionStatuses, responseSubmitted))
+            .collect(Collectors.toCollection(ArrayList::new));
+
+        boolean allSectionsDone = allSectionsCompleted(sectionStatuses, paymentsApplicable);
+        TaskStatus checkYourAnswersStatus = allSectionsDone || responseSubmitted
+            ? TaskStatus.AVAILABLE
+            : TaskStatus.NOT_AVAILABLE;
+
+        sectionTasks.add(Task.builder()
+            .templateId(TASK_CHECK_YOUR_ANSWERS_AND_SUBMIT)
+            .status(checkYourAnswersStatus)
+            .build());
+
+        return TaskGroup.builder()
+            .groupId(TaskGroupId.RESPONSE)
+            .tasks(ListValueUtils.wrapListItems(sectionTasks))
+            .build();
+    }
+
+    private Task sectionTask(RespondToClaimSection section,
+                             Map<RespondToClaimSection, SectionStatus> sectionStatuses,
+                             boolean responseSubmitted) {
+        TaskStatus status = responseSubmitted
+            ? TaskStatus.COMPLETED
+            : toTaskStatus(sectionStatuses.get(section));
+        return Task.builder()
+            .templateId(section.templateId())
+            .status(status)
+            .build();
+    }
+
+    private boolean allSectionsCompleted(
+        Map<RespondToClaimSection, SectionStatus> sectionStatuses,
+        boolean paymentsApplicable
+    ) {
+        return RespondToClaimSection.applicableInOrder(paymentsApplicable)
+            .stream()
+            .allMatch(section -> sectionStatuses.get(section) == SectionStatus.COMPLETED);
+    }
+
+    private TaskStatus toTaskStatus(SectionStatus status) {
+        if (status == SectionStatus.COMPLETED) {
+            return TaskStatus.COMPLETED;
+        }
+        if (status == SectionStatus.IN_PROGRESS) {
+            return TaskStatus.IN_PROGRESS;
+        }
+        return TaskStatus.AVAILABLE;
+    }
+
+    private Map<RespondToClaimSection, SectionStatus> getSectionStatuses(long caseReference) {
+        return draftCaseDataService.getUnsubmittedCaseData(caseReference, respondPossessionClaim)
+            .map(PCSCase::getPossessionClaimResponse)
+            .map(PossessionClaimResponse::getDefendantResponses)
+            .map(DefendantResponses::getSectionStatuses)
+            .map(this::toSectionStatusMap)
+            .orElse(Map.of());
+    }
+
+    private Map<RespondToClaimSection, SectionStatus> toSectionStatusMap(List<ListValue<SectionStatusEntry>> list) {
+        if (list == null || list.isEmpty()) {
+            return Map.of();
+        }
+        Map<RespondToClaimSection, SectionStatus> map = new EnumMap<>(RespondToClaimSection.class);
+        for (ListValue<SectionStatusEntry> listValue : list) {
+            if (listValue == null || listValue.getValue() == null) {
+                continue;
+            }
+            SectionStatusEntry entry = listValue.getValue();
+            Optional<RespondToClaimSection> section = RespondToClaimSection.fromSectionId(entry.getSectionId());
+            Optional<SectionStatus> status = SectionStatus.from(entry.getStatus());
+            if (section.isPresent() && status.isPresent()) {
+                map.put(section.get(), status.get());
+            }
+        }
+        return map;
+    }
+
+    private boolean isPaymentsSectionApplicable(PCSCase submittedCaseData) {
+        if (submittedCaseData == null) {
+            return false;
+        }
+        return Optional.ofNullable(submittedCaseData.getClaimGroundSummaries())
+            .orElse(List.of())
+            .stream()
+            .map(ListValue::getValue)
+            .anyMatch(this::isRentArrearsGround);
+    }
+
+    private boolean isRentArrearsGround(ClaimGroundSummary ground) {
+        return ground != null && ground.getIsRentArrears() == YesOrNo.YES;
+    }
+
+    private boolean hasSubmittedDefendantResponse(long caseReference) {
+        UUID currentUser = securityContextService.getCurrentUserId();
+        if (currentUser == null) {
+            return false;
+        }
+
+        return defendantResponseRepository.existsByClaimPcsCaseCaseReferenceAndPartyIdamId(
+            caseReference,
+            currentUser
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/task/SectionStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/task/SectionStatus.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.pcs.ccd.service.dashboard.task;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum SectionStatus {
+    IN_PROGRESS,
+    COMPLETED;
+
+    public static Optional<SectionStatus> from(String rawValue) {
+        if (rawValue == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(values())
+            .filter(v -> v.name().equals(rawValue))
+            .findFirst();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/DashboardViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/DashboardViewTest.java
@@ -16,14 +16,17 @@ import uk.gov.hmcts.reform.pcs.ccd.event.dashboard.SubmitDashboardViewHandler;
 import uk.gov.hmcts.reform.pcs.ccd.service.PcsCaseService;
 import uk.gov.hmcts.reform.pcs.ccd.service.dashboard.DashboardJourneyService;
 import uk.gov.hmcts.reform.pcs.ccd.service.dashboard.task.ClaimTaskGroupEvaluator;
+import uk.gov.hmcts.reform.pcs.ccd.service.dashboard.task.ResponseTaskGroupEvaluator;
 import uk.gov.hmcts.reform.pcs.ccd.service.party.DefendantAccessValidator;
 import uk.gov.hmcts.reform.pcs.ccd.util.ListValueUtils;
+import uk.gov.hmcts.reform.pcs.ccd.repository.DefendantResponseRepository;
+import uk.gov.hmcts.reform.pcs.ccd.service.DraftCaseDataService;
 import uk.gov.hmcts.reform.pcs.security.SecurityContextService;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -39,11 +42,20 @@ class DashboardViewTest extends BaseEventTest {
     @Mock
     private SecurityContextService securityContextService;
 
+    @Mock
+    private DraftCaseDataService draftCaseDataService;
+
+    @Mock
+    private DefendantResponseRepository defendantResponseRepository;
+
     private DashboardJourneyService dashboardJourneyService;
 
     @BeforeEach
     void setUp() {
-        dashboardJourneyService = new DashboardJourneyService(new ClaimTaskGroupEvaluator());
+        dashboardJourneyService = new DashboardJourneyService(
+            new ClaimTaskGroupEvaluator(),
+            new ResponseTaskGroupEvaluator(draftCaseDataService, defendantResponseRepository, securityContextService)
+        );
         StartDashboardViewHandler startHandler = new StartDashboardViewHandler(
             pcsCaseService,
             accessValidator,
@@ -61,6 +73,12 @@ class DashboardViewTest extends BaseEventTest {
         PCSCase caseData = PCSCase.builder().propertyAddress(propertyAddress).build();
         PcsCaseEntity caseEntity = PcsCaseEntity.builder().build();
 
+        when(draftCaseDataService.getUnsubmittedCaseData(TEST_CASE_REFERENCE, EventId.respondPossessionClaim))
+            .thenReturn(Optional.empty());
+        when(defendantResponseRepository.existsByClaimPcsCaseCaseReferenceAndPartyIdamId(
+            TEST_CASE_REFERENCE,
+            defendantUserId
+        )).thenReturn(false);
         when(securityContextService.getCurrentUserId()).thenReturn(defendantUserId);
         when(pcsCaseService.loadCase(TEST_CASE_REFERENCE)).thenReturn(caseEntity);
         when(accessValidator.validateAndGetDefendant(caseEntity, defendantUserId))
@@ -75,7 +93,7 @@ class DashboardViewTest extends BaseEventTest {
             .extracting(n -> n.getTemplateId())
             .containsExactly("Defendant.CaseIssued", "Defendant.ResponseToClaim");
         verify(pcsCaseService).loadCase(TEST_CASE_REFERENCE);
-        verify(accessValidator).validateAndGetDefendant(eq(caseEntity), eq(defendantUserId));
+        verify(accessValidator).validateAndGetDefendant(caseEntity, defendantUserId);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/DashboardJourneyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/DashboardJourneyServiceTest.java
@@ -3,27 +3,60 @@ package uk.gov.hmcts.reform.pcs.ccd.service.dashboard;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.ccd.sdk.type.AddressUK;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.DashboardData;
 import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.TaskGroupId;
 import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.TaskStatus;
+import uk.gov.hmcts.reform.pcs.ccd.domain.grounds.ClaimGroundSummary;
+import uk.gov.hmcts.reform.pcs.ccd.domain.respondpossessionclaim.DefendantResponses;
+import uk.gov.hmcts.reform.pcs.ccd.domain.respondpossessionclaim.PossessionClaimResponse;
+import uk.gov.hmcts.reform.pcs.ccd.domain.respondpossessionclaim.SectionStatusEntry;
+import uk.gov.hmcts.reform.pcs.ccd.repository.DefendantResponseRepository;
+import uk.gov.hmcts.reform.pcs.ccd.service.DraftCaseDataService;
 import uk.gov.hmcts.reform.pcs.ccd.service.dashboard.task.ClaimTaskGroupEvaluator;
+import uk.gov.hmcts.reform.pcs.ccd.service.dashboard.task.ResponseTaskGroupEvaluator;
 import uk.gov.hmcts.reform.pcs.ccd.util.ListValueUtils;
+import uk.gov.hmcts.reform.pcs.security.SecurityContextService;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.pcs.ccd.event.EventId.respondPossessionClaim;
 
 class DashboardJourneyServiceTest {
 
     private static final long CASE_REFERENCE = 99_887_766L;
 
     private DashboardJourneyService underTest;
+    private DraftCaseDataService draftCaseDataService;
+    private DefendantResponseRepository defendantResponseRepository;
+    private SecurityContextService securityContextService;
 
     @BeforeEach
     void setUp() {
-        underTest = new DashboardJourneyService(new ClaimTaskGroupEvaluator());
+        draftCaseDataService = mock(DraftCaseDataService.class);
+        defendantResponseRepository = mock(DefendantResponseRepository.class);
+        securityContextService = mock(SecurityContextService.class);
+        when(draftCaseDataService.getUnsubmittedCaseData(CASE_REFERENCE, respondPossessionClaim))
+            .thenReturn(Optional.empty());
+        when(securityContextService.getCurrentUserId()).thenReturn(UUID.randomUUID());
+        when(defendantResponseRepository.existsByClaimPcsCaseCaseReferenceAndPartyIdamId(
+            org.mockito.ArgumentMatchers.eq(CASE_REFERENCE),
+            org.mockito.ArgumentMatchers.any(UUID.class)
+        )).thenReturn(false);
+
+        underTest = new DashboardJourneyService(
+            new ClaimTaskGroupEvaluator(),
+            new ResponseTaskGroupEvaluator(draftCaseDataService, defendantResponseRepository, securityContextService)
+        );
     }
 
     @Test
@@ -70,7 +103,7 @@ class DashboardJourneyServiceTest {
             .extracting(g -> g.getGroupId(), g -> g.getTasks().size())
             .containsExactly(
                 tuple(TaskGroupId.CLAIM, 2),
-                tuple(TaskGroupId.RESPONSE, 3)
+                tuple(TaskGroupId.RESPONSE, 7)
             );
 
         assertThat(ListValueUtils.unwrapListItems(result.getTaskGroups()).getFirst().getTasks())
@@ -83,9 +116,157 @@ class DashboardJourneyServiceTest {
         assertThat(ListValueUtils.unwrapListItems(result.getTaskGroups()).get(1).getTasks())
             .extracting(lv -> lv.getValue().getTemplateId(), lv -> lv.getValue().getStatus())
             .containsExactly(
-                tuple("Defendant.RespondToClaim", TaskStatus.NOT_STARTED),
-                tuple("Defendant.ReviewResponse", TaskStatus.IN_PROGRESS),
-                tuple("Defendant.SubmitResponse", TaskStatus.COMPLETED)
+                tuple("Defendant.RTC.StartNowAndDetails", TaskStatus.AVAILABLE),
+                tuple("Defendant.RTC.PersonalDetails", TaskStatus.AVAILABLE),
+                tuple("Defendant.RTC.DisputeAndTenancy", TaskStatus.AVAILABLE),
+                tuple("Defendant.RTC.SituationAndCircumstances", TaskStatus.AVAILABLE),
+                tuple("Defendant.RTC.IncomeAndExpenditure", TaskStatus.AVAILABLE),
+                tuple("Defendant.RTC.UploadFiles", TaskStatus.AVAILABLE),
+                tuple("Defendant.RTC.CheckYourAnswersAndSubmit", TaskStatus.NOT_AVAILABLE)
+            );
+    }
+
+    @Test
+    void shouldMarkSectionInProgressWhenDraftSectionStatusExists() {
+        DraftCaseDataService draftCaseDataService = mock(DraftCaseDataService.class);
+        DefendantResponseRepository defendantResponseRepository = mock(DefendantResponseRepository.class);
+        SecurityContextService securityContextService = mock(SecurityContextService.class);
+
+        when(draftCaseDataService.getUnsubmittedCaseData(CASE_REFERENCE, respondPossessionClaim))
+            .thenReturn(Optional.of(draftWithSectionStatuses(Map.of("payments", "IN_PROGRESS"))));
+        when(securityContextService.getCurrentUserId()).thenReturn(UUID.randomUUID());
+        when(defendantResponseRepository.existsByClaimPcsCaseCaseReferenceAndPartyIdamId(
+            org.mockito.ArgumentMatchers.eq(CASE_REFERENCE),
+            org.mockito.ArgumentMatchers.any(UUID.class)
+        )).thenReturn(false);
+
+        DashboardJourneyService service = new DashboardJourneyService(
+            new ClaimTaskGroupEvaluator(),
+            new ResponseTaskGroupEvaluator(draftCaseDataService, defendantResponseRepository, securityContextService)
+        );
+
+        DashboardData result = service.computeDashboardData(CASE_REFERENCE, rentArrearsCase());
+
+        assertThat(ListValueUtils.unwrapListItems(result.getTaskGroups()).get(1).getTasks())
+            .extracting(lv -> lv.getValue().getTemplateId(), lv -> lv.getValue().getStatus())
+            .containsExactly(
+                tuple("Defendant.RTC.StartNowAndDetails", TaskStatus.AVAILABLE),
+                tuple("Defendant.RTC.PersonalDetails", TaskStatus.AVAILABLE),
+                tuple("Defendant.RTC.DisputeAndTenancy", TaskStatus.AVAILABLE),
+                tuple("Defendant.RTC.Payments", TaskStatus.IN_PROGRESS),
+                tuple("Defendant.RTC.SituationAndCircumstances", TaskStatus.AVAILABLE),
+                tuple("Defendant.RTC.IncomeAndExpenditure", TaskStatus.AVAILABLE),
+                tuple("Defendant.RTC.UploadFiles", TaskStatus.AVAILABLE),
+                tuple("Defendant.RTC.CheckYourAnswersAndSubmit", TaskStatus.NOT_AVAILABLE)
+            );
+    }
+
+    @Test
+    void shouldMakeCheckYourAnswersAvailableWhenAllApplicableSectionsCompleted() {
+        DraftCaseDataService draftCaseDataService = mock(DraftCaseDataService.class);
+        DefendantResponseRepository defendantResponseRepository = mock(DefendantResponseRepository.class);
+        SecurityContextService securityContextService = mock(SecurityContextService.class);
+
+        when(draftCaseDataService.getUnsubmittedCaseData(CASE_REFERENCE, respondPossessionClaim))
+            .thenReturn(Optional.of(draftWithSectionStatuses(Map.of(
+                "startNowAndDetails", "COMPLETED",
+                "personalDetails", "COMPLETED",
+                "disputeAndTenancy", "COMPLETED",
+                "payments", "COMPLETED",
+                "situationAndCircumstances", "COMPLETED",
+                "incomeAndExpenditure", "COMPLETED",
+                "uploadFiles", "COMPLETED"
+            ))));
+        when(securityContextService.getCurrentUserId()).thenReturn(UUID.randomUUID());
+
+        DashboardJourneyService service = new DashboardJourneyService(
+            new ClaimTaskGroupEvaluator(),
+            new ResponseTaskGroupEvaluator(draftCaseDataService, defendantResponseRepository, securityContextService)
+        );
+
+        DashboardData result = service.computeDashboardData(CASE_REFERENCE, rentArrearsCase());
+
+        assertThat(ListValueUtils.unwrapListItems(result.getTaskGroups()).get(1).getTasks())
+            .extracting(lv -> lv.getValue().getTemplateId(), lv -> lv.getValue().getStatus())
+            .containsExactly(
+                tuple("Defendant.RTC.StartNowAndDetails", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.PersonalDetails", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.DisputeAndTenancy", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.Payments", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.SituationAndCircumstances", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.IncomeAndExpenditure", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.UploadFiles", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.CheckYourAnswersAndSubmit", TaskStatus.AVAILABLE)
+            );
+    }
+
+    @Test
+    void shouldIgnorePaymentsSectionForNonRentArrearsClaims() {
+        DraftCaseDataService draftCaseDataService = mock(DraftCaseDataService.class);
+        DefendantResponseRepository defendantResponseRepository = mock(DefendantResponseRepository.class);
+        SecurityContextService securityContextService = mock(SecurityContextService.class);
+
+        when(draftCaseDataService.getUnsubmittedCaseData(CASE_REFERENCE, respondPossessionClaim))
+            .thenReturn(Optional.of(draftWithSectionStatuses(Map.of(
+                "startNowAndDetails", "COMPLETED",
+                "personalDetails", "COMPLETED",
+                "disputeAndTenancy", "COMPLETED",
+                "situationAndCircumstances", "COMPLETED",
+                "incomeAndExpenditure", "COMPLETED",
+                "uploadFiles", "COMPLETED"
+            ))));
+        when(securityContextService.getCurrentUserId()).thenReturn(UUID.randomUUID());
+
+        DashboardJourneyService service = new DashboardJourneyService(
+            new ClaimTaskGroupEvaluator(),
+            new ResponseTaskGroupEvaluator(draftCaseDataService, defendantResponseRepository, securityContextService)
+        );
+
+        DashboardData result = service.computeDashboardData(CASE_REFERENCE, nonRentArrearsCase());
+
+        assertThat(ListValueUtils.unwrapListItems(result.getTaskGroups()).get(1).getTasks())
+            .extracting(lv -> lv.getValue().getTemplateId(), lv -> lv.getValue().getStatus())
+            .containsExactly(
+                tuple("Defendant.RTC.StartNowAndDetails", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.PersonalDetails", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.DisputeAndTenancy", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.SituationAndCircumstances", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.IncomeAndExpenditure", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.UploadFiles", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.CheckYourAnswersAndSubmit", TaskStatus.AVAILABLE)
+            );
+    }
+
+    @Test
+    void shouldMarkResponseTasksCompletedWhenSubmittedResponseExists() {
+        DraftCaseDataService draftCaseDataService = mock(DraftCaseDataService.class);
+        DefendantResponseRepository defendantResponseRepository = mock(DefendantResponseRepository.class);
+        SecurityContextService securityContextService = mock(SecurityContextService.class);
+        UUID userId = UUID.randomUUID();
+
+        when(draftCaseDataService.getUnsubmittedCaseData(CASE_REFERENCE, respondPossessionClaim))
+            .thenReturn(Optional.of(draftWithSectionStatuses(Map.of())));
+        when(securityContextService.getCurrentUserId()).thenReturn(userId);
+        when(defendantResponseRepository.existsByClaimPcsCaseCaseReferenceAndPartyIdamId(CASE_REFERENCE, userId))
+            .thenReturn(true);
+
+        DashboardJourneyService service = new DashboardJourneyService(
+            new ClaimTaskGroupEvaluator(),
+            new ResponseTaskGroupEvaluator(draftCaseDataService, defendantResponseRepository, securityContextService)
+        );
+
+        DashboardData result = service.computeDashboardData(CASE_REFERENCE, PCSCase.builder().build());
+
+        assertThat(ListValueUtils.unwrapListItems(result.getTaskGroups()).get(1).getTasks())
+            .extracting(lv -> lv.getValue().getTemplateId(), lv -> lv.getValue().getStatus())
+            .containsExactly(
+                tuple("Defendant.RTC.StartNowAndDetails", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.PersonalDetails", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.DisputeAndTenancy", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.SituationAndCircumstances", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.IncomeAndExpenditure", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.UploadFiles", TaskStatus.COMPLETED),
+                tuple("Defendant.RTC.CheckYourAnswersAndSubmit", TaskStatus.AVAILABLE)
             );
     }
 
@@ -105,5 +286,44 @@ class DashboardJourneyServiceTest {
             .toList();
 
         assertThat(keysForResponseNotification).containsExactly("ctaLabel");
+    }
+
+    private PCSCase draftWithSectionStatuses(Map<String, String> sectionStatuses) {
+        List<ListValue<SectionStatusEntry>> list = sectionStatuses.entrySet().stream()
+            .map(e -> ListValue.<SectionStatusEntry>builder()
+                .value(SectionStatusEntry.builder()
+                    .sectionId(e.getKey())
+                    .status(e.getValue())
+                    .build())
+                .build())
+            .toList();
+
+        return PCSCase.builder()
+            .possessionClaimResponse(
+                PossessionClaimResponse.builder()
+                    .defendantResponses(
+                        DefendantResponses.builder()
+                            .sectionStatuses(list)
+                            .build()
+                    )
+                    .build()
+            )
+            .build();
+    }
+
+    private PCSCase rentArrearsCase() {
+        return PCSCase.builder()
+            .claimGroundSummaries(List.of(ListValue.<ClaimGroundSummary>builder()
+                .value(ClaimGroundSummary.builder().isRentArrears(YesOrNo.YES).build())
+                .build()))
+            .build();
+    }
+
+    private PCSCase nonRentArrearsCase() {
+        return PCSCase.builder()
+            .claimGroundSummaries(List.of(ListValue.<ClaimGroundSummary>builder()
+                .value(ClaimGroundSummary.builder().isRentArrears(YesOrNo.NO).build())
+                .build()))
+            .build();
     }
 }


### PR DESCRIPTION
### Jira link

See [HDPI-5407](https://tools.hmcts.net/jira/browse/HDPI-5407)

### Change description

This PR moves respond-to-claim dashboard progress from a placeholder response task list to section-based tasks driven by
saved draft data and submitted response state.

- Adds section status persistence in the domain model via `sectionStatuses` on defendant responses, with dedicated
  section/status value types.
- Introduces a response task-group evaluator that:
  - maps draft section statuses to dashboard task statuses (`AVAILABLE`, `IN_PROGRESS`, `COMPLETED`);
  - conditionally includes the payments section only for rent-arrears claims; and
  - controls "Check your answers and submit" availability based on section completion or an existing submitted response.
- Updates dashboard journey wiring/context so the response task-group evaluator receives case reference and submitted case data for status computation.

### Testing done

- Automated unit tests added/updated for the new section-based response task logic:
  - `src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/DashboardJourneyServiceTest.java`
  - `src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/DashboardViewTest.java`
- Functional response fixture updated:
  - `src/functionalTest/resources/responses/dashboardView-startEventCallbackResponse.json`

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
