### PR TITLE
HDPI-7118: Guard null document type in gen app document persistence

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/document/DocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/document/DocumentService.java
@@ -181,6 +181,9 @@ public class DocumentService {
     }
 
     public DocumentType mapAdditionalDocumentTypeToDocumentType(AdditionalDocumentType additionalType) {
+        if (additionalType == null) {
+            return null;
+        }
         return switch (additionalType) {
             case WITNESS_STATEMENT -> DocumentType.WITNESS_STATEMENT;
             case RENT_STATEMENT -> DocumentType.RENT_STATEMENT;

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/genapp/GenAppService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/genapp/GenAppService.java
@@ -144,7 +144,9 @@ public class GenAppService {
                     .fileName(updatedFilename)
                     .binaryUrl(uploadedDocument.getDocument().getBinaryUrl())
                     .categoryId(CaseFileCategory.APPLICATIONS.getId())
-                    .type(documentService.mapAdditionalDocumentTypeToDocumentType(uploadedDocument.getDocumentType()))
+                    .type(uploadedDocument.getDocumentType() != null
+                        ? documentService.mapAdditionalDocumentTypeToDocumentType(uploadedDocument.getDocumentType())
+                        : null)
                     .contentType(uploadedDocument.getContentType())
                     .size(uploadedDocument.getSizeInBytes())
                     .build();

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/document/DocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/document/DocumentServiceTest.java
@@ -804,6 +804,15 @@ class DocumentServiceTest {
         assertThat(actualDocumentType).isEqualTo(expectedDocumentType);
     }
 
+    @Test
+    void shouldReturnNullWhenAdditionalDocumentTypeIsNull() {
+        // When
+        DocumentType actualDocumentType = underTest.mapAdditionalDocumentTypeToDocumentType(null);
+
+        // Then
+        assertThat(actualDocumentType).isNull();
+    }
+
     private static Stream<Arguments> additionalDocumentCategoryScenarios() {
         return Stream.of(
             Arguments.of(

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/genapp/GenAppServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/genapp/GenAppServiceTest.java
@@ -388,6 +388,51 @@ class GenAppServiceTest {
     }
 
     @Test
+    void shouldSaveUploadedDocumentWithNullTypeWhenNoDocumentType() {
+        // Given
+        String originalFilename = "original filename";
+        String modifiedFilename = "modified filename";
+
+        Document document = Document.builder()
+            .filename(originalFilename)
+            .url("test url")
+            .binaryUrl("test binary url")
+            .build();
+
+        UUID applicantPartyId = UUID.randomUUID();
+        when(applicantParty.getId()).thenReturn(applicantPartyId);
+        when(documentNameService.appendGenAppPostfix(eq(originalFilename), isA(GenAppEntity.class),
+                                      eq(mainClaim), eq(applicantPartyId)))
+            .thenReturn(modifiedFilename);
+
+        UploadedDocument uploadedDocument = UploadedDocument.builder()
+            .document(document)
+            .contentType("test content type")
+            .sizeInBytes(1234L)
+            .build();
+
+        CitizenGenAppRequest genAppRequest = CitizenGenAppRequest.builder()
+            .sotAccepted(VerticalYesNo.YES)
+            .hasSupportingDocuments(VerticalYesNo.YES)
+            .uploadedDocuments(List.of(ListValue.<UploadedDocument>builder().value(uploadedDocument).build()))
+            .build();
+
+        when(documentRepository.saveAll(anyList())).thenReturn(List.of(mock(DocumentEntity.class)));
+
+        // When
+        Throwable throwable = catchThrowable(
+            () -> underTest.createGenAppEntity(genAppRequest, pcsCaseEntity, applicantParty)
+        );
+
+        // Then
+        assertThat(throwable).isNull();
+
+        verify(documentRepository).saveAll(documentEntityListCaptor.capture());
+        assertThat(documentEntityListCaptor.getValue()).hasSize(1);
+        assertThat(documentEntityListCaptor.getValue().getFirst().getType()).isNull();
+    }
+
+    @Test
     void shouldNotSaveUploadedDocumentsIfSupportingDocumentsFlagIsNo() {
         // Given
         Document document = Document.builder()


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/HDPI-7118
### Change description

Making an application with a supporting document was 500ing — gen-app uploads carry no document type, and since #1839 pcs-api fed that null into
  mapAdditionalDocumentTypeToDocumentType, a switch with no null branch, throwing NPE on /ccd-persistence/cases.


### Testing done

Build is green 

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
