### PR TITLE
Fix docker executable path and clean up containers on CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -560,15 +560,18 @@ check.dependsOn cftlibTest
 // Add wiremock docker compose dependency
 dockerCompose.isRequiredBy cftlibTest
 
+def cleanUpContainers = System.getenv("CI") != null
+
 dockerCompose {
   useComposeFiles = ['docker-compose-wiremock.yml']
-  stopContainers = false
-  removeContainers = false
-  waitForTcpPorts = false
+  stopContainers = cleanUpContainers
+  removeContainers = cleanUpContainers
+  buildBeforeUp = false
+  buildBeforePull = false
 }
 
 composeUp.doFirst {
-  dockerCompose.executable = "which docker".execute().text
+  dockerCompose.dockerExecutable = ("which docker".execute().text).replaceAll("\n", "")
 }
 
 tasks.named("processIntegrationTestResources") {


### PR DESCRIPTION
### Change description

A [recent PR](https://github.com/hmcts/pcs-api/pull/1803) added a wiremock docker compose for the Fee Register and added a plugin to the build.gradle to start that wiremock container for the Cftlib tests.

This PR fixes an issue with the configuration of that to set the docker executable path correctly and also to tear down the container if running on CI.

### Testing done

Full build run

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
