### PR TITLE
Fallback to pod DB in preview 

### DIFF
--- a/charts/pcs-api/values.poddb.preview.template.yaml
+++ b/charts/pcs-api/values.poddb.preview.template.yaml
@@ -6,6 +6,19 @@ global:
 java:
   postgresql:
     enabled: true
-
+  secrets:
+    PCS_DB_PASSWORD:
+      key: password
+ccd:
+  ccd-definition-store-api:
+    java:
+      secrets:
+        DEFINITION_STORE_DB_PASSWORD:
+          key: password
+  ccd-data-store-api:
+    java:
+      secrets:
+        DATA_STORE_DB_PASSWORD:
+          key: password
 postgresql:
   enabled: false

--- a/charts/pcs-api/values.poddb.preview.template.yaml
+++ b/charts/pcs-api/values.poddb.preview.template.yaml
@@ -2,10 +2,13 @@ global:
   postgresSecret: ${SERVICE_NAME}-postgresql
   postgresHostname: "{{ .Release.Name }}-postgresql"
   postgresUsername: "javapostgres"
+  databaseNamePrefix: ""
 
 java:
   postgresql:
     enabled: true
+  environment:
+    PCS_DB_NAME: "javadatabase"
   secrets:
     PCS_DB_PASSWORD:
       key: password

--- a/charts/pcs-api/values.poddb.preview.template.yaml
+++ b/charts/pcs-api/values.poddb.preview.template.yaml
@@ -1,0 +1,11 @@
+global:
+  postgresSecret: ${SERVICE_NAME}-postgresql
+  postgresHostname: "{{ .Release.Name }}-postgresql"
+  postgresUsername: "javapostgres"
+
+java:
+  postgresql:
+    enabled: true
+
+postgresql:
+  enabled: false


### PR DESCRIPTION
There is an ongoing MS incident preventing DBs being created on preview. This should unblock us for time being where people can add pr-values:poddb label along with ccd label to get it working on a transient DB (it means data will be lost on a helm release clear / shutdown over night)


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
