### PR TITLE
HDPI-6033: Refactor FeesAndPayTaskComponent to use consistent naming

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/ResumePossessionClaim.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/ResumePossessionClaim.java
@@ -51,7 +51,7 @@ import static uk.gov.hmcts.reform.pcs.ccd.event.EventId.resumePossessionClaim;
 import static uk.gov.hmcts.reform.pcs.ccd.task.AccessCodeGenerationComponent.ACCESS_CODE_TASK_DESCRIPTOR;
 import static uk.gov.hmcts.reform.pcs.ccd.util.AddressFormatter.BR_DELIMITER;
 import static uk.gov.hmcts.reform.pcs.feesandpay.model.PaymentCallbackHandlerType.CLAIM;
-import static uk.gov.hmcts.reform.pcs.feesandpay.task.FeesAndPayTaskComponent.FEE_CASE_ISSUED_TASK_DESCRIPTOR;
+import static uk.gov.hmcts.reform.pcs.feesandpay.task.FeesAndPayTaskComponent.FEES_AND_PAY_TASK_DESCRIPTOR;
 
 @Slf4j
 @Component
@@ -216,7 +216,7 @@ public class ResumePossessionClaim implements CCDConfig<PCSCase, State, UserRole
             .build();
 
         schedulerClient.scheduleIfNotExists(
-            FEE_CASE_ISSUED_TASK_DESCRIPTOR
+            FEES_AND_PAY_TASK_DESCRIPTOR
                 .instance(UUID.randomUUID().toString())
                 .data(taskData)
                 .scheduledTo(Instant.now().plusSeconds(schedulingConfig.getScheduleFeeCaseIssuedInSeconds()))

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/ResumePossessionClaim.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/ResumePossessionClaim.java
@@ -207,7 +207,6 @@ public class ResumePossessionClaim implements CCDConfig<PCSCase, State, UserRole
     private FeeDetails scheduleCaseIssueFeePayment(long caseReference, UUID responsiblePartyId) {
         FeeDetails feeDetails = feeService.getFee(FeeType.CASE_ISSUE_FEE);
         FeesAndPayTaskData taskData = FeesAndPayTaskData.builder()
-            .feeType(FeeType.CASE_ISSUE_FEE.getCode())
             .feeDetails(feeDetails)
             .ccdCaseNumber(String.valueOf(caseReference))
             .caseReference(caseReference)

--- a/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/model/FeesAndPayTaskData.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/model/FeesAndPayTaskData.java
@@ -18,8 +18,6 @@ public class FeesAndPayTaskData implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private String feeType;
-
     private FeeDetails feeDetails;
 
     private long caseReference;

--- a/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/task/FeesAndPayTaskComponent.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/task/FeesAndPayTaskComponent.java
@@ -53,13 +53,13 @@ public class FeesAndPayTaskComponent {
             ))
             .execute((taskInstance, executionContext) -> {
                 FeesAndPayTaskData taskData = taskInstance.getData();
-                log.debug("Executing fee service request for fee type: {}", taskData.getFeeType());
+                log.debug("Executing fee service request for fee details: {}", taskData.getFeeDetails());
                 try {
                     paymentService.createServiceRequest(taskData);
                     return new CompletionHandler.OnCompleteRemove<>();
                 } catch (Exception e) {
-                    log.error("Failed to create fee service request for type: {}. Attempt {}/{}",
-                                taskData.getFeeType(),
+                    log.error("Failed to create fee service request for fee details: {}. Attempt {}/{}",
+                                taskData.getFeeDetails(),
                                 executionContext.getExecution().consecutiveFailures + 1,
                                 maxRetriesFeesAndPay,
                                 e);

--- a/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/task/FeesAndPayTaskComponent.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/task/FeesAndPayTaskComponent.java
@@ -18,10 +18,10 @@ import java.time.Duration;
 @Component
 public class FeesAndPayTaskComponent {
 
-    private static final String FEES_AND_PAY_CASE_ISSUED_TASK_NAME = "fees-and-pay-task";
+    private static final String FEES_AND_PAY_TASK_NAME = "fees-and-pay-task";
 
-    public static final TaskDescriptor<FeesAndPayTaskData> FEE_CASE_ISSUED_TASK_DESCRIPTOR =
-        TaskDescriptor.of(FEES_AND_PAY_CASE_ISSUED_TASK_NAME, FeesAndPayTaskData.class);
+    public static final TaskDescriptor<FeesAndPayTaskData> FEES_AND_PAY_TASK_DESCRIPTOR =
+        TaskDescriptor.of(FEES_AND_PAY_TASK_NAME, FeesAndPayTaskData.class);
 
     private final PaymentService paymentService;
     private final int maxRetriesFeesAndPay;
@@ -46,7 +46,7 @@ public class FeesAndPayTaskComponent {
      */
     @Bean
     public CustomTask<FeesAndPayTaskData> feePaymentTask() {
-        return Tasks.custom(FEE_CASE_ISSUED_TASK_DESCRIPTOR)
+        return Tasks.custom(FEES_AND_PAY_TASK_DESCRIPTOR)
             .onFailure(new FailureHandler.MaxRetriesFailureHandler<>(
                 maxRetriesFeesAndPay,
                 new FailureHandler.ExponentialBackoffFailureHandler<>(feesAndPayBackoffDelay)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -223,8 +223,8 @@ fees:
       amountOrVolume: 1
       keyword: SealWrit
   request:
-    max-retries: ${NOTIFY_CHECK_STATUS_MAX_RETRIES:5}
-    backoff-delay-seconds: ${NOTIFY_CHECK_STATUS_BACKOFF_DELAY_SECONDS:3600s}
+    max-retries: ${FEES_AND_PAY_TASK_MAX_RETRIES:5}
+    backoff-delay-seconds: ${FEES_AND_PAY_TASK_BACKOFF_DELAY_SECONDS:600s}
 
 access-code:
   hash-pins-enabled: ${HASH_PINS_ENABLED:false}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/ResumePossessionClaimTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/ResumePossessionClaimTest.java
@@ -63,7 +63,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.pcs.ccd.domain.CompletionNextStep.SUBMIT_AND_PAY_NOW;
 import static uk.gov.hmcts.reform.pcs.ccd.event.EventId.resumePossessionClaim;
 import static uk.gov.hmcts.reform.pcs.ccd.task.AccessCodeGenerationComponent.ACCESS_CODE_TASK_DESCRIPTOR;
-import static uk.gov.hmcts.reform.pcs.feesandpay.task.FeesAndPayTaskComponent.FEE_CASE_ISSUED_TASK_DESCRIPTOR;
+import static uk.gov.hmcts.reform.pcs.feesandpay.task.FeesAndPayTaskComponent.FEES_AND_PAY_TASK_DESCRIPTOR;
 import static uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry.ENGLAND;
 import static uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry.SCOTLAND;
 import static uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry.WALES;
@@ -440,7 +440,7 @@ class ResumePossessionClaimTest extends BaseEventTest {
             callSubmitHandler(caseData);
 
             // Then
-            FeesAndPayTaskData taskData = getScheduledTaskData(FEE_CASE_ISSUED_TASK_DESCRIPTOR);
+            FeesAndPayTaskData taskData = getScheduledTaskData(FEES_AND_PAY_TASK_DESCRIPTOR);
             assertThat(taskData.getResponsiblePartyId()).isEqualTo(claimantPartyId);
         }
 
@@ -457,7 +457,7 @@ class ResumePossessionClaimTest extends BaseEventTest {
             callSubmitHandler(caseData);
 
             // Then
-            FeesAndPayTaskData taskData = getScheduledTaskData(FEE_CASE_ISSUED_TASK_DESCRIPTOR);
+            FeesAndPayTaskData taskData = getScheduledTaskData(FEES_AND_PAY_TASK_DESCRIPTOR);
             assertThat(taskData.getFeeType()).isEqualTo(FeeType.CASE_ISSUE_FEE.getCode());
             assertThat(taskData.getFeeDetails()).isEqualTo(feeDetails);
             assertThat(taskData.getCaseReference()).isEqualTo(TEST_CASE_REFERENCE);

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/ResumePossessionClaimTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/ResumePossessionClaimTest.java
@@ -458,7 +458,6 @@ class ResumePossessionClaimTest extends BaseEventTest {
 
             // Then
             FeesAndPayTaskData taskData = getScheduledTaskData(FEES_AND_PAY_TASK_DESCRIPTOR);
-            assertThat(taskData.getFeeType()).isEqualTo(FeeType.CASE_ISSUE_FEE.getCode());
             assertThat(taskData.getFeeDetails()).isEqualTo(feeDetails);
             assertThat(taskData.getCaseReference()).isEqualTo(TEST_CASE_REFERENCE);
             assertThat(taskData.getCcdCaseNumber()).isEqualTo(String.valueOf(TEST_CASE_REFERENCE));

--- a/src/test/java/uk/gov/hmcts/reform/pcs/feesandpay/task/FeesAndPayTaskComponentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/feesandpay/task/FeesAndPayTaskComponentTest.java
@@ -18,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.pcs.feesandpay.model.FeeDetails;
-import uk.gov.hmcts.reform.pcs.feesandpay.model.FeeType;
 import uk.gov.hmcts.reform.pcs.feesandpay.model.FeesAndPayTaskData;
 import uk.gov.hmcts.reform.pcs.feesandpay.service.PaymentService;
 
@@ -69,9 +68,8 @@ class FeesAndPayTaskComponentTest {
         when(executionContext.getExecution()).thenReturn(execution);
     }
 
-    private FeesAndPayTaskData buildTaskData(String feeType, FeeDetails feeDetails) {
+    private FeesAndPayTaskData buildTaskData(FeeDetails feeDetails) {
         return FeesAndPayTaskData.builder()
-            .feeType(feeType)
             .feeDetails(feeDetails)
             .caseReference(123)
             .ccdCaseNumber("1111-2222-3333-4444")
@@ -109,7 +107,7 @@ class FeesAndPayTaskComponentTest {
         @DisplayName("Should create service request with fee details")
         void shouldCreateServiceRequestWithFeeDetails() {
             FeeDetails feeDetails = mock(FeeDetails.class);
-            FeesAndPayTaskData data = buildTaskData("some fee type", feeDetails);
+            FeesAndPayTaskData data = buildTaskData(feeDetails);
             when(taskInstance.getData()).thenReturn(data);
 
             CustomTask<FeesAndPayTaskData> task = feesAndPayTaskComponent.feePaymentTask();
@@ -129,7 +127,7 @@ class FeesAndPayTaskComponentTest {
         @DisplayName("Should rethrow exception when payment service call fails")
         void shouldThrowFeeNotFoundExceptionWhenApiCallFails() {
             FeeDetails feeDetails = mock(FeeDetails.class);
-            FeesAndPayTaskData data = buildTaskData(FeeType.CASE_ISSUE_FEE.getCode(), feeDetails);
+            FeesAndPayTaskData data = buildTaskData(feeDetails);
             when(taskInstance.getData()).thenReturn(data);
 
             FeignException exception = mock(FeignException.class);

--- a/src/test/java/uk/gov/hmcts/reform/pcs/feesandpay/task/FeesAndPayTaskComponentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/feesandpay/task/FeesAndPayTaskComponentTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.pcs.feesandpay.task.FeesAndPayTaskComponent.FEE_CASE_ISSUED_TASK_DESCRIPTOR;
+import static uk.gov.hmcts.reform.pcs.feesandpay.task.FeesAndPayTaskComponent.FEES_AND_PAY_TASK_DESCRIPTOR;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -87,9 +87,9 @@ class FeesAndPayTaskComponentTest {
         @Test
         @DisplayName("Should create task descriptor with correct name and type")
         void shouldCreateTaskDescriptorWithCorrectNameAndType() {
-            assertThat(FEE_CASE_ISSUED_TASK_DESCRIPTOR.getTaskName())
+            assertThat(FEES_AND_PAY_TASK_DESCRIPTOR.getTaskName())
                 .isEqualTo("fees-and-pay-task");
-            assertThat(FEE_CASE_ISSUED_TASK_DESCRIPTOR.getDataClass())
+            assertThat(FEES_AND_PAY_TASK_DESCRIPTOR.getDataClass())
                 .isEqualTo(FeesAndPayTaskData.class);
         }
 


### PR DESCRIPTION
### Jira link

See [HDPI-6033](https://tools.hmcts.net/jira/browse/HDPI-6033)

### Change description

Refactor FeesAndPayTaskComponent to use consistent naming, as it mentions CASE_ISSUED in some of the names.
Also changing the env vars used to override the retry config, and reducing the default backoff interval from 1 hour to 10 minutes.

### Testing done

Full build run

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
