### PR TITLE
HDPI-6756 - Remove defendant name if name known set from Yes to No.

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/DefendantsDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/DefendantsDetails.java
@@ -78,6 +78,11 @@ public class DefendantsDetails implements CcdPageConfiguration {
 
         PCSCase caseData = details.getData();
 
+        if (caseData.getDefendant1().getNameKnown() == VerticalYesNo.NO) {
+            caseData.getDefendant1().setFirstName(null);
+            caseData.getDefendant1().setLastName(null);
+        }
+
         boolean additionalDefendantsProvided = caseData.getAddAnotherDefendant() == VerticalYesNo.YES;
 
         DefendantDetails defendantDetails = caseData.getDefendant1();

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/DraftCaseJsonMerger.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/DraftCaseJsonMerger.java
@@ -14,8 +14,7 @@ import java.util.Set;
 @Component
 public class DraftCaseJsonMerger {
 
-    private static final Set<String> REPLACE_FIELDS = Set.of("address");
-
+    private static final Set<String> REPLACE_FIELDS = Set.of("address, defendant1");
 
     private final ObjectMapper objectMapper;
 
@@ -61,7 +60,7 @@ public class DraftCaseJsonMerger {
             if (base.has(fieldName)) {
                 JsonNode baseChild = base.get(fieldName);
 
-                if (REPLACE_FIELDS.contains(fieldName.toLowerCase())
+                if (REPLACE_FIELDS.stream().anyMatch(s -> s.contains(fieldName.toLowerCase()))
                     && patchChild.isObject()
                     && base instanceof ObjectNode) {
 

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/DefendantsDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/page/resumepossessionclaim/DefendantsDetailsTest.java
@@ -103,6 +103,54 @@ class DefendantsDetailsTest extends BasePageTest {
                                                                  errorMessage1, errorMessage2, errorMessage3);
     }
 
+    @Test
+    void shouldSetDefendantNameToNullIfNameKnownFalse() {
+        // Given
+        DefendantDetails defendant1 = DefendantDetails.builder()
+                .nameKnown(VerticalYesNo.NO)
+                .firstName("John")
+                .lastName("Smith")
+                .addressKnown(VerticalYesNo.NO)
+                .build();
+        PCSCase caseData = PCSCase.builder()
+            .defendant1(defendant1)
+            .addAnotherDefendant(VerticalYesNo.NO)
+            .additionalDefendants(List.of())
+            .defendantCircumstances(new DefendantCircumstances())
+            .build();
+
+        // When
+        AboutToStartOrSubmitResponse<PCSCase, State> response = callMidEventHandler(caseData);
+
+        // Then
+        assertThat(response.getData().getDefendant1().getFirstName()).isNull();
+        assertThat(response.getData().getDefendant1().getLastName()).isNull();
+    }
+
+    @Test
+    void shouldLeaveDefendantNamesIfNameKnownTrue() {
+        // Given
+        DefendantDetails defendant1 = DefendantDetails.builder()
+                .nameKnown(VerticalYesNo.YES)
+                .firstName("John")
+                .lastName("Smith")
+                .addressKnown(VerticalYesNo.NO)
+                .build();
+        PCSCase caseData = PCSCase.builder()
+                .defendant1(defendant1)
+                .addAnotherDefendant(VerticalYesNo.NO)
+                .additionalDefendants(List.of())
+                .defendantCircumstances(new DefendantCircumstances())
+                .build();
+
+        // When
+        AboutToStartOrSubmitResponse<PCSCase, State> response = callMidEventHandler(caseData);
+
+        // Then
+        assertThat(response.getData().getDefendant1().getFirstName()).isEqualTo("John");
+        assertThat(response.getData().getDefendant1().getLastName()).isEqualTo("Smith");
+    }
+
     @ParameterizedTest
     @MethodSource("defendantTermScenarios")
     void shouldSetDefendantTermPossessive(VerticalYesNo additionalDefendants, String expectedTermPossessive) {

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/DraftCaseJsonMergerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/DraftCaseJsonMergerTest.java
@@ -205,4 +205,35 @@ class DraftCaseJsonMergerTest {
         assertThat(address.get("PostCode").asText()).isEqualTo("ABC123");
     }
 
+    @Test
+    void shouldClearDefendantNameIfPatchDoesNotContainName() throws Exception {
+        //Given
+        String baseJson = """
+        {
+          "defendant1": {
+            "nameKnown": "YES",
+            "firstName": "Jane",
+            "lastName": "Doe"
+          }
+        }
+            """;
+
+        String patchJson = """
+            {
+              "defendant1": {
+                "nameKnown": "NO"
+                }
+              }
+            }
+            """;
+
+        // When
+        String mergedJson = underTest.mergeJson(baseJson, patchJson);
+        JsonNode merged = objectMapper.readTree(mergedJson);
+        JsonNode defendant = merged.at("/defendant1");
+
+        // Then: name fields cleared
+        assertThat(defendant.get("firstName")).isNull();
+        assertThat(defendant.get("lastName")).isNull();
+    }
 }


### PR DESCRIPTION
### Jira link

See [HDPI-6756](https://tools.hmcts.net/jira/browse/HDPI-6756)

### Change description

Ensure the first name and last name are cleared if the nameKnown field is set to 'No' when previously set to 'Yes'.

### Testing done

XUI testing done to ensure the draft data shows no first or last names when the nameKnown is set to 'NO' after previously having it set to 'Yes' with defendant name and stored in draft.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change