### PR TITLE
HDPI-4276: Serialise scheduler task data as JSON

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcs/controllers/PaymentCallBackControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcs/controllers/PaymentCallBackControllerIT.java
@@ -17,7 +17,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.payments.client.models.FeeDto;
-import uk.gov.hmcts.reform.pcs.idam.IdamUserInfoApi;
 import uk.gov.hmcts.reform.pcs.ccd.entity.ClaimEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.feesandpay.FeePaymentEntity;
@@ -32,6 +31,7 @@ import uk.gov.hmcts.reform.pcs.feesandpay.model.PaymentStatusCallback;
 import uk.gov.hmcts.reform.pcs.feesandpay.service.PaymentCallbackStrategy;
 import uk.gov.hmcts.reform.pcs.feesandpay.service.PaymentCallbackStrategyFactory;
 import uk.gov.hmcts.reform.pcs.feesandpay.service.PaymentService;
+import uk.gov.hmcts.reform.pcs.idam.IdamUserInfoApi;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -74,26 +74,27 @@ public class PaymentCallBackControllerIT extends AbstractPostgresContainerIT {
     @Mock
     private PaymentCallbackStrategy pretendStrategy;
 
-    private long caseReference;
     private String serviceCaseReference;
-    private FeeDto feeDto;
     private FeesAndPayTaskData feesAndPayTaskData;
     private ClaimEntity claimEntity;
 
     @BeforeEach
     void setUp() throws JsonProcessingException {
         serviceCaseReference = UUID.randomUUID().toString();
-        feesAndPayTaskData = Instancio.create(FeesAndPayTaskData.class);
-        feesAndPayTaskData.setCaseReference(CASE_REFERENCE);
-        feesAndPayTaskData.setPaymentCallbackHandlerType(PaymentCallbackHandlerType.CLAIM);
-        caseReference = feesAndPayTaskData.getCaseReference();
-        feeDto = Instancio.create(FeeDto.class);
-        feeDto.setCcdCaseNumber(String.valueOf(caseReference));
+        FeeDto feeDto = Instancio.create(FeeDto.class);
+        feeDto.setCcdCaseNumber(String.valueOf(CASE_REFERENCE));
         PcsCaseEntity pcsCaseEntity = establishTestCase();
         claimEntity = pcsCaseEntity.getClaims().getFirst();
         ClaimPartyEntity claimPartyEntity = claimEntity.getClaimParties().getFirst();
         UUID claimantPartyId = claimPartyEntity.getParty().getId();
-        feesAndPayTaskData.setResponsiblePartyId(claimantPartyId);
+
+        feesAndPayTaskData = Instancio.create(FeesAndPayTaskData.class);
+        feesAndPayTaskData.toBuilder()
+            .caseReference(CASE_REFERENCE)
+            .paymentCallbackHandlerType(PaymentCallbackHandlerType.CLAIM)
+            .responsiblePartyId(claimantPartyId)
+            .build();
+
         Mockito.when(paymentCallbackStrategyFactory.getStrategy(any())).thenReturn(pretendStrategy);
         establishFeePayment(serviceCaseReference);
     }
@@ -103,7 +104,7 @@ public class PaymentCallBackControllerIT extends AbstractPostgresContainerIT {
     void shouldProcessPaymentCallback() throws Exception {
         // Given
         PaymentStatusCallback paymentStatusCallback = Instancio.create(PaymentStatusCallback.class);
-        paymentStatusCallback.setCcdCaseNumber(String.valueOf(caseReference));
+        paymentStatusCallback.setCcdCaseNumber(String.valueOf(CASE_REFERENCE));
         paymentStatusCallback.setServiceRequestReference(serviceCaseReference);
         paymentStatusCallback.setServiceRequestStatus(PaymentStatus.PAID.getValue());
 
@@ -125,7 +126,7 @@ public class PaymentCallBackControllerIT extends AbstractPostgresContainerIT {
 
     PcsCaseEntity establishTestCase() {
         return caseCreationHelper
-            .createTestCaseWithParty(caseReference, null, PartyRole.CLAIMANT);
+            .createTestCaseWithParty(CASE_REFERENCE, null, PartyRole.CLAIMANT);
     }
 
     void establishFeePayment(String serviceCaseReference) throws JsonProcessingException {

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/model/AccessCodeTaskData.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/model/AccessCodeTaskData.java
@@ -3,19 +3,12 @@ package uk.gov.hmcts.reform.pcs.ccd.model;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import java.io.Serial;
-import java.io.Serializable;
 
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
-public class AccessCodeTaskData implements Serializable {
+public class AccessCodeTaskData {
 
-    @Serial
-    private static final long serialVersionUID = 1L;
+    private final String caseReference;
 
-    private String caseReference;
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/model/RoleAssignmentTaskData.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/model/RoleAssignmentTaskData.java
@@ -3,18 +3,13 @@ package uk.gov.hmcts.reform.pcs.ccd.model;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import java.io.Serial;
-import java.io.Serializable;
 
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
-public class RoleAssignmentTaskData implements Serializable {
-    @Serial
-    private static final long serialVersionUID = 1L;
-    private String caseReference;
-    private String userId;
+public class RoleAssignmentTaskData {
+
+    private final String caseReference;
+    private final String userId;
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/config/SchedulingConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/config/SchedulingConfig.java
@@ -1,9 +1,11 @@
 package uk.gov.hmcts.reform.pcs.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.SchedulerClient;
 import com.github.kagkarlsson.scheduler.event.ExecutionInterceptor;
 import com.github.kagkarlsson.scheduler.event.SchedulerListener;
+import com.github.kagkarlsson.scheduler.serializer.JacksonSerializer;
 import com.github.kagkarlsson.scheduler.task.Task;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -17,8 +19,6 @@ import org.springframework.context.annotation.Primary;
 import javax.sql.DataSource;
 import java.time.Duration;
 import java.util.List;
-
-import static com.github.kagkarlsson.scheduler.boot.config.DbSchedulerConfigurationSupport.SPRING_JAVA_SERIALIZER;
 
 @Configuration
 @Slf4j
@@ -34,8 +34,11 @@ public class SchedulingConfig {
      */
     @Bean
     @Primary
-    public SchedulerClient schedulerClient(DataSource dataSource) {
-        return SchedulerClient.Builder.create(dataSource).build();
+    public SchedulerClient schedulerClient(DataSource dataSource, ObjectMapper objectMapper) {
+        return SchedulerClient.Builder
+            .create(dataSource)
+            .serializer(new JacksonSerializer(objectMapper))
+            .build();
     }
 
     /**
@@ -51,19 +54,18 @@ public class SchedulingConfig {
     @ConditionalOnProperty(prefix = "db-scheduler", name = "executor-enabled", havingValue = "true")
     @DependsOn("schedulerClient")
     public Scheduler startupTasksScheduler(DataSource dataSource,
-                                            @Value("${db-scheduler.threads}")
-                                            int threadCount,
-                                            @Value("${db-scheduler.polling-interval-seconds}")
-                                            long interval,
-                                            List<Task<?>> tasks,
-                                            List<SchedulerListener> schedulerListeners,
-                                            List<ExecutionInterceptor> executionInterceptors) {
+                                           ObjectMapper objectMapper,
+                                           @Value("${db-scheduler.threads}") int threadCount,
+                                           @Value("${db-scheduler.polling-interval-seconds}") long interval,
+                                           List<Task<?>> tasks,
+                                           List<SchedulerListener> schedulerListeners,
+                                           List<ExecutionInterceptor> executionInterceptors) {
         log.info("Starting scheduler");
 
         var builder = Scheduler.create(dataSource, tasks)
             .threads(threadCount)
             .pollingInterval(Duration.ofSeconds(interval))
-            .serializer(SPRING_JAVA_SERIALIZER)
+            .serializer(new JacksonSerializer(objectMapper))
             .registerShutdownHook();
 
         schedulerListeners.forEach(builder::addSchedulerListener);

--- a/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/model/FeeDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/model/FeeDetails.java
@@ -1,19 +1,16 @@
 package uk.gov.hmcts.reform.pcs.feesandpay.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import uk.gov.hmcts.reform.fees.client.model.FeeLookupResponseDto;
 
-import java.io.Serial;
-import java.io.Serializable;
 import java.math.BigDecimal;
 
 @Data
 @Builder
-public class FeeDetails implements Serializable {
-
-    @Serial
-    private static final long serialVersionUID = 1L;
+@AllArgsConstructor
+public class FeeDetails {
 
     private final String code;
     private final String description;

--- a/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/model/FeesAndPayTaskData.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/model/FeesAndPayTaskData.java
@@ -11,8 +11,6 @@ import java.util.UUID;
 @AllArgsConstructor
 public class FeesAndPayTaskData {
 
-    private final String feeType;
-
     private final FeeDetails feeDetails;
 
     private final long caseReference;

--- a/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/model/FeesAndPayTaskData.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/model/FeesAndPayTaskData.java
@@ -3,33 +3,27 @@ package uk.gov.hmcts.reform.pcs.feesandpay.model;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
-import java.io.Serial;
-import java.io.Serializable;
 import java.util.UUID;
 
 @Data
-@Builder
-@NoArgsConstructor
+@Builder(toBuilder = true)
 @AllArgsConstructor
-public class FeesAndPayTaskData implements Serializable {
+public class FeesAndPayTaskData {
 
-    @Serial
-    private static final long serialVersionUID = 1L;
+    private final String feeType;
 
-    private String feeType;
+    private final FeeDetails feeDetails;
 
-    private FeeDetails feeDetails;
+    private final long caseReference;
 
-    private long caseReference;
-
-    private String ccdCaseNumber;
+    private final String ccdCaseNumber;
 
     @Builder.Default
-    private Integer volume = 1;
+    private final Integer volume = 1;
 
-    private UUID responsiblePartyId;
+    private final UUID responsiblePartyId;
 
-    private PaymentCallbackHandlerType paymentCallbackHandlerType;
+    private final PaymentCallbackHandlerType paymentCallbackHandlerType;
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/notify/model/EmailState.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/notify/model/EmailState.java
@@ -3,27 +3,22 @@ package uk.gov.hmcts.reform.pcs.notify.model;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
-import java.io.Serial;
-import java.io.Serializable;
 import java.util.Map;
 import java.util.UUID;
 
 @Data
 @Builder(toBuilder = true)
-@NoArgsConstructor
 @AllArgsConstructor
-public class EmailState implements Serializable {
-    @Serial
-    private static final long serialVersionUID = 1L;
+public class EmailState {
 
-    private String id;
-    private String emailAddress;
-    private String templateId;
-    private Map<String, Object> personalisation;
-    private String reference;
-    private String emailReplyToId;
-    private String notificationId; // GOV.UK Notify notification ID (set after sending)
-    private UUID dbNotificationId; // Database notification record ID (set before sending)
+    private final String id;
+    private final String emailAddress;
+    private final String templateId;
+    private final Map<String, Object> personalisation;
+    private final String reference;
+    private final String emailReplyToId;
+    private final String notificationId; // GOV.UK Notify notification ID (set after sending)
+    private final UUID dbNotificationId; // Database notification record ID (set before sending)
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/notify/model/SendEmailTaskData.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/notify/model/SendEmailTaskData.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 @Data
 @Builder(toBuilder = true)
 @AllArgsConstructor
-public class EmailState {
+public class SendEmailTaskData {
 
     private final String id;
     private final String emailAddress;

--- a/src/main/java/uk/gov/hmcts/reform/pcs/notify/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/notify/service/NotificationService.java
@@ -23,7 +23,7 @@ import uk.gov.hmcts.reform.pcs.notify.entities.CaseNotification;
 import uk.gov.hmcts.reform.pcs.notify.exception.NotificationException;
 import uk.gov.hmcts.reform.pcs.notify.model.EmailNotificationRequest;
 import uk.gov.hmcts.reform.pcs.notify.model.EmailNotificationResponse;
-import uk.gov.hmcts.reform.pcs.notify.model.EmailState;
+import uk.gov.hmcts.reform.pcs.notify.model.SendEmailTaskData;
 import uk.gov.hmcts.reform.pcs.notify.model.NotificationStatus;
 import uk.gov.hmcts.reform.pcs.notify.repository.NotificationRepository;
 import uk.gov.hmcts.reform.pcs.notify.template.EmailTemplate;
@@ -122,7 +122,7 @@ public class NotificationService {
             party
         );
 
-        EmailState emailState = new EmailState(
+        SendEmailTaskData taskData = new SendEmailTaskData(
             taskId,
             emailRequest.getEmailAddress(),
             emailRequest.getTemplateId(),
@@ -136,7 +136,7 @@ public class NotificationService {
         boolean scheduled = schedulerClient.scheduleIfNotExists(
             SendEmailTaskComponent.sendEmailTask
                 .instance(taskId)
-                .data(emailState)
+                .data(taskData)
                 .scheduledTo(Instant.now())
         );
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/notify/task/SendEmailTaskComponent.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/notify/task/SendEmailTaskComponent.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.pcs.notify.config.NotificationErrorHandler;
 import uk.gov.hmcts.reform.pcs.notify.config.NotificationErrorHandler.NotificationStatusUpdate;
 import uk.gov.hmcts.reform.pcs.notify.entities.CaseNotification;
-import uk.gov.hmcts.reform.pcs.notify.model.EmailState;
+import uk.gov.hmcts.reform.pcs.notify.model.SendEmailTaskData;
 import uk.gov.hmcts.reform.pcs.notify.exception.PermanentNotificationException;
 import uk.gov.hmcts.reform.pcs.notify.exception.TemporaryNotificationException;
 import uk.gov.hmcts.reform.pcs.notify.repository.NotificationRepository;
@@ -37,8 +37,8 @@ import static uk.gov.hmcts.reform.pcs.notify.task.VerifyEmailTaskComponent.verif
 public class SendEmailTaskComponent {
     private static final String SEND_EMAIL_TASK_NAME = "send-email-task";
 
-    public static final TaskDescriptor<EmailState> sendEmailTask =
-        TaskDescriptor.of(SEND_EMAIL_TASK_NAME, EmailState.class);
+    public static final TaskDescriptor<SendEmailTaskData> sendEmailTask =
+        TaskDescriptor.of(SEND_EMAIL_TASK_NAME, SendEmailTaskData.class);
 
     private final NotificationService notificationService;
     private final NotificationClient notificationClient;
@@ -80,30 +80,30 @@ public class SendEmailTaskComponent {
      * @return the custom task for sending email notifications
      */
     @Bean
-    public CustomTask<EmailState> sendEmailTask() {
+    public CustomTask<SendEmailTaskData> sendEmailTask() {
         return Tasks.custom(sendEmailTask)
             .onFailure(new FailureHandler.MaxRetriesFailureHandler<>(
                 maxRetriesSendEmail,
                 new FailureHandler.ExponentialBackoffFailureHandler<>(sendingBackoffDelay)
             ))
             .execute((taskInstance, executionContext) -> {
-                EmailState emailState = taskInstance.getData();
+                SendEmailTaskData taskData = taskInstance.getData();
                 log.info("Processing send email task: {} with DB notification ID: {}",
-                         emailState.getId(), emailState.getDbNotificationId());
+                         taskData.getId(), taskData.getDbNotificationId());
 
                 Optional<CaseNotification> notificationOpt = notificationRepository.findById(
-                    emailState.getDbNotificationId());
+                    taskData.getDbNotificationId());
                 if (notificationOpt.isEmpty()) {
-                    log.error("Notification not found with ID: {}", emailState.getDbNotificationId());
+                    log.error("Notification not found with ID: {}", taskData.getDbNotificationId());
                     return new CompletionHandler.OnCompleteRemove<>();
                 }
 
                 CaseNotification caseNotification = notificationOpt.get();
 
                 try {
-                    final String templateId = emailState.getTemplateId();
-                    final String destinationAddress = emailState.getEmailAddress();
-                    final Map<String, Object> personalisation = emailState.getPersonalisation();
+                    final String templateId = taskData.getTemplateId();
+                    final String destinationAddress = taskData.getEmailAddress();
+                    final Map<String, Object> personalisation = taskData.getPersonalisation();
                     final String referenceId = UUID.randomUUID().toString();
 
                     SendEmailResponse response = notificationClient.sendEmail(
@@ -114,21 +114,21 @@ public class SendEmailTaskComponent {
                     );
 
                     if (response.getNotificationId() == null) {
-                        log.error("Email service returned null notification ID for task: {}", emailState.getId());
+                        log.error("Email service returned null notification ID for task: {}", taskData.getId());
                         throw new PermanentNotificationException("Null notification ID from email service",
                                                                     new IllegalStateException(
                                                                         "Email service returned null notification ID"));
                     }
 
                     notificationService.updateNotificationAfterSending(
-                        emailState.getDbNotificationId(),
+                        taskData.getDbNotificationId(),
                         response.getNotificationId()
                     );
 
                     String notificationId = response.getNotificationId().toString();
                     log.info("Request sent successfully. Notification ID: {}", notificationId);
 
-                    EmailState nextState = emailState.toBuilder()
+                    SendEmailTaskData nextState = taskData.toBuilder()
                         .notificationId(notificationId)
                         .build();
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/notify/task/VerifyEmailTaskComponent.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/notify/task/VerifyEmailTaskComponent.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.pcs.notify.config.NotificationErrorHandler;
-import uk.gov.hmcts.reform.pcs.notify.model.EmailState;
+import uk.gov.hmcts.reform.pcs.notify.model.SendEmailTaskData;
 import uk.gov.hmcts.reform.pcs.notify.service.NotificationService;
 import uk.gov.service.notify.Notification;
 import uk.gov.service.notify.NotificationClient;
@@ -28,8 +28,8 @@ import static uk.gov.hmcts.reform.pcs.notify.model.NotificationStatus.PERMANENT_
 public class VerifyEmailTaskComponent {
     private static final String VERIFY_EMAIL_TASK_NAME = "verify-email-task";
 
-    public static final TaskDescriptor<EmailState> verifyEmailTask =
-        TaskDescriptor.of(VERIFY_EMAIL_TASK_NAME, EmailState.class);
+    public static final TaskDescriptor<SendEmailTaskData> verifyEmailTask =
+        TaskDescriptor.of(VERIFY_EMAIL_TASK_NAME, SendEmailTaskData.class);
 
     private final NotificationService notificationService;
     private final NotificationClient notificationClient;
@@ -63,42 +63,42 @@ public class VerifyEmailTaskComponent {
      * @return the custom task for verifying email delivery status
      */
     @Bean
-    public CustomTask<EmailState> verifyEmailTask() {
+    public CustomTask<SendEmailTaskData> verifyEmailTask() {
         return Tasks.custom(verifyEmailTask)
             .onFailure(new FailureHandler.MaxRetriesFailureHandler<>(
                 maxRetriesCheckEmail,
                 new FailureHandler.ExponentialBackoffFailureHandler<>(statusCheckBackoffDelay)
             ))
             .execute((taskInstance, executionContext) -> {
-                EmailState emailState = taskInstance.getData();
-                log.info("Verifying email delivery for ID: {}", emailState.getNotificationId());
+                SendEmailTaskData taskData = taskInstance.getData();
+                log.info("Verifying email delivery for ID: {}", taskData.getNotificationId());
 
                 try {
-                    Notification notification = notificationClient.getNotificationById(emailState.getNotificationId());
+                    Notification notification = notificationClient.getNotificationById(taskData.getNotificationId());
 
                     if (Objects.equals(notification.getStatus().toLowerCase(), DELIVERED.toString())) {
                         notificationService.updateNotificationStatus(
-                            emailState.getDbNotificationId(),
+                            taskData.getDbNotificationId(),
                             notification.getStatus()
                         );
                     } else {
                         notificationService.updateNotificationStatus(
-                            emailState.getDbNotificationId(),
+                            taskData.getDbNotificationId(),
                             PERMANENT_FAILURE.toString()
                         );
                     }
 
                     String status = notification.getStatus();
                     if (DELIVERED.toString().equalsIgnoreCase(status)) {
-                        log.info("Email successfully delivered: {}", emailState.getId());
+                        log.info("Email successfully delivered: {}", taskData.getId());
                     } else {
-                        log.error("Failure with status: {} for task: {}", status, emailState.getId());
+                        log.error("Failure with status: {} for task: {}", status, taskData.getId());
                     }
                     return new CompletionHandler.OnCompleteRemove<>();
                 } catch (NotificationClientException e) {
                     log.error("Failed to verify status due to API error", e);
 
-                    errorHandler.handleFetchException(e, emailState.getNotificationId());
+                    errorHandler.handleFetchException(e, taskData.getNotificationId());
                     return new CompletionHandler.OnCompleteRemove<>();
                 }
             });

--- a/src/main/resources/db/migration/V110__truncate_scheduled_tasks.sql
+++ b/src/main/resources/db/migration/V110__truncate_scheduled_tasks.sql
@@ -1,0 +1,2 @@
+/* Truncate scheduled tasks because of change in task data serialisation */
+TRUNCATE scheduled_tasks;

--- a/src/test/java/uk/gov/hmcts/reform/pcs/notify/task/SendEmailTaskComponentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/notify/task/SendEmailTaskComponentTest.java
@@ -19,7 +19,7 @@ import uk.gov.hmcts.reform.pcs.notify.config.NotificationErrorHandler.Notificati
 import uk.gov.hmcts.reform.pcs.notify.entities.CaseNotification;
 import uk.gov.hmcts.reform.pcs.notify.exception.PermanentNotificationException;
 import uk.gov.hmcts.reform.pcs.notify.exception.TemporaryNotificationException;
-import uk.gov.hmcts.reform.pcs.notify.model.EmailState;
+import uk.gov.hmcts.reform.pcs.notify.model.SendEmailTaskData;
 import uk.gov.hmcts.reform.pcs.notify.repository.NotificationRepository;
 import uk.gov.hmcts.reform.pcs.notify.service.NotificationService;
 import uk.gov.service.notify.NotificationClient;
@@ -63,7 +63,7 @@ class SendEmailTaskComponentTest {
     private NotificationRepository notificationRepository;
 
     @Mock
-    private TaskInstance<EmailState> taskInstance;
+    private TaskInstance<SendEmailTaskData> taskInstance;
 
     @Mock
     private ExecutionContext executionContext;
@@ -77,7 +77,7 @@ class SendEmailTaskComponentTest {
     private final Duration sendingBackoffDelay = Duration.ofSeconds(30);
     private final Duration statusCheckTaskDelay = Duration.ofMinutes(5);
 
-    private EmailState emailState;
+    private SendEmailTaskData sendEmailTaskData;
     private final UUID dbNotificationId = UUID.randomUUID();
     private final String templateId = "template-456";
     private final String emailAddress = "test@example.com";
@@ -98,7 +98,7 @@ class SendEmailTaskComponentTest {
         );
 
         String taskId = "task-123";
-        emailState = EmailState.builder()
+        sendEmailTaskData = SendEmailTaskData.builder()
             .id(taskId)
             .dbNotificationId(dbNotificationId)
             .templateId(templateId)
@@ -106,7 +106,7 @@ class SendEmailTaskComponentTest {
             .personalisation(personalisation)
             .build();
 
-        when(taskInstance.getData()).thenReturn(emailState);
+        when(taskInstance.getData()).thenReturn(sendEmailTaskData);
         when(taskInstance.getId()).thenReturn(taskId);
     }
 
@@ -118,13 +118,13 @@ class SendEmailTaskComponentTest {
         @DisplayName("Should create task descriptor with correct name and type")
         void shouldCreateTaskDescriptorWithCorrectNameAndType() {
             assertThat(SendEmailTaskComponent.sendEmailTask.getTaskName()).isEqualTo("send-email-task");
-            assertThat(SendEmailTaskComponent.sendEmailTask.getDataClass()).isEqualTo(EmailState.class);
+            assertThat(SendEmailTaskComponent.sendEmailTask.getDataClass()).isEqualTo(SendEmailTaskData.class);
         }
 
         @Test
         @DisplayName("Should create send email task bean")
         void shouldCreateSendEmailTaskBean() {
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
             assertThat(task).isNotNull();
         }
@@ -142,9 +142,9 @@ class SendEmailTaskComponentTest {
             when(notificationClient.sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString()))
                 .thenReturn(sendEmailResponse);
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString());
             verify(notificationService).updateNotificationAfterSending(dbNotificationId, notificationId);
@@ -160,7 +160,7 @@ class SendEmailTaskComponentTest {
             when(notificationClient.sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString()))
                 .thenReturn(sendEmailResponse);
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
             task.execute(taskInstance, executionContext);
 
@@ -181,9 +181,9 @@ class SendEmailTaskComponentTest {
             when(notificationClient.sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString()))
                 .thenReturn(sendEmailResponse);
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             assertThat(result).isInstanceOf(CompletionHandler.OnCompleteReplace.class);
         }
@@ -198,9 +198,9 @@ class SendEmailTaskComponentTest {
         void shouldReturnOnCompleteRemoveWhenNotificationNotFound() throws Exception {
             when(notificationRepository.findById(dbNotificationId)).thenReturn(Optional.empty());
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             assertThat(result).isInstanceOf(CompletionHandler.OnCompleteRemove.class);
             verify(notificationClient, never()).sendEmail(anyString(), anyString(), any(), anyString());
@@ -212,9 +212,9 @@ class SendEmailTaskComponentTest {
         void shouldLogErrorWhenNotificationNotFound() {
             when(notificationRepository.findById(dbNotificationId)).thenReturn(Optional.empty());
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             assertThat(result).isInstanceOf(CompletionHandler.OnCompleteRemove.class);
         }
@@ -232,7 +232,7 @@ class SendEmailTaskComponentTest {
             when(notificationClient.sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString()))
                 .thenReturn(sendEmailResponse);
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
             assertThatThrownBy(() -> task.execute(taskInstance, executionContext))
                 .isInstanceOf(PermanentNotificationException.class)
@@ -257,9 +257,9 @@ class SendEmailTaskComponentTest {
             when(notificationClient.sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString()))
                 .thenThrow(exception);
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             assertThat(result).isInstanceOf(CompletionHandler.OnCompleteRemove.class);
             verify(errorHandler).handleSendEmailException(eq(exception), eq(caseNotification), anyString(), any());
@@ -277,9 +277,9 @@ class SendEmailTaskComponentTest {
             when(notificationClient.sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString()))
                 .thenThrow(exception);
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             assertThat(result).isInstanceOf(CompletionHandler.OnCompleteRemove.class);
             verify(errorHandler).handleSendEmailException(eq(exception), eq(caseNotification), anyString(), any());
@@ -300,7 +300,7 @@ class SendEmailTaskComponentTest {
                 when(notificationClient.sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString()))
                     .thenThrow(exception);
 
-                CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+                CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
                 assertThatThrownBy(() -> task.execute(taskInstance, executionContext))
                     .isInstanceOf(TemporaryNotificationException.class)
@@ -323,7 +323,7 @@ class SendEmailTaskComponentTest {
             when(notificationClient.sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString()))
                 .thenThrow(exception);
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
             task.execute(taskInstance, executionContext);
 
@@ -363,9 +363,9 @@ class SendEmailTaskComponentTest {
             when(notificationClient.sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString()))
                 .thenReturn(sendEmailResponse);
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString());
             assertThat(result).isInstanceOf(CompletionHandler.OnCompleteReplace.class);
@@ -374,7 +374,7 @@ class SendEmailTaskComponentTest {
         @Test
         @DisplayName("Should handle empty personalisation map")
         void shouldHandleEmptyPersonalisationMap() throws Exception {
-            EmailState emptyPersonalisationState = emailState.toBuilder()
+            SendEmailTaskData emptyPersonalisationState = sendEmailTaskData.toBuilder()
                 .personalisation(Map.of())
                 .build();
             when(taskInstance.getData()).thenReturn(emptyPersonalisationState);
@@ -383,9 +383,9 @@ class SendEmailTaskComponentTest {
             when(notificationClient.sendEmail(eq(templateId), eq(emailAddress), eq(Map.of()), anyString()))
                 .thenReturn(sendEmailResponse);
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).sendEmail(eq(templateId), eq(emailAddress), eq(Map.of()), anyString());
             assertThat(result).isInstanceOf(CompletionHandler.OnCompleteReplace.class);
@@ -399,7 +399,7 @@ class SendEmailTaskComponentTest {
         @Test
         @DisplayName("Should configure task with correct failure handlers")
         void shouldConfigureTaskWithCorrectFailureHandlers() {
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
             assertThat(task).isNotNull();
         }
@@ -417,7 +417,7 @@ class SendEmailTaskComponentTest {
                 Duration.ofMinutes(10)
             );
 
-            CustomTask<EmailState> task = component.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = component.sendEmailTask();
             assertThat(task).isNotNull();
         }
     }
@@ -434,9 +434,9 @@ class SendEmailTaskComponentTest {
             when(notificationClient.sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString()))
                 .thenReturn(sendEmailResponse);
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationRepository).findById(dbNotificationId);
             verify(notificationClient).sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString());
@@ -455,9 +455,9 @@ class SendEmailTaskComponentTest {
             when(notificationClient.sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString()))
                 .thenThrow(exception);
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationRepository).findById(dbNotificationId);
             verify(notificationClient).sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString());
@@ -477,7 +477,7 @@ class SendEmailTaskComponentTest {
             when(notificationClient.sendEmail(eq(templateId), eq(emailAddress), eq(personalisation), anyString()))
                 .thenThrow(exception);
 
-            CustomTask<EmailState> task = sendEmailTaskComponent.sendEmailTask();
+            CustomTask<SendEmailTaskData> task = sendEmailTaskComponent.sendEmailTask();
 
             assertThatThrownBy(() -> task.execute(taskInstance, executionContext))
                 .isInstanceOf(TemporaryNotificationException.class)

--- a/src/test/java/uk/gov/hmcts/reform/pcs/notify/task/VerifyEmailTaskComponentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/notify/task/VerifyEmailTaskComponentTest.java
@@ -16,7 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.pcs.notify.config.NotificationErrorHandler;
-import uk.gov.hmcts.reform.pcs.notify.model.EmailState;
+import uk.gov.hmcts.reform.pcs.notify.model.SendEmailTaskData;
 import uk.gov.hmcts.reform.pcs.notify.service.NotificationService;
 import uk.gov.service.notify.Notification;
 import uk.gov.service.notify.NotificationClient;
@@ -49,7 +49,7 @@ class VerifyEmailTaskComponentTest {
     private NotificationErrorHandler errorHandler;
 
     @Mock
-    private TaskInstance<EmailState> taskInstance;
+    private TaskInstance<SendEmailTaskData> taskInstance;
 
     @Mock
     private ExecutionContext executionContext;
@@ -59,7 +59,7 @@ class VerifyEmailTaskComponentTest {
 
     private final Duration statusCheckBackoffDelay = Duration.ofMinutes(2);
 
-    private EmailState emailState;
+    private SendEmailTaskData sendEmailTaskData;
     private final UUID dbNotificationId = UUID.randomUUID();
     private final String taskId = "verify-task-123";
     private final String notificationId = "notification-456";
@@ -78,7 +78,7 @@ class VerifyEmailTaskComponentTest {
 
         String templateId = "template-789";
         String emailAddress = "test@example.com";
-        emailState = EmailState.builder()
+        sendEmailTaskData = SendEmailTaskData.builder()
             .id(taskId)
             .dbNotificationId(dbNotificationId)
             .notificationId(notificationId)
@@ -87,7 +87,7 @@ class VerifyEmailTaskComponentTest {
             .personalisation(personalisation)
             .build();
 
-        when(taskInstance.getData()).thenReturn(emailState);
+        when(taskInstance.getData()).thenReturn(sendEmailTaskData);
         when(taskInstance.getId()).thenReturn(taskId);
     }
 
@@ -99,13 +99,13 @@ class VerifyEmailTaskComponentTest {
         @DisplayName("Should create task descriptor with correct name and type")
         void shouldCreateTaskDescriptorWithCorrectNameAndType() {
             assertThat(VerifyEmailTaskComponent.verifyEmailTask.getTaskName()).isEqualTo("verify-email-task");
-            assertThat(VerifyEmailTaskComponent.verifyEmailTask.getDataClass()).isEqualTo(EmailState.class);
+            assertThat(VerifyEmailTaskComponent.verifyEmailTask.getDataClass()).isEqualTo(SendEmailTaskData.class);
         }
 
         @Test
         @DisplayName("Should create verify email task bean")
         void shouldCreateVerifyEmailTaskBean() {
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
             assertThat(task).isNotNull();
         }
@@ -122,9 +122,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(deliveredStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, deliveredStatus);
@@ -138,9 +138,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(deliveredStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, deliveredStatus);
@@ -154,9 +154,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(deliveredStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, deliveredStatus);
@@ -170,9 +170,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(originalStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, originalStatus);
@@ -192,9 +192,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(status);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, PERMANENT_FAILURE.toString());
@@ -208,9 +208,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(failedStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, PERMANENT_FAILURE.toString());
@@ -224,9 +224,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(pendingStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, PERMANENT_FAILURE.toString());
@@ -240,9 +240,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(customStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, PERMANENT_FAILURE.toString());
@@ -261,8 +261,8 @@ class VerifyEmailTaskComponentTest {
                 new RuntimeException());
             when(notificationClient.getNotificationById(notificationId)).thenThrow(exception);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
             assertThat(result).isInstanceOf(CompletionHandler.OnCompleteRemove.class);
             verify(notificationClient).getNotificationById(notificationId);
             verify(errorHandler).handleFetchException(exception, notificationId);
@@ -276,8 +276,8 @@ class VerifyEmailTaskComponentTest {
                 new RuntimeException());
             when(notificationClient.getNotificationById(notificationId)).thenThrow(exception);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
             assertThat(result).isInstanceOf(CompletionHandler.OnCompleteRemove.class);
             verify(notificationClient).getNotificationById(notificationId);
             verify(errorHandler).handleFetchException(exception, notificationId);
@@ -291,7 +291,7 @@ class VerifyEmailTaskComponentTest {
                 new RuntimeException());
             when(notificationClient.getNotificationById(notificationId)).thenThrow(exception);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
             task.execute(taskInstance, executionContext);
 
@@ -310,9 +310,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(deliveredStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, deliveredStatus);
@@ -322,7 +322,7 @@ class VerifyEmailTaskComponentTest {
         @Test
         @DisplayName("Should handle email state with minimum required fields")
         void shouldHandleEmailStateWithMinimumRequiredFields() throws Exception {
-            EmailState minimalEmailState = EmailState.builder()
+            SendEmailTaskData minimalEmailState = SendEmailTaskData.builder()
                 .id(taskId)
                 .dbNotificationId(dbNotificationId)
                 .notificationId(notificationId)
@@ -333,9 +333,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(deliveredStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, deliveredStatus);
@@ -346,7 +346,7 @@ class VerifyEmailTaskComponentTest {
         @DisplayName("Should handle different notification ID formats")
         void shouldHandleDifferentNotificationIdFormats() throws Exception {
             String uuidNotificationId = UUID.randomUUID().toString();
-            EmailState uuidEmailState = emailState.toBuilder()
+            SendEmailTaskData uuidEmailState = sendEmailTaskData.toBuilder()
                 .notificationId(uuidNotificationId)
                 .build();
             when(taskInstance.getData()).thenReturn(uuidEmailState);
@@ -355,9 +355,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(uuidNotificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(deliveredStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(uuidNotificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, deliveredStatus);
@@ -372,7 +372,7 @@ class VerifyEmailTaskComponentTest {
         @Test
         @DisplayName("Should configure task with correct failure handlers")
         void shouldConfigureTaskWithCorrectFailureHandlers() {
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
             assertThat(task).isNotNull();
         }
@@ -388,7 +388,7 @@ class VerifyEmailTaskComponentTest {
                 Duration.ofMinutes(5)
             );
 
-            CustomTask<EmailState> task = component.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = component.verifyEmailTask();
             assertThat(task).isNotNull();
         }
     }
@@ -404,7 +404,7 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(originalDeliveredStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
             task.execute(taskInstance, executionContext);
 
@@ -418,7 +418,7 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(customStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
             task.execute(taskInstance, executionContext);
 
@@ -431,7 +431,7 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(null);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
             try {
                 task.execute(taskInstance, executionContext);
@@ -448,9 +448,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(emptyStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, PERMANENT_FAILURE.toString());
@@ -464,7 +464,7 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(mixedCaseDelivered);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
             task.execute(taskInstance, executionContext);
 
@@ -483,9 +483,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(deliveredStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, deliveredStatus);
@@ -499,8 +499,8 @@ class VerifyEmailTaskComponentTest {
                 new RuntimeException());
             when(notificationClient.getNotificationById(notificationId)).thenThrow(exception);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
             assertThat(result).isInstanceOf(CompletionHandler.OnCompleteRemove.class);
             verify(notificationClient).getNotificationById(notificationId);
             verify(errorHandler).handleFetchException(exception, notificationId);
@@ -514,9 +514,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(failedStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, PERMANENT_FAILURE.toString());
@@ -530,9 +530,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(mixedCaseDelivered);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, mixedCaseDelivered);
@@ -549,7 +549,7 @@ class VerifyEmailTaskComponentTest {
         void shouldHandleNotificationClientReturningNullNotification() throws Exception {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(null);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
             try {
                 task.execute(taskInstance, executionContext);
@@ -566,9 +566,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(mixedCaseStatus);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, mixedCaseStatus);
@@ -582,9 +582,9 @@ class VerifyEmailTaskComponentTest {
             when(notificationClient.getNotificationById(notificationId)).thenReturn(notification);
             when(notification.getStatus()).thenReturn(statusWithSpaces);
 
-            CustomTask<EmailState> task = verifyEmailTaskComponent.verifyEmailTask();
+            CustomTask<SendEmailTaskData> task = verifyEmailTaskComponent.verifyEmailTask();
 
-            CompletionHandler<EmailState> result = task.execute(taskInstance, executionContext);
+            CompletionHandler<SendEmailTaskData> result = task.execute(taskInstance, executionContext);
 
             verify(notificationClient).getNotificationById(notificationId);
             verify(notificationService).updateNotificationStatus(dbNotificationId, PERMANENT_FAILURE.toString());


### PR DESCRIPTION
### Jira link

See [HDPI-4276](https://tools.hmcts.net/jira/browse/HDPI-4276)

### Change description

Serialise scheduler task data as JSON. This will make it easier to update the task data models in a backwards compatible way, as well as making it easier to view task data manually.

Includes changing task data model classes to no longer implement Serialisable and also to have final fields.

Also includes renaming `EmailState` to `SendEmailTaskData` to making the naming of task data classes more consistent.

### Testing done

Manual checking that tasks are scheduled, (serialisation of task data as JSON), and then read and executed, (deserialisation).

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
