### PR TITLE
Don't tolerate high level data setup failures in any env

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/config/HighLevelDataSetupApp.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/config/HighLevelDataSetupApp.java
@@ -83,12 +83,6 @@ public class HighLevelDataSetupApp extends DataLoaderToDefinitionStore {
     }
 
     @Override
-    protected boolean shouldTolerateDataSetupFailure() {
-        var env = getDataSetupEnvironment();
-        return CcdEnvironment.PERFTEST == env || CcdEnvironment.DEMO == env || CcdEnvironment.ITHC == env;
-    }
-
-    @Override
     protected boolean shouldTolerateDataSetupFailure(Throwable e) {
         return switch (e) {
             case ImportException importException -> isGatewayTimeout(importException);


### PR DESCRIPTION
### Change description

Don't tolerate high level data setup failures in any env. This is achieved by removing the overridden `shouldTolerateDataSetupFailure` implementation, meaning that the default behaviour from the [parent class](https://github.com/hmcts/befta-fw/blob/master/src/main/java/uk/gov/hmcts/befta/dse/ccd/DataLoaderToDefinitionStore.java#L196-L198) will be used, and that is to return `false`

### Testing done

Pipeline run

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
