### PR TITLE
Fix for pcs-api nightly Fee and Pay failure

### DIFF
--- a/src/e2eTest/tests/CommonComponent/feeAndPay.spec.ts
+++ b/src/e2eTest/tests/CommonComponent/feeAndPay.spec.ts
@@ -28,7 +28,7 @@ test.afterEach(async () => {
   }
 });
 
-test.describe('[Common Component Fee And Pay]', async () => {
+test.describe('[Common Component Fee And Pay] @PR', async () => {
   test('Fee And Pay - Pay by account PBA @nightly @feeAndPay', async () => {
     await performAction('clickButton', serviceRequest.payNowLink);
     await performAction('selectPaymentTypePBA', {
@@ -36,7 +36,7 @@ test.describe('[Common Component Fee And Pay]', async () => {
       expectedAmount: serviceRequest.amount404,
       payByOption: serviceRequest.payByAccountRadioOption,
       pbaLabel: serviceRequest.selectPBALabel,
-      pbaIndex: serviceRequest.pbaIndex1,
+      pbaValue: serviceRequest.pbaValue,
       referenceLabel: serviceRequest.pbaReferenceLable,
       referenceText: serviceRequest.pbaReferenceInputText,
       confirmButton: serviceRequest.confirmPaymentButton,

--- a/src/e2eTest/tests/CommonComponent/feeAndPay.spec.ts
+++ b/src/e2eTest/tests/CommonComponent/feeAndPay.spec.ts
@@ -28,7 +28,7 @@ test.afterEach(async () => {
   }
 });
 
-test.describe('[Common Component Fee And Pay] @PR', async () => {
+test.describe('[Common Component Fee And Pay]', async () => {
   test('Fee And Pay - Pay by account PBA @nightly @feeAndPay', async () => {
     await performAction('clickButton', serviceRequest.payNowLink);
     await performAction('selectPaymentTypePBA', {

--- a/src/e2eTest/tests/CommonComponent/feeAndPay.spec.ts
+++ b/src/e2eTest/tests/CommonComponent/feeAndPay.spec.ts
@@ -28,7 +28,7 @@ test.afterEach(async () => {
   }
 });
 
-test.describe('[Common Component Fee And Pay]', async () => {
+test.describe('[Common Component Fee And Pay] @PR', async () => {
   test('Fee And Pay - Pay by account PBA @nightly @feeAndPay', async () => {
     await performAction('clickButton', serviceRequest.payNowLink);
     await performAction('selectPaymentTypePBA', {

--- a/src/e2eTest/utils/actions/custom-actions/commonComponent/feeAndPay.action.ts
+++ b/src/e2eTest/utils/actions/custom-actions/commonComponent/feeAndPay.action.ts
@@ -25,7 +25,7 @@ export class FeeAndPayAction implements IAction {
       await expect(page.getByText(expectedAmount, { exact: true })).toBeVisible();
     }
     await performAction('clickRadioButton', { option: paymentOptions.payByOption });
-    await performAction('select', paymentOptions.pbaLabel, paymentOptions.pbaIndex);
+    await performAction('select', paymentOptions.pbaLabel, paymentOptions.pbaValue);
     const locator = page.locator('button', { hasText: 'Confirm payment' });
     await expect(locator).toBeDisabled();
     await performAction('inputText', paymentOptions.referenceLabel, paymentOptions.referenceText);


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/HDPI-6681

**Change description**
Updated the test to pick up valid PBA for payment, instead of default first value which could be invalid

**Testing done**
Tested locally
<img width="2560" height="873" alt="image" src="https://github.com/user-attachments/assets/4d7380e2-af7d-4d60-a3d4-b48de5b8a1f1" />

Pipeline
<img width="2560" height="935" alt="image" src="https://github.com/user-attachments/assets/a9a1031d-bdd1-4ac0-8707-27727e6f9b41" />


<img width="2560" height="935" alt="image" src="https://github.com/user-attachments/assets/572b2ef5-a2e4-49fb-8605-8a97b89035d2" />


**Checklist**

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
