### PR TITLE
Enabling skipped pact test

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/pcs/contract/FeeRegistrationLookupConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/pcs/contract/FeeRegistrationLookupConsumerTest.java
@@ -7,7 +7,6 @@ import au.com.dius.pact.consumer.junit5.PactTestFor;
 import au.com.dius.pact.core.model.V4Pact;
 import au.com.dius.pact.core.model.annotations.Pact;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -29,8 +28,6 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.context.TestConstructor.AutowireMode.ALL;
 
-// Disabling until provider test is fixed in PAY-8826
-@Disabled
 @ImportAutoConfiguration({
     FeignAutoConfiguration.class,
     FeignClientsConfiguration.class,

--- a/src/contractTest/java/uk/gov/hmcts/reform/pcs/contract/FeeRegistrationLookupConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/pcs/contract/FeeRegistrationLookupConsumerTest.java
@@ -42,8 +42,6 @@ import static org.springframework.test.context.TestConstructor.AutowireMode.ALL;
 class FeeRegistrationLookupConsumerTest {
     private final FeesApi feesApi;
 
-    private static final String SERVICE_AUTH_TOKEN = "Bearer serviceToken";
-
     private static final String POSSESSION_SERVICE = "possession claim";
     private static final String CIVIL_JURISDICTION = "civil";
     private static final String COUNTY_COURT = "county court";


### PR DESCRIPTION
### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->
Enabling consumer tests with feeRegister_lookUp, after the fix made by fee and pay team in https://tools.hmcts.net/jira/browse/PAY-8826

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->
Can I deploy checks passing on PR and successful verification on pact broker:
<img width="1163" height="190" alt="Screenshot 2026-06-22 at 12 28 45" src="https://github.com/user-attachments/assets/f4974264-56a1-4b40-a84f-044cd8c8ed76" />


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
