### PR TITLE
HDPI-7579: Add LaunchDarkly and some initial feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ environment used for targeting.
 
 ### Local Dev
 
-When running the pcs-api locally, set `LAUNCHDARKLY_OFFLINE` set `true` and optionally specify one or more files
+When running the pcs-api locally, set `LAUNCHDARKLY_OFFLINE` to `true` and optionally specify one or more files
 containing flags values to be used. This is set up by default for cftLibTest and bootWithCcd
 
 With no key the client runs offline and every flag uses its default,

--- a/README.md
+++ b/README.md
@@ -284,6 +284,34 @@ response for the possession claim fee:
 }
 ```
 
+## Feature flags
+
+We use [LaunchDarkly](https://launchdarkly.com) for feature flags, so behaviour can be turned on or
+off per environment without a redeploy. Flags live in the `FeatureFlag` enum and are read through
+`FeatureToggleService`:
+
+```java
+if (featureToggle.isEnabled(FeatureFlag.BULK_PRINT)) {
+    // ...
+}
+```
+
+Each flag has a key matching the LaunchDarkly dashboard and a default served when LaunchDarkly can't
+be reached. The first flag is `bulk-print-enabled`. To add one, add a constant
+(`MY_FEATURE("my-feature-enabled", false)`) and create the matching flag in LaunchDarkly; to retire
+one, delete the constant and the compiler points you at every use.
+
+The SDK key comes from the key vault (`LAUNCHDARKLY_SDK_KEY`) and `LAUNCHDARKLY_ENV` sets the
+environment used for targeting.
+
+### Local Dev
+
+When running the pcs-api locally, set `LAUNCHDARKLY_OFFLINE` set `true` and optionally specify one or more files
+containing flags values to be used. This is set up by default for cftLibTest and bootWithCcd
+
+With no key the client runs offline and every flag uses its default,
+so it still runs locally; local and `cftlibTest` set `LAUNCHDARKLY_OFFLINE=true`.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details

--- a/build.gradle
+++ b/build.gradle
@@ -390,6 +390,7 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: springFrameworkBootVersion
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-client', version: springFrameworkBootVersion
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: springFrameworkBootVersion
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '7.14.0'
 
   runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: flywayVersion
 
@@ -515,6 +516,8 @@ project.tasks.named("generateCCDConfig") {
   environment 'PCS_DB_USER_NAME', 'postgres'
   environment 'PCS_DB_PASSWORD', 'postgres'
   environment 'DB_PORT', '6432'
+  environment 'LAUNCHDARKLY_OFFLINE', 'true'
+  environment 'LAUNCHDARKLY_SDK_KEY', 'ignored'
   environment 'ENABLE_TESTING_SUPPORT', 'false'
   environment 'DB_SCHEDULER_EXECUTOR_ENABLED', 'false'
 }
@@ -552,6 +555,10 @@ tasks.withType(CftlibExec).configureEach {
   environment 'CCD_DECENTRALISED_CASE-TYPE-SERVICE-URLS_PCS', 'http://localhost:3206'
   environment 'SPRING_FLYWAY_ENABLED', 'true'
   environment 'SPRING_PROFILES_ACTIVE', 'dev'
+  // No LaunchDarkly key for local/cftlibTest - run the client offline so it serves code defaults
+  environment 'LAUNCHDARKLY_OFFLINE', 'true'
+  environment 'LAUNCHDARKLY_SDK_KEY', 'ignored'
+  environment 'LAUNCHDARKLY_FILES', './featureFlags/flags.json'
   environment 'ENABLE_TESTING_SUPPORT', 'true'
   environment 'IDAM_CLIENT_SECRET', 'dummy-secret-for-local'
   environment 'XUI_JURISDICTIONS', 'PCS'

--- a/charts/pcs-api/Chart.yaml
+++ b/charts/pcs-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for pcs-api App
 name: pcs-api
 home: https://github.com/hmcts/pcs-api
-version: 0.0.65
+version: 0.0.66
 maintainers:
   - name: HMCTS pcs team
 dependencies:

--- a/charts/pcs-api/values.preview.template.yaml
+++ b/charts/pcs-api/values.preview.template.yaml
@@ -23,6 +23,8 @@ java:
           alias: PCS_PRD_ADMIN_USERNAME
         - name: pcs-prd-admin-password
           alias: PCS_PRD_ADMIN_PASSWORD
+        - name: launchdarkly-sdk-key
+          alias: LAUNCHDARKLY_SDK_KEY
   environment:
     PCS_DB_HOST: "{{ .Release.Name }}-postgresql"
     PCS_DB_USER_NAME: "{{ .Values.postgresql.auth.username}}"
@@ -31,6 +33,7 @@ java:
     SPRING_FLYWAY_LOCATIONS: "classpath:db/migration,classpath:db/testdata"
     SPRING_LOGGING_LEVEL_ROOT: "DEBUG"
     ENABLE_TESTING_SUPPORT: true
+    LAUNCHDARKLY_ENV: "${SERVICE_NAME}"
     DB_SCHEDULER_EXECUTOR_ENABLED: true
     DOC_ASSEMBLY_URL: http://dg-docassembly-aat.service.core-compute-aat.internal
     IDAM_API_URL: https://idam-api.aat.platform.hmcts.net

--- a/charts/pcs-api/values.yaml
+++ b/charts/pcs-api/values.yaml
@@ -29,6 +29,8 @@ java:
           alias: PCS_PRD_ADMIN_PASSWORD
         - name: ccd-elastic-search-hosts
           alias: ELASTIC_SEARCH_HOSTS
+        - name: launchdarkly-sdk-key
+          alias: LAUNCHDARKLY_SDK_KEY
   environment:
     PCS_DB_PORT: "5432"
     PCS_DB_USER_NAME: pgadmin
@@ -47,6 +49,7 @@ java:
     PAY_CALLBACK_URL: "http://pcs-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/payment-update"
     FLYWAY_NOOP_STRATEGY: "false"
     SPRING_FLYWAY_ENABLED: "true"
+    LAUNCHDARKLY_ENV: "{{ .Values.global.environment }}"
     CCD_DATA_STORE_URL: "http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     CASE_DOCUMENT_AM_URL: "http://ccd-case-document-am-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     RD_PROFESSIONAL_API_URL: "http://rd-professional-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"

--- a/featureFlags/flags.json
+++ b/featureFlags/flags.json
@@ -1,0 +1,7 @@
+{
+  "flagValues": {
+    "bulk-print-enabled": false,
+    "caseworker-events-enabled": true,
+    "release-1.2-enabled": true
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseView.java
@@ -31,6 +31,7 @@ import uk.gov.hmcts.reform.pcs.ccd.view.ClaimGroundsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.ClaimView;
 import uk.gov.hmcts.reform.pcs.ccd.view.DefendantResponseView;
 import uk.gov.hmcts.reform.pcs.ccd.view.DocumentsView;
+import uk.gov.hmcts.reform.pcs.ccd.view.FeatureFlagView;
 import uk.gov.hmcts.reform.pcs.ccd.view.GenAppsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.NoticeOfPossessionView;
 import uk.gov.hmcts.reform.pcs.ccd.view.PartiesView;
@@ -88,6 +89,7 @@ public class PCSCaseView implements CaseView<PCSCase, State> {
     private final GenAppsView genAppsView;
     private final CaseFlagsView flagsView;
     private final DefendantResponseView defendantResponseView;
+    private final FeatureFlagView featureFlagView;
 
     /**
      * Invoked by CCD to load PCS cases by reference.
@@ -168,6 +170,7 @@ public class PCSCaseView implements CaseView<PCSCase, State> {
         flagsView.setCaseFields(pcsCase, pcsCaseEntity);
         caseListView.setCaseFields(pcsCase);
         defendantResponseView.setCaseFields(pcsCase, pcsCaseEntity);
+        featureFlagView.setCaseFields(pcsCase);
 
         return new SubmittedCase(pcsCase, pcsCaseEntity);
     }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/FeatureFlags.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/FeatureFlags.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.reform.pcs.ccd.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class FeatureFlags {
+
+    private VerticalYesNo release1dot2Enabled;
+    private VerticalYesNo caseWorkerEventsEnabled;
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/PCSCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/PCSCase.java
@@ -91,6 +91,9 @@ public class PCSCase {
     public static final int MIN_MONETARY_AMOUNT = 1;
     public static final int MAX_MONETARY_AMOUNT = 1_000_000_000;
 
+    @CCD(searchable = false)
+    private FeatureFlags featureFlags;
+
     @CCD(
         searchable = false
     )

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/FeatureFlagView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/FeatureFlagView.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.pcs.ccd.view;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.pcs.ccd.domain.FeatureFlags;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
+import uk.gov.hmcts.reform.pcs.service.FeatureFlag;
+import uk.gov.hmcts.reform.pcs.service.FeatureToggleService;
+
+@Component
+@RequiredArgsConstructor
+public class FeatureFlagView {
+
+    private final FeatureToggleService featureToggleService;
+
+    public void setCaseFields(PCSCase pcsCase) {
+        pcsCase.setFeatureFlags(FeatureFlags.builder()
+                                    .release1dot2Enabled(getFlag(FeatureFlag.RELEASE_1_DOT_2))
+                                    .caseWorkerEventsEnabled(getFlag(FeatureFlag.CASEWORKER_EVENTS))
+                                    .build());
+    }
+
+    private VerticalYesNo getFlag(FeatureFlag featureFlag) {
+        return VerticalYesNo.from(featureToggleService.isEnabled(featureFlag));
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/config/LaunchDarklyConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/config/LaunchDarklyConfiguration.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.reform.pcs.config;
+
+import com.launchdarkly.sdk.server.LDClient;
+import com.launchdarkly.sdk.server.LDConfig;
+import com.launchdarkly.sdk.server.integrations.FileData;
+import com.launchdarkly.sdk.server.subsystems.ComponentConfigurer;
+import com.launchdarkly.sdk.server.subsystems.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@Configuration
+@Slf4j
+public class LaunchDarklyConfiguration {
+
+    @Bean(destroyMethod = "close")
+    public LDClient ldClient(@Value("${launchdarkly.sdk-key:}") String sdkKey,
+                             @Value("${launchdarkly.offline-mode:false}") Boolean offlineMode,
+                             @Value("${launchdarkly.files:}") String[] flagFiles) {
+        LDConfig.Builder builder = new LDConfig.Builder();
+
+        if (BooleanUtils.isTrue(offlineMode)) {
+            // Use local flag files as the flag datasource if specified, (instead of the remote service),
+            // otherwise set the whole LDClient to offline mode.
+            getExistingFiles(flagFiles).ifPresentOrElse(
+                localFlagFiles -> builder.dataSource(this.getDataSource(localFlagFiles)),
+                () -> builder.offline(true));
+        }
+
+        LDClient client = new LDClient(sdkKey, builder.build());
+        if (!client.isInitialized()) {
+            log.warn("LaunchDarkly not initialised at startup - serving code defaults until connected");
+        }
+        return client;
+    }
+
+    private ComponentConfigurer<DataSource> getDataSource(Path[] flagFilePaths) {
+        return FileData.dataSource()
+            .filePaths(flagFilePaths)
+            .autoUpdate(true)
+            .duplicateKeysHandling(FileData.DuplicateKeysHandling.IGNORE);
+    }
+
+    private Optional<Path[]> getExistingFiles(String[] files) {
+        if (files == null || files.length < 1) {
+            return Optional.empty();
+        }
+        Path[] existing = Stream.of(files)
+            .map(this::getPathIfExists)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .toArray(Path[]::new);
+        return existing.length > 0 ? Optional.of(existing) : Optional.empty();
+    }
+
+    private Optional<Path> getPathIfExists(String file) {
+        if (StringUtils.isBlank(file)) {
+            return Optional.empty();
+        }
+        Path flagFile = file.startsWith("/") ? Paths.get(file) : Paths.get("").resolve(file);
+        if (Files.exists(flagFile)) {
+            return Optional.of(flagFile);
+        }
+        log.warn("Could not find LaunchDarkly flag file defined by {}", file);
+        return Optional.empty();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/service/FeatureFlag.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/service/FeatureFlag.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.pcs.service;
+
+// LaunchDarkly flags; the boolean is the fail-safe default served when LD cannot be evaluated.
+public enum FeatureFlag {
+
+    BULK_PRINT("bulk-print-enabled", false),
+    CASEWORKER_EVENTS("caseworker-events-enabled", false),
+    RELEASE_1_DOT_2("release-1.2-enabled", false);
+
+    private final String key;
+    private final boolean defaultValue;
+
+    FeatureFlag(String key, boolean defaultValue) {
+        this.key = key;
+        this.defaultValue = defaultValue;
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public boolean defaultValue() {
+        return defaultValue;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/service/FeatureToggleService.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.pcs.service;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.LDClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FeatureToggleService {
+
+    private static final String SERVICE_KEY = "pcs-api";
+
+    private final LDClient ldClient;
+    private final LDContext context;
+
+    public FeatureToggleService(LDClient ldClient,
+                                @Value("${launchdarkly.env:default}") String environment) {
+        this.ldClient = ldClient;
+        this.context = context(environment);
+    }
+
+    public boolean isEnabled(FeatureFlag flag) {
+        return ldClient.boolVariation(flag.key(), context, flag.defaultValue());
+    }
+
+    // Anonymous service identity carrying the environment attribute for LD targeting; invariant, built once.
+    private static LDContext context(String environment) {
+        return LDContext.builder(SERVICE_KEY)
+            .set("environment", environment)
+            .anonymous(true)
+            .build();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -263,6 +263,12 @@ access-code:
     max-retries: ${ACCESS_CODE_MAX_RETRIES:5}
     backoff-delay-seconds: ${ACCESS_CODE_BACKOFF_DELAY_SECONDS:3600s}
 
+launchdarkly:
+  sdk-key: ${LAUNCHDARKLY_SDK_KEY:}
+  offline-mode: ${LAUNCHDARKLY_OFFLINE:false}
+  env: ${LAUNCHDARKLY_ENV:default}
+  files: ${LAUNCHDARKLY_FILES:}
+
 claim-form:
   request:
     max-retries: ${CLAIM_FORM_MAX_RETRIES:5}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/PCSCaseViewTest.java
@@ -34,6 +34,7 @@ import uk.gov.hmcts.reform.pcs.ccd.view.ClaimGroundsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.ClaimView;
 import uk.gov.hmcts.reform.pcs.ccd.view.DefendantResponseView;
 import uk.gov.hmcts.reform.pcs.ccd.view.DocumentsView;
+import uk.gov.hmcts.reform.pcs.ccd.view.FeatureFlagView;
 import uk.gov.hmcts.reform.pcs.ccd.view.GenAppsView;
 import uk.gov.hmcts.reform.pcs.ccd.view.NoticeOfPossessionView;
 import uk.gov.hmcts.reform.pcs.ccd.view.PartiesView;
@@ -127,6 +128,8 @@ class PCSCaseViewTest {
     private CaseFlagsView caseFlagsView;
     @Mock
     private DefendantResponseView defendantResponseView;
+    @Mock
+    private FeatureFlagView featureFlagView;
 
     private PCSCaseView underTest;
 
@@ -142,7 +145,7 @@ class PCSCaseViewTest {
                                     statementOfTruthView, caseFieldsView, searchCriteriaIndexer, caseListView,
                                     caseLinkView, enforcementOrderMediator,
                                     caseNoteView, caseTabView, partiesView, genAppsView, caseFlagsView,
-                                    defendantResponseView
+                                    defendantResponseView, featureFlagView
         );
     }
 
@@ -314,6 +317,7 @@ class PCSCaseViewTest {
         verify(defendantResponseView).setCaseFields(pcsCase, pcsCaseEntity);
         verify(caseListView).setCaseFields(pcsCase);
         verify(genAppsView).setCaseFields(pcsCase, pcsCaseEntity);
+        verify(featureFlagView).setCaseFields(pcsCase);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/FeatureFlagViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/FeatureFlagViewTest.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.reform.pcs.ccd.view;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
+import uk.gov.hmcts.reform.pcs.service.FeatureFlag;
+import uk.gov.hmcts.reform.pcs.service.FeatureToggleService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FeatureFlagViewTest {
+
+    @Mock
+    private FeatureToggleService featureToggleService;
+
+    private FeatureFlagView underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new FeatureFlagView(featureToggleService);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetCaseworkerFeatureFlagInCaseData(boolean flagEnabled) {
+        // Given
+        PCSCase pcsCase = PCSCase.builder().build();
+        when(featureToggleService.isEnabled(isA(FeatureFlag.class))).thenReturn(false);
+        when(featureToggleService.isEnabled(FeatureFlag.CASEWORKER_EVENTS)).thenReturn(flagEnabled);
+
+        // When
+        underTest.setCaseFields(pcsCase);
+
+        // Then
+        assertThat(pcsCase.getFeatureFlags().getCaseWorkerEventsEnabled())
+            .isEqualTo(VerticalYesNo.from(flagEnabled));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetRelease1dot2FeatureFlagInCaseData(boolean flagEnabled) {
+        // Given
+        PCSCase pcsCase = PCSCase.builder().build();
+        when(featureToggleService.isEnabled(isA(FeatureFlag.class))).thenReturn(false);
+        when(featureToggleService.isEnabled(FeatureFlag.RELEASE_1_DOT_2)).thenReturn(flagEnabled);
+
+        // When
+        underTest.setCaseFields(pcsCase);
+
+        // Then
+        assertThat(pcsCase.getFeatureFlags().getRelease1dot2Enabled())
+            .isEqualTo(VerticalYesNo.from(flagEnabled));
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/config/LaunchDarklyConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/config/LaunchDarklyConfigurationTest.java
@@ -1,0 +1,61 @@
+package uk.gov.hmcts.reform.pcs.config;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.LDClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LaunchDarklyConfigurationTest {
+
+    private final LaunchDarklyConfiguration underTest = new LaunchDarklyConfiguration();
+
+    @Test
+    void shouldRunOfflineWhenOfflineModeTrueEvenWithKeyPresent() throws Exception {
+        // LAUNCHDARKLY_OFFLINE=true forces offline regardless of a configured key (used by local/cftlibTest)
+        try (LDClient client = underTest.ldClient("sdk-key-present", true, new String[0])) {
+            assertThat(client.isInitialized()).isTrue();
+
+            LDContext context = LDContext.create("test");
+            assertThat(client.boolVariation("any-flag", context, true)).isTrue();
+            assertThat(client.boolVariation("any-flag", context, false)).isFalse();
+        }
+    }
+
+    @Test
+    void shouldServeFlagValuesFromFileDataSource(@TempDir Path dir) throws Exception {
+        Path flagFile = Files.writeString(dir.resolve("flags.json"),
+            "{ \"flagValues\": { \"bulk-print-enabled\": true } }");
+
+        // a file data source loads flags from disk instead of the network, so the key is unused
+        try (LDClient client = underTest.ldClient("dummy-key", true, new String[]{flagFile.toString()})) {
+            assertThat(client.boolVariation("bulk-print-enabled", LDContext.create("test"), false)).isTrue();
+        }
+    }
+
+    @Test
+    void shouldIgnoreBlankAndMissingFlagFilesButUseTheValidOne(@TempDir Path dir) throws Exception {
+        Path flagFile = Files.writeString(dir.resolve("flags.json"),
+            "{ \"flagValues\": { \"bulk-print-enabled\": true } }");
+
+        // blank entries and non-existent paths are filtered out; only the real file drives the data source
+        String[] files = {"", dir.resolve("does-not-exist.json").toString(), flagFile.toString()};
+        try (LDClient client = underTest.ldClient("dummy-key", true, files)) {
+            assertThat(client.boolVariation("bulk-print-enabled", LDContext.create("test"), false)).isTrue();
+        }
+    }
+
+    @Test
+    void shouldBuildOfflineClientWithoutDataSourceWhenNoFlagFilesProvided() throws Exception {
+        // key present + not offline + no flag files => no file data source is attached; without a
+        // connection the client stays uninitialised and every evaluation falls back to the passed default
+        try (LDClient client = underTest.ldClient("dummy-key", true, new String[0])) {
+            assertThat(client.isInitialized()).isTrue();
+            assertThat(client.boolVariation("any-flag", LDContext.create("test"), true)).isTrue();
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/service/FeatureFlagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/service/FeatureFlagTest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.pcs.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FeatureFlagTest {
+
+    @Test
+    void shouldHaveUniqueNonBlankKebabCaseKeys() {
+        List<String> keys = Arrays.stream(FeatureFlag.values()).map(FeatureFlag::key).toList();
+
+        assertThat(keys).doesNotHaveDuplicates();
+        assertThat(keys).allSatisfy(key ->
+            assertThat(key).isNotBlank().matches("[a-z0-9]+(-[a-z0-9.]+)*"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/service/FeatureToggleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/service/FeatureToggleServiceTest.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.reform.pcs.service;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.LDClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FeatureToggleServiceTest {
+
+    private static final String FLAG_KEY = "bulk-print-enabled";
+
+    @Mock
+    private LDClient ldClient;
+
+    @Captor
+    private ArgumentCaptor<LDContext> contextCaptor;
+
+    @Test
+    void shouldReturnVariationValueFromLdClient() {
+        FeatureToggleService underTest = new FeatureToggleService(ldClient, "aat");
+        when(ldClient.boolVariation(eq(FLAG_KEY), any(LDContext.class), eq(false))).thenReturn(true);
+
+        assertThat(underTest.isEnabled(FeatureFlag.BULK_PRINT)).isTrue();
+    }
+
+    @Test
+    void shouldBuildContextWithServiceKeyAndEnvironment() {
+        FeatureToggleService underTest = new FeatureToggleService(ldClient, "aat");
+        when(ldClient.boolVariation(eq(FLAG_KEY), contextCaptor.capture(), eq(false))).thenReturn(true);
+
+        underTest.isEnabled(FeatureFlag.BULK_PRINT);
+
+        LDContext context = contextCaptor.getValue();
+        assertThat(context.getKind().toString()).isEqualTo("user");
+        assertThat(context.getKey()).isEqualTo("pcs-api");
+        assertThat(context.isAnonymous()).isTrue();
+        assertThat(context.getValue("environment").stringValue()).isEqualTo("aat");
+    }
+
+    @Test
+    void shouldReturnFalseWhenFlagOff() {
+        FeatureToggleService underTest = new FeatureToggleService(ldClient, "aat");
+        when(ldClient.boolVariation(eq(FLAG_KEY), any(LDContext.class), eq(false))).thenReturn(false);
+
+        assertThat(underTest.isEnabled(FeatureFlag.BULK_PRINT)).isFalse();
+    }
+
+    @Test
+    void shouldPassFlagFailSafeDefaultToLdClient() {
+        FeatureToggleService underTest = new FeatureToggleService(ldClient, "default");
+
+        underTest.isEnabled(FeatureFlag.BULK_PRINT);
+
+        // the per-flag fail-safe default is what LaunchDarkly serves when it cannot evaluate
+        verify(ldClient).boolVariation(eq(FLAG_KEY), any(LDContext.class), eq(FeatureFlag.BULK_PRINT.defaultValue()));
+    }
+}


### PR DESCRIPTION
### Jira link

See [HDPI-7579](https://tools.hmcts.net/jira/browse/HDPI-7579)

### Change description

Add LaunchDarkly and some initial feature flags for:

- bulk-print-enabled
- caseworker-events-enabled
- release-1.2-enabled

Mostly lifted from https://github.com/hmcts/pcs-api/pull/2113 to have in a separate ticket, with a tweak for offline/local operation.

These flags are not used by anything in this PR, but they can be seen in the case data and it has been proved locally that they can be used to show/hide events in the Next Steps dropdown in ExUI.

<img width="655" height="382" alt="image" src="https://github.com/user-attachments/assets/ab9d08ae-3936-4f95-af06-86665d88c720" />


### Testing done

Tested locally with a temporary show condition based on a feature flag. Also tested in Preview by toggling the feature flag and confirming the case data JSON is updated.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
