### PR TITLE
HDPI-7118: Stop NPE when notice served but no service method selected

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/NoticeOfPossessionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/NoticeOfPossessionService.java
@@ -37,6 +37,10 @@ public class NoticeOfPossessionService {
             noticeOfPossessionEntity.setUnableToUploadReason(noticeServedDetails.getUnableToUploadReason());
         }
 
+        if (noticeServiceMethod == null) {
+            return noticeOfPossessionEntity;
+        }
+
         switch (noticeServiceMethod) {
             case FIRST_CLASS_POST ->
                 noticeOfPossessionEntity.setNoticeDate(noticeServedDetails.getPostedDate());

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/NoticeOfPossessionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/NoticeOfPossessionService.java
@@ -28,6 +28,9 @@ public class NoticeOfPossessionService {
         }
 
         NoticeServedDetails noticeServedDetails = pcsCase.getNoticeServedDetails();
+        if (noticeServedDetails == null) {
+            return noticeOfPossessionEntity;
+        }
 
         NoticeServiceMethod noticeServiceMethod = noticeServedDetails.getServiceMethod();
 

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/NoticeOfPossessionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/NoticeOfPossessionServiceTest.java
@@ -81,6 +81,20 @@ class NoticeOfPossessionServiceTest {
         assertThat(noticeOfPossessionEntity.getServingMethod()).isNull();
     }
 
+    @Test
+    void shouldNotThrowWhenNoticeServedButNoticeServedDetailsIsNull() {
+        // Given notice served but the notice-served details object is absent (e.g. Wales path)
+        when(pcsCase.getLegislativeCountry()).thenReturn(LegislativeCountry.ENGLAND);
+        when(pcsCase.getNoticeServed()).thenReturn(YesOrNo.YES);
+        when(pcsCase.getNoticeServedDetails()).thenReturn(null);
+
+        // When / Then - must not dereference null details
+        NoticeOfPossessionEntity noticeOfPossessionEntity =
+            assertDoesNotThrow(() -> underTest.createNoticeOfPossessionEntity(pcsCase));
+
+        assertThat(noticeOfPossessionEntity.getNoticeServed()).isEqualTo(YesOrNo.YES);
+    }
+
     @ParameterizedTest
     @EnumSource(value = YesOrNo.class)
     void shouldSetNoticeServedForWales(YesOrNo noticeServed) {

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/NoticeOfPossessionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/NoticeOfPossessionServiceTest.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -63,6 +64,21 @@ class NoticeOfPossessionServiceTest {
                            .noticeServed(YesOrNo.NO)
                            .build()
             );
+    }
+
+    @Test
+    void shouldNotThrowWhenNoticeServedButServiceMethodIsNull() {
+        // Given notice served but no service method selected
+        when(pcsCase.getLegislativeCountry()).thenReturn(LegislativeCountry.ENGLAND);
+        when(pcsCase.getNoticeServed()).thenReturn(YesOrNo.YES);
+        when(noticeServedDetails.getServiceMethod()).thenReturn(null);
+
+        // When / Then - the switch must not be reached with a null method
+        NoticeOfPossessionEntity noticeOfPossessionEntity =
+            assertDoesNotThrow(() -> underTest.createNoticeOfPossessionEntity(pcsCase));
+
+        assertThat(noticeOfPossessionEntity.getNoticeServed()).isEqualTo(YesOrNo.YES);
+        assertThat(noticeOfPossessionEntity.getServingMethod()).isNull();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Jira link

fix for pcs frontend failure 
### Change description

Stop NPE when notice served but no service method selected

### Testing done
Test were passed

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
