### PR TITLE
Add acr login before running CCD definition-processor docker

### DIFF
--- a/bin/create-xlsx.sh
+++ b/bin/create-xlsx.sh
@@ -20,6 +20,8 @@ for case_dir in "$run_dir"/build/definitions/*/; do
 
   ccd_definition_file="CCD_Definition_${case_type}_${env}.xlsx"
 
+az acr login -n hmctsprod
+
 docker run --rm --name "json2xlsx" \
   -v "$run_dir/build/definitions/${case_type}:/tmp/ccd-input" \
   -v "$run_dir/build/definitions:/tmp/ccd-output" \


### PR DESCRIPTION
### Change description

Trying an `acr login` before pulling the docker image to generate CCD definition XLS, to see if that avoids the issue we have seen in occasional builds.

### Testing done

Pipeline run.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
