### PR TITLE
HDPI-6407: Align view building components

### DIFF
--- a/src/e2eTest/data/page-data-figma/checkingNotice.page.data.ts
+++ b/src/e2eTest/data/page-data-figma/checkingNotice.page.data.ts
@@ -3,7 +3,7 @@ export const checkingNotice = {
   mainHeader: `Notice of your intention to begin possession proceedings`,
   youMayHaveAlreadyServedParagraph: `You may have already served the defendants with notice of your intention to begin possession proceedings. Notice periods vary between grounds and some do not require any notice to be served. You should read the guidance on possession notice periods (opens in new tab) to make sure your claim is valid.`,
   guidanceOnPossessionLink: `guidance on possession notice periods (opens in new tab)`,
-  mainHeaderEnglandNewTab: `Understanding the possession action process: A guide for private landlords in England`,
+  mainHeaderEnglandNewTab: `Understanding the possession action process: guidance for landlords and tenants - GOV.UK`,
   mainHeaderWalesNewTab: `Understanding the possession process: guidance for private landlords | GOV.WALES`,
   aJudgeMightNotGrantParagraph: `A judge might not grant a possession order if you have not followed the correct notice procedure`,
   haveYouServedNoticeToQuestion: `Have you served notice to the defendants?`,

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseView.java
@@ -23,7 +23,7 @@ import uk.gov.hmcts.reform.pcs.ccd.view.ClaimView;
 import uk.gov.hmcts.reform.pcs.ccd.view.DocumentsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.HousingActWalesView;
 import uk.gov.hmcts.reform.pcs.ccd.view.NoticeOfPossessionView;
-import uk.gov.hmcts.reform.pcs.ccd.view.PartyView;
+import uk.gov.hmcts.reform.pcs.ccd.view.PartiesView;
 import uk.gov.hmcts.reform.pcs.ccd.view.RentArrearsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.RentDetailsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.StatementOfTruthView;
@@ -51,7 +51,7 @@ public class PCSCaseView implements CaseView<PCSCase, State> {
     private final DraftCaseDataService draftCaseDataService;
     private final CaseTitleService caseTitleService;
     private final ClaimView claimView;
-    private final PartyView partyView;
+    private final PartiesView partiesView;
     private final DocumentsView documentsView;
     private final TenancyLicenceView tenancyLicenceView;
     private final ClaimGroundsView claimGroundsView;
@@ -103,7 +103,7 @@ public class PCSCaseView implements CaseView<PCSCase, State> {
         setDerivedProperties(pcsCase, pcsCaseEntity);
 
         claimView.setCaseFields(pcsCase, pcsCaseEntity);
-        partyView.setCaseFields(pcsCase, pcsCaseEntity);
+        partiesView.setCaseFields(pcsCase, pcsCaseEntity);
         documentsView.setCaseFields(pcsCase, pcsCaseEntity);
         tenancyLicenceView.setCaseFields(pcsCase, pcsCaseEntity);
         claimGroundsView.setCaseFields(pcsCase, pcsCaseEntity);

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseView.java
@@ -6,45 +6,35 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.CaseView;
 import uk.gov.hmcts.ccd.sdk.CaseViewRequest;
 import uk.gov.hmcts.ccd.sdk.type.AddressUK;
-import uk.gov.hmcts.ccd.sdk.type.Document;
-import uk.gov.hmcts.ccd.sdk.type.ListValue;
-import uk.gov.hmcts.ccd.sdk.type.SearchCriteria;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
-import uk.gov.hmcts.reform.pcs.ccd.domain.Party;
 import uk.gov.hmcts.reform.pcs.ccd.domain.State;
-import uk.gov.hmcts.reform.pcs.ccd.enforcementorder.EnforcementOrderMediator;
 import uk.gov.hmcts.reform.pcs.ccd.entity.AddressEntity;
-import uk.gov.hmcts.reform.pcs.ccd.entity.ClaimEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
-import uk.gov.hmcts.reform.pcs.ccd.entity.party.ClaimPartyEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
-import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyRole;
 import uk.gov.hmcts.reform.pcs.ccd.repository.PcsCaseRepository;
 import uk.gov.hmcts.reform.pcs.ccd.service.CaseTitleService;
 import uk.gov.hmcts.reform.pcs.ccd.service.DraftCaseDataService;
-import uk.gov.hmcts.reform.pcs.ccd.util.ListValueUtils;
 import uk.gov.hmcts.reform.pcs.ccd.view.AlternativesToPossessionView;
 import uk.gov.hmcts.reform.pcs.ccd.view.AsbProhibitedConductView;
+import uk.gov.hmcts.reform.pcs.ccd.view.CaseLinkView;
 import uk.gov.hmcts.reform.pcs.ccd.view.ClaimGroundsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.ClaimView;
+import uk.gov.hmcts.reform.pcs.ccd.view.DocumentsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.HousingActWalesView;
 import uk.gov.hmcts.reform.pcs.ccd.view.NoticeOfPossessionView;
+import uk.gov.hmcts.reform.pcs.ccd.view.PartyView;
 import uk.gov.hmcts.reform.pcs.ccd.view.RentArrearsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.RentDetailsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.StatementOfTruthView;
 import uk.gov.hmcts.reform.pcs.ccd.view.TenancyLicenceView;
-import uk.gov.hmcts.reform.pcs.ccd.view.CaseLinkView;
+import uk.gov.hmcts.reform.pcs.ccd.view.enforcementorder.EnforcementOrderView;
 import uk.gov.hmcts.reform.pcs.ccd.view.globalsearch.CaseFieldsView;
 import uk.gov.hmcts.reform.pcs.exception.CaseNotFoundException;
 import uk.gov.hmcts.reform.pcs.security.SecurityContextService;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static uk.gov.hmcts.reform.pcs.ccd.event.EventId.resumePossessionClaim;
 
@@ -61,6 +51,8 @@ public class PCSCaseView implements CaseView<PCSCase, State> {
     private final DraftCaseDataService draftCaseDataService;
     private final CaseTitleService caseTitleService;
     private final ClaimView claimView;
+    private final PartyView partyView;
+    private final DocumentsView documentsView;
     private final TenancyLicenceView tenancyLicenceView;
     private final ClaimGroundsView claimGroundsView;
     private final RentDetailsView rentDetailsView;
@@ -72,7 +64,7 @@ public class PCSCaseView implements CaseView<PCSCase, State> {
     private final StatementOfTruthView statementOfTruthView;
     private final CaseFieldsView caseFieldsView;
     private final CaseLinkView caseLinkView;
-    private final EnforcementOrderMediator enforcementOrderMediator;
+    private final EnforcementOrderView enforcementOrderView;
 
     /**
      * Invoked by CCD to load PCS cases by reference.
@@ -86,12 +78,7 @@ public class PCSCaseView implements CaseView<PCSCase, State> {
         boolean hasUnsubmittedCaseData = caseHasUnsubmittedData(caseReference, state);
 
         setMarkdownFields(pcsCase, hasUnsubmittedCaseData);
-        enforcementOrderMediator.handleEnforcementRequirements(caseReference, pcsCase);
-
         caseFieldsView.setCaseFields(pcsCase);
-
-        //allows indexing for Global Search
-        pcsCase.setSearchCriteria(new SearchCriteria());
 
         return pcsCase;
     }
@@ -107,21 +94,17 @@ public class PCSCaseView implements CaseView<PCSCase, State> {
     private PCSCase getSubmittedCase(long caseReference) {
         PcsCaseEntity pcsCaseEntity = loadCaseData(caseReference);
 
-        Map<PartyRole, List<ListValue<Party>>> partyMap = getPartyMap(pcsCaseEntity);
-
         PCSCase pcsCase = PCSCase.builder()
             .propertyAddress(convertAddress(pcsCaseEntity.getPropertyAddress()))
             .legislativeCountry(pcsCaseEntity.getLegislativeCountry())
             .caseManagementLocationNumber(pcsCaseEntity.getCaseManagementLocation())
-            .allClaimants(partyMap.get(PartyRole.CLAIMANT))
-            .allDefendants(partyMap.get(PartyRole.DEFENDANT))
-            .allUnderlesseeOrMortgagees(partyMap.get(PartyRole.UNDERLESSEE_OR_MORTGAGEE))
-            .allDocuments(mapAndWrapDocuments(pcsCaseEntity))
             .build();
 
         setDerivedProperties(pcsCase, pcsCaseEntity);
 
         claimView.setCaseFields(pcsCase, pcsCaseEntity);
+        partyView.setCaseFields(pcsCase, pcsCaseEntity);
+        documentsView.setCaseFields(pcsCase, pcsCaseEntity);
         tenancyLicenceView.setCaseFields(pcsCase, pcsCaseEntity);
         claimGroundsView.setCaseFields(pcsCase, pcsCaseEntity);
         rentDetailsView.setCaseFields(pcsCase, pcsCaseEntity);
@@ -133,32 +116,9 @@ public class PCSCaseView implements CaseView<PCSCase, State> {
         noticeOfPossessionView.setCaseFields(pcsCase, pcsCaseEntity);
         statementOfTruthView.setCaseFields(pcsCase, pcsCaseEntity);
         caseLinkView.setCaseFields(pcsCase, pcsCaseEntity);
+        enforcementOrderView.setCaseFields(pcsCase, pcsCaseEntity);
 
         return pcsCase;
-    }
-
-    private Map<PartyRole, List<ListValue<Party>>> getPartyMap(PcsCaseEntity pcsCaseEntity) {
-        List<ClaimEntity> claims = pcsCaseEntity.getClaims();
-
-        if (claims.isEmpty()) {
-            return Map.of();
-        }
-
-        ClaimEntity mainClaim = claims.getFirst();
-        return mainClaim.getClaimParties().stream()
-            .collect(Collectors.groupingBy(
-                ClaimPartyEntity::getRole,
-                Collectors.mapping(this::getPartyListValue, Collectors.toList())
-            ));
-    }
-
-    private ListValue<Party> getPartyListValue(ClaimPartyEntity claimPartyEntity) {
-        Party party = modelMapper.map(claimPartyEntity.getParty(), Party.class);
-
-        return ListValue.<Party>builder()
-            .id(claimPartyEntity.getId().getPartyId().toString())
-            .value(party)
-            .build();
     }
 
     private void setDerivedProperties(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
@@ -167,8 +127,6 @@ public class PCSCaseView implements CaseView<PCSCase, State> {
             .orElse(false);
 
         pcsCase.setUserPcqIdSet(YesOrNo.from(pcqIdSet));
-
-        pcsCase.setParties(mapAndWrapParties(pcsCaseEntity.getParties()));
     }
 
     private void setMarkdownFields(PCSCase pcsCase, boolean hasUnsubmittedCaseData) {
@@ -233,28 +191,4 @@ public class PCSCaseView implements CaseView<PCSCase, State> {
             .orElseThrow(() -> new CaseNotFoundException(caseRef));
     }
 
-    private List<ListValue<Party>> mapAndWrapParties(Set<PartyEntity> partyEntities) {
-        return partyEntities.stream()
-            .map(entity -> modelMapper.map(entity, Party.class))
-            .collect(Collectors.collectingAndThen(Collectors.toList(), ListValueUtils::wrapListItems));
-    }
-
-    private List<ListValue<Document>> mapAndWrapDocuments(PcsCaseEntity pcsCaseEntity) {
-
-        if (pcsCaseEntity.getDocuments().isEmpty()) {
-            return List.of();
-        }
-
-        return pcsCaseEntity.getDocuments().stream()
-            .map(entity -> ListValue.<Document>builder()
-                .id(entity.getId().toString())
-                .value(Document.builder()
-                           .filename(entity.getFileName())
-                           .url(entity.getUrl())
-                           .binaryUrl(entity.getBinaryUrl())
-                           .categoryId(entity.getCategoryId())
-                           .build())
-                .build())
-            .collect(Collectors.toList());
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/AlternativesToPossessionView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/AlternativesToPossessionView.java
@@ -14,8 +14,9 @@ import java.util.Optional;
 import static uk.gov.hmcts.reform.pcs.ccd.util.YesOrNoConverter.toVerticalYesNo;
 
 @Component
-public class AlternativesToPossessionView {
+public class AlternativesToPossessionView implements ViewComponent {
 
+    @Override
     public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
         getMainClaim(pcsCaseEntity)
             .map(ClaimEntity::getPossessionAlternativesEntity)

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/AsbProhibitedConductView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/AsbProhibitedConductView.java
@@ -11,8 +11,9 @@ import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 import java.util.Optional;
 
 @Component
-public class AsbProhibitedConductView {
+public class AsbProhibitedConductView implements ViewComponent {
 
+    @Override
     public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
         getMainClaim(pcsCaseEntity)
             .map(ClaimEntity::getAsbProhibitedConductEntity)

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/CaseLinkView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/CaseLinkView.java
@@ -11,11 +11,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
-public class CaseLinkView {
+public class CaseLinkView implements ViewComponent {
 
+    @Override
     public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
         setCaseLinks(pcsCase, pcsCaseEntity);
-
     }
 
     private void setCaseLinks(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/ClaimGroundsView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/ClaimGroundsView.java
@@ -31,10 +31,11 @@ import java.util.Optional;
 import java.util.Set;
 
 @Component
-public class ClaimGroundsView {
+public class ClaimGroundsView implements ViewComponent {
 
     private static final Comparator<ListValue<ClaimGroundSummary>> GROUNDS_COMPARATOR = createGroundsComparator();
 
+    @Override
     public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
         getMainClaim(pcsCaseEntity)
             .ifPresent(mainClaim -> setClaimGroundFields(pcsCase, mainClaim));

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/ClaimView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/ClaimView.java
@@ -11,8 +11,9 @@ import uk.gov.hmcts.reform.pcs.ccd.type.DynamicStringList;
 import uk.gov.hmcts.reform.pcs.ccd.type.DynamicStringListElement;
 
 @Component
-public class ClaimView {
+public class ClaimView implements ViewComponent {
 
+    @Override
     public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
         if (!pcsCaseEntity.getClaims().isEmpty()) {
             ClaimEntity mainClaim = pcsCaseEntity.getClaims().getFirst();

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/DocumentsView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/DocumentsView.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.reform.pcs.ccd.view;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.type.Document;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class DocumentsView implements ViewComponent {
+
+    @Override
+    public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
+        pcsCase.setAllDocuments(mapAndWrapDocuments(pcsCaseEntity));
+    }
+
+    private List<ListValue<Document>> mapAndWrapDocuments(PcsCaseEntity pcsCaseEntity) {
+        if (pcsCaseEntity.getDocuments().isEmpty()) {
+            return List.of();
+        }
+
+        return pcsCaseEntity.getDocuments().stream()
+            .map(entity -> ListValue.<Document>builder()
+                .id(entity.getId().toString())
+                .value(Document.builder()
+                           .filename(entity.getFileName())
+                           .url(entity.getUrl())
+                           .binaryUrl(entity.getBinaryUrl())
+                           .categoryId(entity.getCategoryId())
+                           .build())
+                .build())
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/HousingActWalesView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/HousingActWalesView.java
@@ -10,8 +10,9 @@ import uk.gov.hmcts.reform.pcs.ccd.entity.claim.HousingActWalesEntity;
 import java.util.Optional;
 
 @Component
-public class HousingActWalesView {
+public class HousingActWalesView implements ViewComponent {
 
+    @Override
     public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
         getMainClaim(pcsCaseEntity)
             .map(ClaimEntity::getHousingActWales)

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/NoticeOfPossessionView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/NoticeOfPossessionView.java
@@ -13,8 +13,9 @@ import uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry;
 import java.util.Optional;
 
 @Component
-public class NoticeOfPossessionView {
+public class NoticeOfPossessionView implements ViewComponent {
 
+    @Override
     public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
         getMainClaim(pcsCaseEntity)
             .map(ClaimEntity::getNoticeOfPossession)

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/PartiesView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/PartiesView.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 
 @Component
 @AllArgsConstructor
-public class PartyView implements ViewComponent {
+public class PartiesView implements ViewComponent {
 
     private final ModelMapper modelMapper;
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/PartyView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/PartyView.java
@@ -1,0 +1,67 @@
+package uk.gov.hmcts.reform.pcs.ccd.view;
+
+import lombok.AllArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.domain.Party;
+import uk.gov.hmcts.reform.pcs.ccd.entity.ClaimEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.ClaimPartyEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyRole;
+import uk.gov.hmcts.reform.pcs.ccd.util.ListValueUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@AllArgsConstructor
+public class PartyView implements ViewComponent {
+
+    private final ModelMapper modelMapper;
+
+    @Override
+    public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
+        pcsCase.setParties(mapAndWrapParties(pcsCaseEntity.getParties()));
+
+        Map<PartyRole, List<ListValue<Party>>> partyMap = getPartyMap(pcsCaseEntity);
+        pcsCase.setAllClaimants(partyMap.get(PartyRole.CLAIMANT));
+        pcsCase.setAllDefendants(partyMap.get(PartyRole.DEFENDANT));
+        pcsCase.setAllUnderlesseeOrMortgagees(partyMap.get(PartyRole.UNDERLESSEE_OR_MORTGAGEE));
+    }
+
+    private List<ListValue<Party>> mapAndWrapParties(Set<PartyEntity> partyEntities) {
+        return partyEntities.stream()
+            .map(entity -> modelMapper.map(entity, Party.class))
+            .collect(Collectors.collectingAndThen(Collectors.toList(), ListValueUtils::wrapListItems));
+    }
+
+    private Map<PartyRole, List<ListValue<Party>>> getPartyMap(PcsCaseEntity pcsCaseEntity) {
+        List<ClaimEntity> claims = pcsCaseEntity.getClaims();
+
+        if (claims.isEmpty()) {
+            return Map.of();
+        }
+
+        ClaimEntity mainClaim = claims.getFirst();
+        return mainClaim.getClaimParties().stream()
+            .collect(Collectors.groupingBy(
+                ClaimPartyEntity::getRole,
+                Collectors.mapping(this::getPartyListValue, Collectors.toList())
+            ));
+    }
+
+    private ListValue<Party> getPartyListValue(ClaimPartyEntity claimPartyEntity) {
+        Party party = modelMapper.map(claimPartyEntity.getParty(), Party.class);
+
+        return ListValue.<Party>builder()
+            .id(claimPartyEntity.getId().getPartyId().toString())
+            .value(party)
+            .build();
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/RentArrearsView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/RentArrearsView.java
@@ -15,8 +15,9 @@ import java.util.Optional;
 import java.util.Set;
 
 @Component
-public class RentArrearsView {
+public class RentArrearsView implements ViewComponent {
 
+    @Override
     public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
         getMainClaim(pcsCaseEntity)
             .map(ClaimEntity::getRentArrears)

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/RentDetailsView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/RentDetailsView.java
@@ -7,8 +7,9 @@ import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.TenancyLicenceEntity;
 
 @Component
-public class RentDetailsView {
+public class RentDetailsView implements ViewComponent {
 
+    @Override
     public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
         TenancyLicenceEntity tenancyLicence = pcsCaseEntity.getTenancyLicence();
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/StatementOfTruthView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/StatementOfTruthView.java
@@ -15,8 +15,9 @@ import java.util.List;
 import java.util.Optional;
 
 @Component
-public class StatementOfTruthView {
+public class StatementOfTruthView implements ViewComponent {
 
+    @Override
     public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
         getMainClaim(pcsCaseEntity)
             .map(ClaimEntity::getStatementOfTruth)

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/TenancyLicenceView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/TenancyLicenceView.java
@@ -12,8 +12,9 @@ import uk.gov.hmcts.reform.pcs.ccd.entity.TenancyLicenceEntity;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry;
 
 @Component
-public class TenancyLicenceView {
+public class TenancyLicenceView implements ViewComponent {
 
+    @Override
     public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
         TenancyLicenceEntity tenancyLicence = pcsCaseEntity.getTenancyLicence();
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/ViewComponent.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/ViewComponent.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.pcs.ccd.view;
+
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
+
+public interface ViewComponent {
+
+    void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity);
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/enforcementorder/EnforcementOrderView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/enforcementorder/EnforcementOrderView.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.pcs.ccd.enforcementorder;
+package uk.gov.hmcts.reform.pcs.ccd.view.enforcementorder;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,9 +8,8 @@ import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 import uk.gov.hmcts.reform.pcs.ccd.entity.ClaimEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.enforcetheorder.EnforcementOrderEntity;
-import uk.gov.hmcts.reform.pcs.ccd.repository.PcsCaseRepository;
 import uk.gov.hmcts.reform.pcs.ccd.repository.enforcetheorder.EnforcementOrderRepository;
-import uk.gov.hmcts.reform.pcs.exception.CaseNotFoundException;
+import uk.gov.hmcts.reform.pcs.ccd.view.ViewComponent;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -21,28 +20,26 @@ import java.util.Optional;
 import static uk.gov.hmcts.reform.pcs.ccd.page.enforcetheorder.confirmeviction.MarkupContent.CONFIRM_EVICTION_SUMMARY_NO_DATES;
 import static uk.gov.hmcts.reform.pcs.ccd.page.enforcetheorder.confirmeviction.MarkupContent.CONFIRM_EVICTION_SUMMARY_WITH_DATES;
 
+
 @Component
 @Slf4j
 @AllArgsConstructor
-public class EnforcementOrderMediator {
+public class EnforcementOrderView implements ViewComponent {
 
-    private final PcsCaseRepository pcsCaseRepository;
     private final EnforcementOrderRepository enforcementOrderRepository;
 
-    public void handleEnforcementRequirements(long caseReference, PCSCase pcsCase) {
-        if (caseReference > 0 && pcsCase != null) {
-            getEnforcementOrder(caseReference).ifPresent(enforcementOrderEntity ->
-                Optional.ofNullable(enforcementOrderEntity.getBailiffDate())
-                    .ifPresentOrElse(
-                        date -> prepareEvictionWithDates(pcsCase, date),
-                        () -> prepareEvictionWithNoDates(pcsCase)
-                    ));
-        }
+    @Override
+    public void setCaseFields(PCSCase pcsCase, PcsCaseEntity pcsCaseEntity) {
+        getEnforcementOrder(pcsCaseEntity)
+            .ifPresent(enforcementOrderEntity ->
+                           Optional.ofNullable(enforcementOrderEntity.getBailiffDate())
+                               .ifPresentOrElse(
+                                   date -> prepareEvictionWithDates(pcsCase, date),
+                                   () -> prepareEvictionWithNoDates(pcsCase)
+                               ));
     }
 
-    Optional<EnforcementOrderEntity> getEnforcementOrder(long caseReference) {
-        PcsCaseEntity pcsCaseEntity = pcsCaseRepository.findByCaseReference(caseReference)
-            .orElseThrow(() -> new CaseNotFoundException(caseReference));
+    Optional<EnforcementOrderEntity> getEnforcementOrder(PcsCaseEntity pcsCaseEntity) {
         List<ClaimEntity> claims = pcsCaseEntity.getClaims();
         if (claims != null && !claims.isEmpty()) {
             // At this point we do not know which Enforcement Order the Confirm Eviction is placed against.

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseViewTest.java
@@ -25,7 +25,7 @@ import uk.gov.hmcts.reform.pcs.ccd.view.ClaimView;
 import uk.gov.hmcts.reform.pcs.ccd.view.DocumentsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.HousingActWalesView;
 import uk.gov.hmcts.reform.pcs.ccd.view.NoticeOfPossessionView;
-import uk.gov.hmcts.reform.pcs.ccd.view.PartyView;
+import uk.gov.hmcts.reform.pcs.ccd.view.PartiesView;
 import uk.gov.hmcts.reform.pcs.ccd.view.RentArrearsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.RentDetailsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.StatementOfTruthView;
@@ -67,7 +67,7 @@ class PCSCaseViewTest {
     @Mock
     private ClaimView claimView;
     @Mock
-    private PartyView partyView;
+    private PartiesView partyView;
     @Mock
     private DocumentsView documentsView;
     @Mock

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseViewTest.java
@@ -9,42 +9,35 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import uk.gov.hmcts.ccd.sdk.CaseViewRequest;
 import uk.gov.hmcts.ccd.sdk.type.AddressUK;
-import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
-import uk.gov.hmcts.reform.pcs.ccd.domain.Party;
 import uk.gov.hmcts.reform.pcs.ccd.domain.State;
-import uk.gov.hmcts.reform.pcs.ccd.enforcementorder.EnforcementOrderMediator;
 import uk.gov.hmcts.reform.pcs.ccd.entity.AddressEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.ClaimEntity;
-import uk.gov.hmcts.reform.pcs.ccd.entity.DocumentEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
-import uk.gov.hmcts.reform.pcs.ccd.entity.party.ClaimPartyEntity;
-import uk.gov.hmcts.reform.pcs.ccd.entity.party.ClaimPartyId;
-import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
-import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyRole;
 import uk.gov.hmcts.reform.pcs.ccd.repository.PcsCaseRepository;
 import uk.gov.hmcts.reform.pcs.ccd.service.CaseTitleService;
 import uk.gov.hmcts.reform.pcs.ccd.service.DraftCaseDataService;
 import uk.gov.hmcts.reform.pcs.ccd.view.AlternativesToPossessionView;
 import uk.gov.hmcts.reform.pcs.ccd.view.AsbProhibitedConductView;
+import uk.gov.hmcts.reform.pcs.ccd.view.CaseLinkView;
 import uk.gov.hmcts.reform.pcs.ccd.view.ClaimGroundsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.ClaimView;
+import uk.gov.hmcts.reform.pcs.ccd.view.DocumentsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.HousingActWalesView;
 import uk.gov.hmcts.reform.pcs.ccd.view.NoticeOfPossessionView;
+import uk.gov.hmcts.reform.pcs.ccd.view.PartyView;
 import uk.gov.hmcts.reform.pcs.ccd.view.RentArrearsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.RentDetailsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.StatementOfTruthView;
 import uk.gov.hmcts.reform.pcs.ccd.view.TenancyLicenceView;
+import uk.gov.hmcts.reform.pcs.ccd.view.enforcementorder.EnforcementOrderView;
 import uk.gov.hmcts.reform.pcs.ccd.view.globalsearch.CaseFieldsView;
-import uk.gov.hmcts.reform.pcs.ccd.view.CaseLinkView;
 import uk.gov.hmcts.reform.pcs.exception.CaseNotFoundException;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry;
 import uk.gov.hmcts.reform.pcs.security.SecurityContextService;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -74,6 +67,10 @@ class PCSCaseViewTest {
     @Mock
     private ClaimView claimView;
     @Mock
+    private PartyView partyView;
+    @Mock
+    private DocumentsView documentsView;
+    @Mock
     private TenancyLicenceView tenancyLicenceView;
     @Mock
     private ClaimGroundsView claimGroundsView;
@@ -99,7 +96,7 @@ class PCSCaseViewTest {
     @Mock
     private CaseFieldsView caseFieldsView;
     @Mock
-    private EnforcementOrderMediator enforcementOrderMediator;
+    private EnforcementOrderView enforcementOrderView;
     @Mock
     private CaseLinkView caseLinkView;
 
@@ -111,11 +108,11 @@ class PCSCaseViewTest {
         when(pcsCaseEntity.getClaims()).thenReturn(List.of(claimEntity));
 
         underTest = new PCSCaseView(pcsCaseRepository, securityContextService, modelMapper, draftCaseDataService,
-                                    caseTitleService, claimView, tenancyLicenceView, claimGroundsView, rentDetailsView,
-                                    alternativesToPossessionView, housingActWalesView, asbProhibitedConductView,
-                                    rentArrearsView, noticeOfPossessionView,
-                                    statementOfTruthView, caseFieldsView, caseLinkView, enforcementOrderMediator
-        );
+                                    caseTitleService, claimView, partyView, documentsView, tenancyLicenceView,
+                                    claimGroundsView, rentDetailsView, alternativesToPossessionView,
+                                    housingActWalesView, asbProhibitedConductView, rentArrearsView,
+                                    noticeOfPossessionView, statementOfTruthView, caseFieldsView, caseLinkView,
+                                    enforcementOrderView);
     }
 
     @Test
@@ -177,25 +174,6 @@ class PCSCaseViewTest {
     }
 
     @Test
-    void shouldMapPartyEntity() {
-        // Given
-        PartyEntity partyEntity = mock(PartyEntity.class);
-        when(pcsCaseEntity.getParties()).thenReturn(Set.of(partyEntity));
-
-        Party party = mock(Party.class);
-
-        when(modelMapper.map(partyEntity, Party.class)).thenReturn(party);
-
-        // When
-        PCSCase pcsCase = underTest.getCase(request(CASE_REFERENCE, DEFAULT_STATE));
-
-        // Then
-        List<ListValue<Party>> mappedParties = pcsCase.getParties();
-        assertThat(mappedParties).hasSize(1);
-        assertThat(mappedParties.getFirst().getValue()).isSameAs(party);
-    }
-
-    @Test
     void shouldMapLegislativeCountry() {
         // Given
         LegislativeCountry expectedLegislativeCountry = LegislativeCountry.SCOTLAND;
@@ -209,126 +187,14 @@ class PCSCaseViewTest {
     }
 
     @Test
-    void shouldMapAllParties() {
-        // Given
-        Party claimant = mock(Party.class);
-        UUID claimantId = UUID.randomUUID();
-        ClaimPartyEntity claimantClaimParty = createClaimPartyEntity(claimant, claimantId, PartyRole.CLAIMANT);
-
-        Party defendant1 = mock(Party.class);
-        UUID defendant1Id = UUID.randomUUID();
-        ClaimPartyEntity defendant1ClaimParty = createClaimPartyEntity(defendant1, defendant1Id, PartyRole.DEFENDANT);
-
-        Party defendant2 = mock(Party.class);
-        UUID defendant2Id = UUID.randomUUID();
-        ClaimPartyEntity defendant2ClaimParty = createClaimPartyEntity(defendant2, defendant2Id, PartyRole.DEFENDANT);
-
-        Party underlessee1 = mock(Party.class);
-        UUID underlessee1Id = UUID.randomUUID();
-        ClaimPartyEntity underlessee1ClaimParty = createClaimPartyEntity(
-            underlessee1,
-            underlessee1Id,
-            PartyRole.UNDERLESSEE_OR_MORTGAGEE
-        );
-
-        Party underlessee2 = mock(Party.class);
-        UUID underlessee2Id = UUID.randomUUID();
-        ClaimPartyEntity underlessee2ClaimParty = createClaimPartyEntity(
-            underlessee2,
-            underlessee2Id,
-            PartyRole.UNDERLESSEE_OR_MORTGAGEE
-        );
-
-        when(claimEntity.getClaimParties()).thenReturn(
-            List.of(claimantClaimParty, defendant1ClaimParty, defendant2ClaimParty,
-                    underlessee1ClaimParty, underlessee2ClaimParty
-            ));
-
-        // When
-        PCSCase pcsCase = underTest.getCase(request(CASE_REFERENCE, DEFAULT_STATE));
-
-        // Then
-        assertThat(pcsCase.getAllClaimants())
-            .containsExactly(asListValue(claimantId, claimant));
-
-        assertThat(pcsCase.getAllDefendants())
-            .containsExactly(
-                asListValue(defendant1Id, defendant1),
-                asListValue(defendant2Id, defendant2)
-            );
-
-        assertThat(pcsCase.getAllUnderlesseeOrMortgagees())
-            .containsExactly(
-                asListValue(underlessee1Id, underlessee1),
-                asListValue(underlessee2Id, underlessee2)
-            );
-
-    }
-
-    @Test
-    void shouldReturnEmptyListWhenNoDocumentsExist() {
-        // Given
-        when(pcsCaseEntity.getDocuments()).thenReturn(List.of());
-
-        // When
-        PCSCase pcsCase = underTest.getCase(request(CASE_REFERENCE, DEFAULT_STATE));
-
-        // Then
-        assertThat(pcsCase.getAllDocuments()).isEmpty();
-    }
-
-    @Test
-    void shouldMapDocuments() {
-        // Given
-        DocumentEntity entity1 = DocumentEntity.builder()
-            .id(UUID.randomUUID())
-            .fileName("doc1.pdf")
-            .url("url1")
-            .build();
-
-        DocumentEntity entity2 = DocumentEntity.builder()
-            .id(UUID.randomUUID())
-            .fileName("doc2.pdf")
-            .url("url2")
-            .build();
-
-        when(pcsCaseEntity.getDocuments()).thenReturn(List.of(entity1,entity2));
-
-        // When
-        PCSCase pcsCase = underTest.getCase(request(CASE_REFERENCE, DEFAULT_STATE));
-
-        //Then
-        assertThat(pcsCase.getAllDocuments()).hasSize(2);
-        assertThat(pcsCase.getAllDocuments()).extracting(lv -> lv.getValue().getFilename())
-            .containsExactly("doc1.pdf", "doc2.pdf");
-    }
-
-    private static ListValue<Party> asListValue(UUID id, Party party) {
-        return ListValue.<Party>builder().id(id.toString()).value(party).build();
-    }
-
-    private ClaimPartyEntity createClaimPartyEntity(Party party, UUID partyId, PartyRole partyRole) {
-        PartyEntity partyEntity = mock(PartyEntity.class);
-
-        when(modelMapper.map(partyEntity, Party.class)).thenReturn(party);
-
-        ClaimPartyId claimPartyId = new ClaimPartyId();
-        claimPartyId.setPartyId(partyId);
-
-        return ClaimPartyEntity.builder()
-            .id(claimPartyId)
-            .role(partyRole)
-            .party(partyEntity)
-            .build();
-    }
-
-    @Test
     void shouldSetCaseFieldsInViewHelpers() {
         // When
         PCSCase pcsCase = underTest.getCase(request(CASE_REFERENCE, DEFAULT_STATE));
 
         // Then
         verify(claimView).setCaseFields(pcsCase, pcsCaseEntity);
+        verify(partyView).setCaseFields(pcsCase, pcsCaseEntity);
+        verify(documentsView).setCaseFields(pcsCase, pcsCaseEntity);
         verify(tenancyLicenceView).setCaseFields(pcsCase, pcsCaseEntity);
         verify(claimGroundsView).setCaseFields(pcsCase, pcsCaseEntity);
         verify(rentDetailsView).setCaseFields(pcsCase, pcsCaseEntity);
@@ -339,6 +205,7 @@ class PCSCaseViewTest {
         verify(noticeOfPossessionView).setCaseFields(pcsCase, pcsCaseEntity);
         verify(statementOfTruthView).setCaseFields(pcsCase, pcsCaseEntity);
         verify(caseLinkView).setCaseFields(pcsCase, pcsCaseEntity);
+        verify(enforcementOrderView).setCaseFields(pcsCase, pcsCaseEntity);
     }
 
     @Test
@@ -350,15 +217,6 @@ class PCSCaseViewTest {
 
         // Then
         verify(caseFieldsView).setCaseFields(pcsCase);
-    }
-
-    @Test
-    void shouldCallEnforcementOrderMediator() {
-        // When
-        PCSCase pcsCase = underTest.getCase(request(CASE_REFERENCE, DEFAULT_STATE));
-
-        // Then
-        verify(enforcementOrderMediator).handleEnforcementRequirements(CASE_REFERENCE, pcsCase);
     }
 
     private AddressUK stubAddressEntityModelMapper(AddressEntity addressEntity) {

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/DocumentsViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/DocumentsViewTest.java
@@ -1,0 +1,72 @@
+package uk.gov.hmcts.reform.pcs.ccd.view;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.entity.DocumentEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentsViewTest {
+
+    private PCSCase pcsCase;
+    @Mock
+    private PcsCaseEntity pcsCaseEntity;
+
+    private DocumentsView underTest;
+
+    @BeforeEach
+    void setUp() {
+        pcsCase = PCSCase.builder().build();
+
+        underTest = new DocumentsView();
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoDocumentsExist() {
+        // Given
+        when(pcsCaseEntity.getDocuments()).thenReturn(List.of());
+
+        // When
+        underTest.setCaseFields(pcsCase, pcsCaseEntity);
+
+        // Then
+        assertThat(pcsCase.getAllDocuments()).isEmpty();
+    }
+
+    @Test
+    void shouldMapDocuments() {
+        // Given
+        DocumentEntity entity1 = DocumentEntity.builder()
+            .id(UUID.randomUUID())
+            .fileName("doc1.pdf")
+            .url("url1")
+            .build();
+
+        DocumentEntity entity2 = DocumentEntity.builder()
+            .id(UUID.randomUUID())
+            .fileName("doc2.pdf")
+            .url("url2")
+            .build();
+
+        when(pcsCaseEntity.getDocuments()).thenReturn(List.of(entity1,entity2));
+
+        // When
+        underTest.setCaseFields(pcsCase, pcsCaseEntity);
+
+        //Then
+        assertThat(pcsCase.getAllDocuments()).hasSize(2);
+        assertThat(pcsCase.getAllDocuments()).extracting(lv -> lv.getValue().getFilename())
+            .containsExactly("doc1.pdf", "doc2.pdf");
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/PartiesViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/PartiesViewTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class PartyViewTest {
+class PartiesViewTest {
 
     @Mock
     private ModelMapper modelMapper;
@@ -34,13 +34,13 @@ class PartyViewTest {
     @Mock
     private ClaimEntity claimEntity;
 
-    private PartyView underTest;
+    private PartiesView underTest;
 
     @BeforeEach
     void setUp() {
         when(pcsCaseEntity.getClaims()).thenReturn(List.of(claimEntity));
 
-        underTest = new PartyView(modelMapper);
+        underTest = new PartiesView(modelMapper);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/PartyViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/PartyViewTest.java
@@ -1,0 +1,144 @@
+package uk.gov.hmcts.reform.pcs.ccd.view;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+import uk.gov.hmcts.ccd.sdk.type.ListValue;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.domain.Party;
+import uk.gov.hmcts.reform.pcs.ccd.entity.ClaimEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.ClaimPartyEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.ClaimPartyId;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
+import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyRole;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PartyViewTest {
+
+    @Mock
+    private ModelMapper modelMapper;
+    @Mock
+    private PcsCaseEntity pcsCaseEntity;
+    @Mock
+    private ClaimEntity claimEntity;
+
+    private PartyView underTest;
+
+    @BeforeEach
+    void setUp() {
+        when(pcsCaseEntity.getClaims()).thenReturn(List.of(claimEntity));
+
+        underTest = new PartyView(modelMapper);
+    }
+
+    @Test
+    void shouldMapPartyEntity() {
+        // Given
+        PartyEntity partyEntity = mock(PartyEntity.class);
+        when(pcsCaseEntity.getParties()).thenReturn(Set.of(partyEntity));
+
+        Party party = mock(Party.class);
+        when(modelMapper.map(partyEntity, Party.class)).thenReturn(party);
+
+        PCSCase pcsCase = PCSCase.builder().build();
+
+        // When
+        underTest.setCaseFields(pcsCase, pcsCaseEntity);
+
+        // Then
+        List<ListValue<Party>> mappedParties = pcsCase.getParties();
+        assertThat(mappedParties).hasSize(1);
+        assertThat(mappedParties.getFirst().getValue()).isSameAs(party);
+    }
+
+    @Test
+    void shouldMapAllPartiesByType() {
+        // Given
+        Party claimant = mock(Party.class);
+        UUID claimantId = UUID.randomUUID();
+        ClaimPartyEntity claimantClaimParty = createClaimPartyEntity(claimant, claimantId, PartyRole.CLAIMANT);
+
+        Party defendant1 = mock(Party.class);
+        UUID defendant1Id = UUID.randomUUID();
+        ClaimPartyEntity defendant1ClaimParty = createClaimPartyEntity(defendant1, defendant1Id, PartyRole.DEFENDANT);
+
+        Party defendant2 = mock(Party.class);
+        UUID defendant2Id = UUID.randomUUID();
+        ClaimPartyEntity defendant2ClaimParty = createClaimPartyEntity(defendant2, defendant2Id, PartyRole.DEFENDANT);
+
+        Party underlessee1 = mock(Party.class);
+        UUID underlessee1Id = UUID.randomUUID();
+        ClaimPartyEntity underlessee1ClaimParty = createClaimPartyEntity(
+            underlessee1,
+            underlessee1Id,
+            PartyRole.UNDERLESSEE_OR_MORTGAGEE
+        );
+
+        Party underlessee2 = mock(Party.class);
+        UUID underlessee2Id = UUID.randomUUID();
+        ClaimPartyEntity underlessee2ClaimParty = createClaimPartyEntity(
+            underlessee2,
+            underlessee2Id,
+            PartyRole.UNDERLESSEE_OR_MORTGAGEE
+        );
+
+        when(claimEntity.getClaimParties()).thenReturn(
+            List.of(claimantClaimParty, defendant1ClaimParty, defendant2ClaimParty,
+                    underlessee1ClaimParty, underlessee2ClaimParty
+            ));
+
+        PCSCase pcsCase = PCSCase.builder().build();
+
+        // When
+        underTest.setCaseFields(pcsCase, pcsCaseEntity);
+
+        // Then
+        assertThat(pcsCase.getAllClaimants())
+            .containsExactly(asListValue(claimantId, claimant));
+
+        assertThat(pcsCase.getAllDefendants())
+            .containsExactly(
+                asListValue(defendant1Id, defendant1),
+                asListValue(defendant2Id, defendant2)
+            );
+
+        assertThat(pcsCase.getAllUnderlesseeOrMortgagees())
+            .containsExactly(
+                asListValue(underlessee1Id, underlessee1),
+                asListValue(underlessee2Id, underlessee2)
+            );
+
+    }
+
+    private ClaimPartyEntity createClaimPartyEntity(Party party, UUID partyId, PartyRole partyRole) {
+        PartyEntity partyEntity = mock(PartyEntity.class);
+
+        when(modelMapper.map(partyEntity, Party.class)).thenReturn(party);
+
+        ClaimPartyId claimPartyId = new ClaimPartyId();
+        claimPartyId.setPartyId(partyId);
+
+        return ClaimPartyEntity.builder()
+            .id(claimPartyId)
+            .role(partyRole)
+            .party(partyEntity)
+            .build();
+    }
+
+    private static ListValue<Party> asListValue(UUID id, Party party) {
+        return ListValue.<Party>builder().id(id.toString()).value(party).build();
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/enforcementorder/EnforcementOrderViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/enforcementorder/EnforcementOrderViewTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.pcs.ccd.enforcementorder;
+package uk.gov.hmcts.reform.pcs.ccd.view.enforcementorder;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,9 +15,7 @@ import uk.gov.hmcts.reform.pcs.ccd.domain.enforcetheorder.EnforcementOrder;
 import uk.gov.hmcts.reform.pcs.ccd.entity.ClaimEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.enforcetheorder.EnforcementOrderEntity;
-import uk.gov.hmcts.reform.pcs.ccd.repository.PcsCaseRepository;
 import uk.gov.hmcts.reform.pcs.ccd.repository.enforcetheorder.EnforcementOrderRepository;
-import uk.gov.hmcts.reform.pcs.exception.CaseNotFoundException;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -33,26 +31,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class EnforcementOrderMediatorTest {
+class EnforcementOrderViewTest {
 
-    private static final long CASE_REFERENCE = 1234567890L;
-
-    @Mock
-    private PcsCaseRepository pcsCaseRepository;
     @Mock
     private EnforcementOrderRepository enforcementOrderRepository;
-
     @InjectMocks
-    private EnforcementOrderMediator underTest;
+    private EnforcementOrderView underTest;
 
     private PCSCase pcsCase;
 
@@ -66,65 +57,55 @@ class EnforcementOrderMediatorTest {
     @Test
     void shouldSetShowConfirmEvictionJourneyToYesWhenBailiffDateExists() {
         // Given
-        long caseReference = 1234567890L;
         LocalDateTime bailiffDate = LocalDateTime.parse("2026-04-15T10:00:00");
 
         PcsCaseEntity pcsCaseEntity = createPcsCaseEntity();
         EnforcementOrderEntity enforcementOrderEntity = createEnforcementOrderEntity(bailiffDate);
 
-        when(pcsCaseRepository.findByCaseReference(caseReference))
-            .thenReturn(Optional.of(pcsCaseEntity));
         when(enforcementOrderRepository.findByClaimId(any(UUID.class)))
             .thenReturn(List.of(enforcementOrderEntity));
 
         // When
-        underTest.handleEnforcementRequirements(caseReference, pcsCase);
+        underTest.setCaseFields(pcsCase, pcsCaseEntity);
 
         // Then
         assertEquals(YesOrNo.YES, pcsCase.getShowConfirmEvictionJourney());
         assertNotNull(pcsCase.getConfirmEvictionSummaryMarkup());
         assertTrue(pcsCase.getConfirmEvictionSummaryMarkup().contains("Confirm the eviction date"));
-        verify(pcsCaseRepository).findByCaseReference(caseReference);
         verify(enforcementOrderRepository).findByClaimId(any(UUID.class));
     }
 
     @Test
     void shouldSetShowConfirmEvictionJourneyToNoWhenBailiffDateIsNull() {
         // Given
-        long caseReference = 1234567890L;
         PcsCaseEntity pcsCaseEntity = createPcsCaseEntity();
         EnforcementOrderEntity enforcementOrderEntity = createEnforcementOrderEntity(null);
 
-        when(pcsCaseRepository.findByCaseReference(caseReference))
-            .thenReturn(Optional.of(pcsCaseEntity));
         when(enforcementOrderRepository.findByClaimId(any(UUID.class)))
             .thenReturn(List.of(enforcementOrderEntity));
 
         // When
-        underTest.handleEnforcementRequirements(caseReference, pcsCase);
+        underTest.setCaseFields(pcsCase, pcsCaseEntity);
 
         // Then
         assertEquals(YesOrNo.NO, pcsCase.getShowConfirmEvictionJourney());
         assertNotNull(pcsCase.getConfirmEvictionSummaryMarkup());
         assertTrue(pcsCase.getConfirmEvictionSummaryMarkup().contains("You cannot enforce the order at the moment"));
-        verify(pcsCaseRepository).findByCaseReference(caseReference);
         verify(enforcementOrderRepository).findByClaimId(any(UUID.class));
     }
 
     @Test
     void shouldFormatBailiffDateCorrectlyInMarkup() {
         // Given
-        long caseReference = 1234567890L;
         LocalDateTime bailiffDate = LocalDateTime.parse("2026-05-20T14:30:00");
 
         PcsCaseEntity pcsCaseEntity = createPcsCaseEntity();
         EnforcementOrderEntity enforcementOrderEntity = createEnforcementOrderEntity(bailiffDate);
 
-        when(pcsCaseRepository.findByCaseReference(caseReference)).thenReturn(Optional.of(pcsCaseEntity));
         when(enforcementOrderRepository.findByClaimId(any(UUID.class))).thenReturn(List.of(enforcementOrderEntity));
 
         // When
-        underTest.handleEnforcementRequirements(caseReference, pcsCase);
+        underTest.setCaseFields(pcsCase, pcsCaseEntity);
 
         // Then
         DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy", Locale.UK);
@@ -135,19 +116,16 @@ class EnforcementOrderMediatorTest {
     @Test
     void shouldCalculateDeadlineDateAsMinus72HoursFromBailiffDate() {
         // Given
-        long caseReference = 1234567890L;
         LocalDateTime bailiffDate = LocalDateTime.parse("2026-05-20T14:30:00");
 
         PcsCaseEntity pcsCaseEntity = createPcsCaseEntity();
         EnforcementOrderEntity enforcementOrderEntity = createEnforcementOrderEntity(bailiffDate);
 
-        when(pcsCaseRepository.findByCaseReference(caseReference))
-            .thenReturn(Optional.of(pcsCaseEntity));
         when(enforcementOrderRepository.findByClaimId(any(UUID.class)))
             .thenReturn(List.of(enforcementOrderEntity));
 
         // When
-        underTest.handleEnforcementRequirements(caseReference, pcsCase);
+        underTest.setCaseFields(pcsCase, pcsCaseEntity);
 
         // Then
         DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.UK);
@@ -156,117 +134,48 @@ class EnforcementOrderMediatorTest {
     }
 
     @Test
-    void shouldNotProcessWhenCaseReferenceIsZero() {
-        // Given
-        long caseReference = 0L;
-
-        // When
-        underTest.handleEnforcementRequirements(caseReference, pcsCase);
-
-        // Then
-        assertNull(pcsCase.getShowConfirmEvictionJourney());
-        assertNull(pcsCase.getConfirmEvictionSummaryMarkup());
-        verify(pcsCaseRepository, never()).findByCaseReference(anyLong());
-    }
-
-    @Test
-    void shouldNotProcessWhenCaseReferenceIsNegative() {
-        // Given
-        long caseReference = -1L;
-
-        // When
-        underTest.handleEnforcementRequirements(caseReference, pcsCase);
-
-        // Then
-        assertNull(pcsCase.getShowConfirmEvictionJourney());
-        assertNull(pcsCase.getConfirmEvictionSummaryMarkup());
-        verify(pcsCaseRepository, never()).findByCaseReference(anyLong());
-    }
-
-    @Test
-    void shouldNotProcessWhenPcsCaseIsNull() {
-        // Given
-        long caseReference = 1234567890L;
-
-        // When
-        underTest.handleEnforcementRequirements(caseReference, null);
-
-        // Then
-        verify(pcsCaseRepository, never()).findByCaseReference(anyLong());
-    }
-
-    @Test
-    void shouldThrowCaseNotFoundExceptionWhenCaseDoesNotExist() {
-        // Given
-        long caseReference = 1234567890L;
-
-        when(pcsCaseRepository.findByCaseReference(caseReference))
-            .thenReturn(Optional.empty());
-
-        // When & Then
-        assertThrows(CaseNotFoundException.class, () ->
-            underTest.handleEnforcementRequirements(caseReference, pcsCase)
-        );
-        verify(pcsCaseRepository).findByCaseReference(caseReference);
-    }
-
-    @Test
     void shouldReturnEmptyWhenClaimsListIsNull() {
         // Given
-        long caseReference = 1234567890L;
         PcsCaseEntity pcsCaseEntity = new PcsCaseEntity();
         pcsCaseEntity.setClaims(null);
 
-        when(pcsCaseRepository.findByCaseReference(caseReference))
-            .thenReturn(Optional.of(pcsCaseEntity));
-
         // When
-        Optional<EnforcementOrderEntity> result = underTest.getEnforcementOrder(caseReference);
+        Optional<EnforcementOrderEntity> result = underTest.getEnforcementOrder(pcsCaseEntity);
 
         // Then
         assertTrue(result.isEmpty());
-        verify(pcsCaseRepository).findByCaseReference(caseReference);
         verify(enforcementOrderRepository, never()).findByClaimId(any());
     }
 
     @Test
     void shouldReturnEmptyWhenClaimsListIsEmpty() {
         // Given
-        long caseReference = 1234567890L;
         PcsCaseEntity pcsCaseEntity = new PcsCaseEntity();
         pcsCaseEntity.setClaims(new ArrayList<>());
 
-        when(pcsCaseRepository.findByCaseReference(caseReference))
-            .thenReturn(Optional.of(pcsCaseEntity));
-
         // When
-        Optional<EnforcementOrderEntity> result = underTest.getEnforcementOrder(caseReference);
+        Optional<EnforcementOrderEntity> result = underTest.getEnforcementOrder(pcsCaseEntity);
 
         // Then
         assertTrue(result.isEmpty());
-        verify(pcsCaseRepository).findByCaseReference(caseReference);
         verify(enforcementOrderRepository, never()).findByClaimId(any());
     }
 
     @Test
     void shouldReturnEnforcementOrderWhenFound() {
         // Given
-        long caseReference = 1234567890L;
         PcsCaseEntity pcsCaseEntity = createPcsCaseEntity();
         EnforcementOrderEntity enforcementOrderEntity = createEnforcementOrderEntity(LocalDateTime.now());
 
-        when(pcsCaseRepository.findByCaseReference(caseReference))
-            .thenReturn(Optional.of(pcsCaseEntity));
         when(enforcementOrderRepository.findByClaimId(any(UUID.class)))
             .thenReturn(List.of(enforcementOrderEntity));
 
         // When
-        Optional<EnforcementOrderEntity> result = underTest.getEnforcementOrder(caseReference);
+        Optional<EnforcementOrderEntity> result = underTest.getEnforcementOrder(pcsCaseEntity);
 
         // Then
         assertTrue(result.isPresent());
         assertEquals(enforcementOrderEntity, result.get());
-        verify(pcsCaseRepository).findByCaseReference(caseReference);
         verify(enforcementOrderRepository).findByClaimId(any(UUID.class));
     }
 
@@ -274,36 +183,29 @@ class EnforcementOrderMediatorTest {
     void shouldReturnEmptyWhenEnforcementOrderNotFound() {
         // Given
         PcsCaseEntity pcsCaseEntity = createPcsCaseEntity();
-
-        when(pcsCaseRepository.findByCaseReference(CASE_REFERENCE)).thenReturn(Optional.of(pcsCaseEntity));
         when(enforcementOrderRepository.findByClaimId(any(UUID.class))).thenReturn(List.of());
 
         // When
-        Optional<EnforcementOrderEntity> result = underTest.getEnforcementOrder(CASE_REFERENCE);
+        Optional<EnforcementOrderEntity> result = underTest.getEnforcementOrder(pcsCaseEntity);
 
         // Then
         assertTrue(result.isEmpty());
-        verify(pcsCaseRepository).findByCaseReference(CASE_REFERENCE);
         verify(enforcementOrderRepository).findByClaimId(any(UUID.class));
     }
 
     @Test
     void shouldNotSetMarkupWhenEnforcementOrderNotPresent() {
         // Given
-        long caseReference = 1234567890L;
         PcsCaseEntity pcsCaseEntity = createPcsCaseEntity();
 
-        when(pcsCaseRepository.findByCaseReference(caseReference))
-            .thenReturn(Optional.of(pcsCaseEntity));
         when(enforcementOrderRepository.findByClaimId(any(UUID.class))).thenReturn(List.of());
 
         // When
-        underTest.handleEnforcementRequirements(caseReference, pcsCase);
+        underTest.setCaseFields(pcsCase, pcsCaseEntity);
 
         // Then
         assertNull(pcsCase.getShowConfirmEvictionJourney());
         assertNull(pcsCase.getConfirmEvictionSummaryMarkup());
-        verify(pcsCaseRepository).findByCaseReference(caseReference);
         verify(enforcementOrderRepository).findByClaimId(any(UUID.class));
     }
 


### PR DESCRIPTION
### Jira link

See [HDPI-6407](https://tools.hmcts.net/jira/browse/HDPI-6407)

### Change description

 Align view building components to all implement a `ViewComponent` interface and also follow the same naming convention. This is in advance of some further refactoring of the `PcsCaseView` class where I plan to inject a collection of all the `ViewComponent` implementations

* Rename `EnforcementOrderMediator` to be `EnforcementOrderView` and change the method signature. This component no longer looks up the PcsCaseEntity and instead uses the passed in parameter like the other view components
* Add the `ViewComponent` interface to all view component classes

Note that the `CaseFieldsView` class, (added in https://github.com/hmcts/pcs-api/pull/1570 for GlobalSearch), needs renaming to something more descriptive and also some more significant refactoring to align with the established pattern so a separate ticket will be raised for that.

### Testing done

Full build run, with regression tests

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
