### PR TITLE
Put Artifactory before Gradle plugin repo

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,8 @@
 pluginManagement {
     repositories {
-        gradlePluginPortal()
         maven {
             url = 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1'
         }
+        gradlePluginPortal()
     }
 }


### PR DESCRIPTION
### Jira link

See [HDPI-6455](https://tools.hmcts.net/jira/browse/HDPI-6455)

### Change description

Change the order of the Gradle plugin repos so that the internal Maven repo is hit first.

### Testing done

Build run in Jenkins

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
