### PR TITLE
HDPI-4573: Fix merge issues

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/MakeAnApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/MakeAnApplication.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 import uk.gov.hmcts.reform.pcs.ccd.domain.State;
 import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
 import uk.gov.hmcts.reform.pcs.ccd.domain.genapp.GenAppRequest;
+import uk.gov.hmcts.reform.pcs.ccd.entity.DocumentEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.GenAppEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
@@ -187,7 +188,10 @@ public class MakeAnApplication implements CCDConfig<PCSCase, State, UserRole> {
             applicantParty
         );
 
-        documentImportService.addDocumentToCase(caseReference, documentUrl, CaseFileCategory.APPLICATIONS);
+        DocumentEntity documentEntity = documentImportService
+            .addDocumentToCase(caseReference, documentUrl, CaseFileCategory.APPLICATIONS);
+
+        genAppEntity.setSubmissionDocument(documentEntity);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/MakeAnApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/MakeAnApplicationTest.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
 import uk.gov.hmcts.reform.pcs.ccd.domain.genapp.CitizenGenAppRequest;
 import uk.gov.hmcts.reform.pcs.ccd.domain.genapp.GenAppType;
 import uk.gov.hmcts.reform.pcs.ccd.domain.genapp.XuiGenAppRequest;
+import uk.gov.hmcts.reform.pcs.ccd.entity.DocumentEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.GenAppEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
@@ -47,8 +48,10 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -63,7 +66,7 @@ class MakeAnApplicationTest extends BaseEventTest {
     private PartyService partyService;
     @Mock
     private SecurityContextService securityContextService;
-    @Mock
+    @Mock(strictness = LENIENT)
     private GenAppService genAppService;
     @Mock
     private GenAppRepository genAppRepository;
@@ -75,11 +78,17 @@ class MakeAnApplicationTest extends BaseEventTest {
     private LegalRepresentativeService legalRepresentativeService;
     @Mock
     private FeeApplier feeApplier;
+    @Mock
+    private GenAppEntity genAppEntity;
     @Captor
     private ArgumentCaptor<BiConsumer<PCSCase, String>> feeSetterCaptor;
 
     @BeforeEach
     void setUp() {
+        when(genAppService.createGenAppEntity(any(CitizenGenAppRequest.class),
+                                              any(PcsCaseEntity.class),
+                                              any(PartyEntity.class))).thenReturn(genAppEntity);
+
         MakeAnApplication underTest = new MakeAnApplication(pcsCaseService, partyService,
                                                             securityContextService, genAppService,
                                                             genAppRepository, genAppDocumentGenerator,
@@ -309,14 +318,14 @@ class MakeAnApplicationTest extends BaseEventTest {
 
             PartyEntity applicantParty = stubCurrentUserParty();
 
-            GenAppEntity genAppEntity = mock(GenAppEntity.class);
-            when(genAppService.createGenAppEntity(genAppRequest, pcsCaseEntity, applicantParty))
-                .thenReturn(genAppEntity);
-
             String documentUrl = "some document URL";
             when(genAppDocumentGenerator
                      .generateSubmissionDocument(TEST_CASE_REFERENCE, genAppRequest, genAppEntity, applicantParty))
                 .thenReturn(documentUrl);
+
+            DocumentEntity documentEntity = mock(DocumentEntity.class);
+            when(documentImportService.addDocumentToCase(eq(TEST_CASE_REFERENCE), anyString(), any()))
+                .thenReturn(documentEntity);
 
             // When
             callSubmitHandler(caseData);
@@ -325,6 +334,8 @@ class MakeAnApplicationTest extends BaseEventTest {
             verify(documentImportService).addDocumentToCase(TEST_CASE_REFERENCE, documentUrl,
                                                             CaseFileCategory.APPLICATIONS
             );
+
+            verify(genAppEntity).setSubmissionDocument(documentEntity);
         }
 
         private PartyEntity stubCurrentUserParty() {


### PR DESCRIPTION
### Jira link

See [HDPI-4573](https://tools.hmcts.net/jira/browse/HDPI-4573)

### Change description

The [original PR](https://github.com/hmcts/pcs-api/pull/1802) for HDPI-4573 added a code change to `CitizenCreateGenApp` to set the submission document on a gen app before persisting. However, when updating that PR branch with the latest from master, the `CitizenCreateGenApp` class had been renamed to `MakeAnApplication` and the code change was lost in the merge.

This PR puts that change back. For info, the change in the original PR can be seen in the class `CitizenCreateGenApp.java‎` in this commit:

https://github.com/hmcts/pcs-api/pull/1802/changes/746b08b7a366e03f830259b8f1c68c27d1e0b974#diff-8cf498235c3aeed85efa25c270e5e1aa1e237f8ecebed0776572cbd471cafe35L98


### Testing done

Full build run. Code changes tested locally with pcs-frontend to confirm that it fixes the issues seen in the pcs-frontend functional tests in master

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
