### PR TITLE
HDPI-7542: Fix claim form filename to Claim - Claimant 1

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/claimform/ClaimFormDocumentGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/claimform/ClaimFormDocumentGenerator.java
@@ -17,7 +17,7 @@ import uk.gov.hmcts.reform.pcs.document.service.DocAssemblyService;
 public class ClaimFormDocumentGenerator {
 
     static final String TEMPLATE_ID = "CV-PCS-CLM-ENG-Claim-Pack.docx";
-    static final String OUTPUT_FILENAME = "Claim form";
+    static final String OUTPUT_FILENAME = "Claim - Claimant 1";
 
     private final DocAssemblyService docAssemblyService;
 


### PR DESCRIPTION
### Jira link

HDPI-7542

### Change description

Fix claim form document filename to follow the naming convention "Claim - Claimant 1.pdf" (was "Claim form.pdf"), fixing inconsistent naming in EXUI Case File View

### Testing done

Tested locally

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
