### PR TITLE
Skip creation of Search Criteria object for PCS-STAGING

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CaseType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CaseType.java
@@ -56,7 +56,10 @@ public class CaseType implements CCDConfig<PCSCase, State, AccessProfile> {
      * per-PR preview type, driven by the CASE_TYPE_SUFFIX env var.
      */
     public static boolean isSuffixedCaseType() {
-        String suffix = getenv().get("CASE_TYPE_SUFFIX");
+        return isSuffixed(getenv().get("CASE_TYPE_SUFFIX"));
+    }
+
+    static boolean isSuffixed(String suffix) {
         return suffix != null && !suffix.isBlank();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CaseType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CaseType.java
@@ -56,8 +56,6 @@ public class CaseType implements CCDConfig<PCSCase, State, AccessProfile> {
      * per-PR preview type, driven by the CASE_TYPE_SUFFIX env var.
      */
     public static boolean isSuffixedCaseType() {
-        // A canonical PCS case type has no suffix. The pipeline encodes "canonical" as either an
-        // unset CASE_TYPE_SUFFIX or an empty string (see Jenkinsfile_CNP), so blank == canonical.
         String suffix = getenv().get("CASE_TYPE_SUFFIX");
         return suffix != null && !suffix.isBlank();
     }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CaseType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CaseType.java
@@ -56,9 +56,10 @@ public class CaseType implements CCDConfig<PCSCase, State, AccessProfile> {
      * per-PR preview type, driven by the CASE_TYPE_SUFFIX env var.
      */
     public static boolean isSuffixedCaseType() {
-        return ofNullable(getenv().get("CASE_TYPE_SUFFIX"))
-            .filter(suffix -> !suffix.isBlank())
-            .isPresent();
+        // A canonical PCS case type has no suffix. The pipeline encodes "canonical" as either an
+        // unset CASE_TYPE_SUFFIX or an empty string (see Jenkinsfile_CNP), so blank == canonical.
+        String suffix = getenv().get("CASE_TYPE_SUFFIX");
+        return suffix != null && !suffix.isBlank();
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CaseType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CaseType.java
@@ -51,6 +51,14 @@ public class CaseType implements CCDConfig<PCSCase, State, AccessProfile> {
             .orElse(base);
     }
 
+    /**
+     * Whether this deployment runs a suffixed case type, e.g. PCS-STAGING or a
+     * per-PR preview type, driven by the CASE_TYPE_SUFFIX env var.
+     */
+    public static boolean isSuffixedCaseType() {
+        return ofNullable(getenv().get("CASE_TYPE_SUFFIX")).isPresent();
+    }
+
     @Override
     public void configure(final ConfigBuilder<PCSCase, State, AccessProfile> builder) {
         builder.setCallbackHost(caseApiUrl);

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CaseType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CaseType.java
@@ -56,7 +56,9 @@ public class CaseType implements CCDConfig<PCSCase, State, AccessProfile> {
      * per-PR preview type, driven by the CASE_TYPE_SUFFIX env var.
      */
     public static boolean isSuffixedCaseType() {
-        return ofNullable(getenv().get("CASE_TYPE_SUFFIX")).isPresent();
+        return ofNullable(getenv().get("CASE_TYPE_SUFFIX"))
+            .filter(suffix -> !suffix.isBlank())
+            .isPresent();
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseView.java
@@ -110,7 +110,10 @@ public class PCSCaseView implements CaseView<PCSCase, State> {
 
         caseFieldsView.setCaseFields(pcsCase);
 
-        pcsCase.setSearchCriteria(searchCriteriaIndexer.buildSearchCriteria(pcsCase));
+        // Only the canonical PCS case type is indexed into the shared global_search index.
+        if (!CaseType.isSuffixedCaseType()) {
+            pcsCase.setSearchCriteria(searchCriteriaIndexer.buildSearchCriteria(pcsCase));
+        }
 
         return pcsCase;
     }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/CaseTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/CaseTypeTest.java
@@ -42,6 +42,14 @@ class CaseTypeTest {
     }
 
     @Test
+    void shouldNotBeSuffixedCaseTypeByDefault() {
+        // No CASE_TYPE_SUFFIX in the test environment -> canonical PCS, which IS indexed into
+        // global search. The suffixed (true) branch is covered behaviourally by
+        // PCSCaseViewTest#shouldNotSetSearchCriteriaForSuffixedCaseType.
+        assertThat(CaseType.isSuffixedCaseType()).isFalse();
+    }
+
+    @Test
     void shouldGetJurisdictionId() {
         // When
         String jurisdictionId = CaseType.getJurisdictionId();

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/CaseTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/CaseTypeTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
 import uk.gov.hmcts.ccd.sdk.api.CaseCategory;
@@ -18,10 +17,7 @@ import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.AccessProfile;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 import uk.gov.hmcts.reform.pcs.ccd.domain.State;
 
-import java.util.Map;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,34 +42,19 @@ class CaseTypeTest {
     }
 
     @Test
-    void shouldNotBeSuffixedCaseTypeWhenSuffixAbsent() {
-        // CASE_TYPE_SUFFIX not set -> suffix is null -> canonical PCS (indexed into global search)
-        try (MockedStatic<System> system = mockStatic(System.class)) {
-            system.when(System::getenv).thenReturn(Map.of());
-            assertThat(CaseType.isSuffixedCaseType()).isFalse();
-        }
-    }
-
-    @Test
-    void shouldNotBeSuffixedCaseTypeWhenSuffixBlank() {
-        // Pipeline encodes "canonical" as an empty CASE_TYPE_SUFFIX (see Jenkinsfile_CNP)
-        try (MockedStatic<System> system = mockStatic(System.class)) {
-            system.when(System::getenv).thenReturn(Map.of("CASE_TYPE_SUFFIX", ""));
-            assertThat(CaseType.isSuffixedCaseType()).isFalse();
-        }
-        try (MockedStatic<System> system = mockStatic(System.class)) {
-            system.when(System::getenv).thenReturn(Map.of("CASE_TYPE_SUFFIX", "   "));
-            assertThat(CaseType.isSuffixedCaseType()).isFalse();
-        }
+    void shouldNotBeSuffixedCaseTypeWhenSuffixAbsentOrBlank() {
+        // Canonical PCS (indexed into global search): unset or blank CASE_TYPE_SUFFIX.
+        // The pipeline encodes "canonical" as either unset or an empty string (see Jenkinsfile_CNP).
+        assertThat(CaseType.isSuffixed(null)).isFalse();
+        assertThat(CaseType.isSuffixed("")).isFalse();
+        assertThat(CaseType.isSuffixed("   ")).isFalse();
     }
 
     @Test
     void shouldBeSuffixedCaseTypeWhenSuffixSet() {
-        // Suffixed (e.g. PCS-STAGING, PR previews) -> NOT indexed into global search
-        try (MockedStatic<System> system = mockStatic(System.class)) {
-            system.when(System::getenv).thenReturn(Map.of("CASE_TYPE_SUFFIX", "staging"));
-            assertThat(CaseType.isSuffixedCaseType()).isTrue();
-        }
+        // Suffixed (e.g. PCS-STAGING, PR previews) -> NOT indexed into global search.
+        assertThat(CaseType.isSuffixed("staging")).isTrue();
+        assertThat(CaseType.isSuffixed("1234")).isTrue();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/CaseTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/CaseTypeTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
 import uk.gov.hmcts.ccd.sdk.api.CaseCategory;
@@ -17,7 +18,10 @@ import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.AccessProfile;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 import uk.gov.hmcts.reform.pcs.ccd.domain.State;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,11 +46,34 @@ class CaseTypeTest {
     }
 
     @Test
-    void shouldNotBeSuffixedCaseTypeByDefault() {
-        // No CASE_TYPE_SUFFIX in the test environment -> canonical PCS, which IS indexed into
-        // global search. The suffixed (true) branch is covered behaviourally by
-        // PCSCaseViewTest#shouldNotSetSearchCriteriaForSuffixedCaseType.
-        assertThat(CaseType.isSuffixedCaseType()).isFalse();
+    void shouldNotBeSuffixedCaseTypeWhenSuffixAbsent() {
+        // CASE_TYPE_SUFFIX not set -> suffix is null -> canonical PCS (indexed into global search)
+        try (MockedStatic<System> system = mockStatic(System.class)) {
+            system.when(System::getenv).thenReturn(Map.of());
+            assertThat(CaseType.isSuffixedCaseType()).isFalse();
+        }
+    }
+
+    @Test
+    void shouldNotBeSuffixedCaseTypeWhenSuffixBlank() {
+        // Pipeline encodes "canonical" as an empty CASE_TYPE_SUFFIX (see Jenkinsfile_CNP)
+        try (MockedStatic<System> system = mockStatic(System.class)) {
+            system.when(System::getenv).thenReturn(Map.of("CASE_TYPE_SUFFIX", ""));
+            assertThat(CaseType.isSuffixedCaseType()).isFalse();
+        }
+        try (MockedStatic<System> system = mockStatic(System.class)) {
+            system.when(System::getenv).thenReturn(Map.of("CASE_TYPE_SUFFIX", "   "));
+            assertThat(CaseType.isSuffixedCaseType()).isFalse();
+        }
+    }
+
+    @Test
+    void shouldBeSuffixedCaseTypeWhenSuffixSet() {
+        // Suffixed (e.g. PCS-STAGING, PR previews) -> NOT indexed into global search
+        try (MockedStatic<System> system = mockStatic(System.class)) {
+            system.when(System::getenv).thenReturn(Map.of("CASE_TYPE_SUFFIX", "staging"));
+            assertThat(CaseType.isSuffixedCaseType()).isTrue();
+        }
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseViewTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import uk.gov.hmcts.ccd.sdk.CaseViewRequest;
@@ -55,6 +56,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -207,6 +209,22 @@ class PCSCaseViewTest {
         // Then - indexing is delegated to the indexer and its result is set on the case
         verify(searchCriteriaIndexer).buildSearchCriteria(pcsCase);
         assertThat(pcsCase.getSearchCriteria()).isSameAs(searchCriteria);
+    }
+
+    @Test
+    void shouldNotSetSearchCriteriaForSuffixedCaseType() {
+        // Given a suffixed (non-canonical) case type, e.g. PCS-STAGING or a PR preview type
+        try (MockedStatic<CaseType> caseTypeMock = mockStatic(CaseType.class)) {
+            caseTypeMock.when(CaseType::isSuffixedCaseType).thenReturn(true);
+
+            // When
+            PCSCase pcsCase = underTest.getCase(request(CASE_REFERENCE, DEFAULT_STATE));
+
+            // Then - the indexer is never invoked and SearchCriteria is left null, so the
+            // decentralised indexer won't write a global_search document for this case type
+            verify(searchCriteriaIndexer, never()).buildSearchCriteria(any(PCSCase.class));
+            assertThat(pcsCase.getSearchCriteria()).isNull();
+        }
     }
 
     @Test


### PR DESCRIPTION

### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [HDPI-7208](https://tools.hmcts.net/jira/browse/HDPI-7208)

### Change description

 ### Problem
  In AAT, Global Search was intermittently timing out (504) or returning no
  results when searching by common fields (e.g. a shared solicitor email),
  while lookups by case reference always worked.

  Root cause: the same codebase is deployed under multiple case type IDs via
  `CASE_TYPE_SUFFIX` — the canonical `PCS` plus suffixed types such as
  `PCS-STAGING` (and per-PR preview types). **All** of these were being indexed
  into the shared CCD `global_search` index. A single search therefore matched
  both a `PCS` case and a `PCS-STAGING` case for the same seeded data.

  Global Search is two-step: it finds case refs in `global_search`, then
  hydrates each case by calling the owning service's persistence endpoint
  (`GET /ccd-persistence/cases?case-refs=…`). The staging service that backs
  `PCS-STAGING` only runs at specific times, so hydrating those refs returns
  404 when it's down — which fails/stalls the whole search and surfaces as a 504.

  Confirmed in AAT: the canonical case hydrates `200` from
  `pcs-api-aat.service.core-compute-aat.internal`, while the suffixed case's
  host returns `404 page not found`.

  ### Change
  
  - `CaseType.isSuffixedCaseType()` — returns `true` when `CASE_TYPE_SUFFIX` is
    set (i.e. `PCS-STAGING`, PR previews), mirroring the existing `withSuffix`
    logic that makes `PCS` canonical only when no suffix is present.
  - `PCSCaseView.getCase(...)` — the `SearchCriteria` field is now only
    populated for the canonical case type.
    
  ### Why this is the correct lever
  The decentralised ES indexer (`DecentralisedESIndexer`, CCD SDK) writes a
  `global_search` document **only when the case data contains a `SearchCriteria`
  key** — it does not consult the case type's search-criteria *config*. Our
  `@Primary` ObjectMapper uses `JsonInclude.Value.ALL_NON_NULL`
  (`JacksonConfiguration`), so leaving `searchCriteria` null omits the key from
  the persisted data entirely, and the case is never indexed into
  `global_search`. Canonical `PCS` cases are unaffected.



<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
