### PR TITLE
Revert temporary jurisdiction workaround and standardise to “Civil Po…

### DIFF
--- a/src/e2eTest/data/page-data/caseList.page.data.ts
+++ b/src/e2eTest/data/page-data/caseList.page.data.ts
@@ -7,9 +7,7 @@ export const caseList = {
   caseTypeLabel: 'Case type',
   eventLabel: 'Event',
   caseNumberLabel: 'Case Number',
-  //HDPI-5381 updated this from Possessions-> Civil Possession, however due to ccd config issue this change not reflected in AAT yet. As temp fix we have added this condition to keep the build green until ccd issue is resolved.
-  possessionsJurisdiction: process.env.CHANGE_ID ? 'Civil Possession' : 'Possessions',
-  //possessionsJurisdiction: 'Civil Possession',
+  possessionsJurisdiction: 'Civil Possession',
   caseType:
     {
       civilPossessions: getCaseTypeName()

--- a/src/e2eTest/data/page-data/createCase.page.data.ts
+++ b/src/e2eTest/data/page-data/createCase.page.data.ts
@@ -7,9 +7,7 @@ export const createCase =
     jurisdictionLabel: 'Jurisdiction',
     caseTypeLabel: 'Case type',
     eventLabel: 'Event',
-    //HDPI-5381 updated this from Possessions-> Civil Possession, however due to ccd config issue this change not reflected in AAT yet. As temp fix we have added this condition to keep the build green until ccd issue is resolved.
-    possessionsJurisdiction: process.env.CHANGE_ID ? 'Civil Possession' : 'Possessions',
-    //possessionsJurisdiction: 'Civil Possession',
+    possessionsJurisdiction: 'Civil Possession',
     caseType:
       {
         civilPossessions: getCaseTypeName()

--- a/src/e2eTest/data/page-data/search.page.data.ts
+++ b/src/e2eTest/data/page-data/search.page.data.ts
@@ -8,9 +8,7 @@ export const search =
     caseTypeLabel: 'Case type',
     eventLabel: 'Event',
     caseNumberLabel: 'Case Number',
-    //HDPI-5381 updated this from Possessions-> Civil Possession, however due to ccd config issue this change not reflected in AAT yet. As temp fix we have added this condition to keep the build green until ccd issue is resolved.
-    possessionsJurisdiction: process.env.CHANGE_ID ? 'Civil Possession' : 'Possessions',
-    //possessionsJurisdiction: 'Civil Possession',
+    possessionsJurisdiction: 'Civil Possession',
     caseType:
       {
         civilPossessions: getCaseTypeName()


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/HDPI-5505


**Change description**
Fews days back, Jurisdiction value was updated from “Possessions” to “Civil Possession”. However it didnt reflect in AAT due to CCD issue.

Now that issue has been fixed, so updated e2e scripts to look for 'Civil Possession' for Jurisdiction dropdown during e2e journey

**Testing done**

Preview tests:
<img width="1725" height="1064" alt="image" src="https://github.com/user-attachments/assets/26d35a34-9a75-4588-a153-06fcaf545c45" />


Tested locally by pointing to AAT:
<img width="1725" height="1064" alt="image" src="https://github.com/user-attachments/assets/4e30edb2-df29-4f1d-acd3-41865853dc72" />


**Checklist**

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
