### PR TITLE
HDPI-6455: Add HMCTS Artifactory as Maven repository fallback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -354,6 +354,7 @@ repositories {
   mavenLocal()
   mavenCentral()
   maven { url = 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1'}
+  maven { url = 'https://artifactory.platform.hmcts.net/artifactory/maven-remotes'}
 }
 
 ext {

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,5 +4,8 @@ pluginManagement {
         maven {
             url = 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1'
         }
+        maven {
+            url = 'https://artifactory.platform.hmcts.net/artifactory/maven-remotes'
+        }
     }
 }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/HDPI-6455

### Change description
Adds https://artifactory.platform.hmcts.net/artifactory/maven-remotes as an additional fallback Maven repository for dependency and plugin resolution.
**Updated:**
settings.gradle → pluginManagement.repositories
build.gradle → repositories
Existing repository order remains unchanged, so Maven Central and Azure Artifacts (hmcts-lib) will still be checked first before falling back to Artifactory.


### Testing done

PR build is green

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
