### PR TITLE
Enable query store top capture

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -29,6 +29,16 @@ module "postgresql" {
       name : var.product
     }
   ]
+  pgsql_server_configuration = [
+    {
+      name  = "backslash_quote"
+      value = "on"
+    },
+    {
+      name  = "pg_qs.query_capture_mode"
+      value = "top"
+    }
+  ]
 
   pgsql_version        = var.pgsql_version
   admin_user_object_id = var.jenkins_AAD_objectId


### PR DESCRIPTION
This enables Query Store top query capture.

The server already has Query Store available, but query capture is set to none by default, so useful statement-level data is not collected.

 Setting pg_qs.query_capture_mode to top enables monitoring of the highest impact queries across all PCS environments managed by this infrastructure.