### PR TITLE
HDPI-6991: NPE when underlessee/mortgage nameKnown

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/CaseDetailsTabView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/CaseDetailsTabView.java
@@ -459,9 +459,9 @@ public class CaseDetailsTabView {
         AddressUK address = addressKnown == VerticalYesNo.YES ? underlesseeMortgageeParty.getAddress() : null;
 
         return UnderlesseeOrMortgageInformationTabDetails.builder()
-            .nameKnown(nameKnown.getLabel())
+            .nameKnown(nameKnown != null ? nameKnown.getLabel() : NO_ANSWER)
             .name(name)
-            .addressKnown(addressKnown.getLabel())
+            .addressKnown(addressKnown != null ? addressKnown.getLabel() : NO_ANSWER)
             .address(address)
             .build();
     }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/CaseDetailsTabViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/CaseDetailsTabViewTest.java
@@ -440,6 +440,26 @@ public class CaseDetailsTabViewTest {
     }
 
     @Test
+    void shouldNotThrowWhenUnderlesseeMortgageNameKnownOrAddressKnownIsNull() {
+        PCSCase pcsCase = PCSCase.builder()
+            .allUnderlesseeOrMortgagees(List.of(
+                listValue(
+                    Party.builder()
+                        .orgName("underlessee name")
+                        .build()
+                )
+            ))
+            .build();
+
+        // When
+        CaseDetailsTab caseDetailsTab = caseDetailsTabView.buildCaseDetailsTab(pcsCase);
+
+        // Then
+        assertThat(caseDetailsTab.getMortgageOneDetails().getNameKnown()).isEqualTo(noAnswer);
+        assertThat(caseDetailsTab.getMortgageOneDetails().getAddressKnown()).isEqualTo(noAnswer);
+    }
+
+    @Test
     void shouldSetPlaceholderValuesIfOnlyAlternativesToPossessionIsSet() {
         // Given
         PCSCase pcsCase = PCSCase.builder()


### PR DESCRIPTION


### Jira link


### Change description

  CaseDetailsTabView.buildUnderlesseeMortgageTabDetails calls nameKnown/addressKnown.getLabel() with no null check, so a case with an underlessee/mortgage party missing nameKnown/addressKnown NPEs on the case fetch (every respond-to-claim
  page) -> 500 -> frontend "technical problems", journey dies at start-now. 

### Testing done
PR is green.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
