### PR TITLE
HDPI-7554 add feature flag for respond to claim LR journey test contr…

### DIFF
--- a/featureFlags/flags.json
+++ b/featureFlags/flags.json
@@ -2,6 +2,7 @@
   "flagValues": {
     "bulk-print-enabled": false,
     "caseworker-events-enabled": true,
+    "cui-respond-to-claim-lr-enabled": true,
     "release-1.2-enabled": true
   }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/service/FeatureFlag.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/service/FeatureFlag.java
@@ -5,6 +5,7 @@ public enum FeatureFlag {
 
     BULK_PRINT("bulk-print-enabled", false),
     CASEWORKER_EVENTS("caseworker-events-enabled", false),
+    CUI_RESPOND_TO_CLAIM_LR("cui-respond-to-claim-lr-enabled", false),
     RELEASE_1_DOT_2("release-1.2-enabled", false);
 
     private final String key;

--- a/src/main/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportController.java
@@ -32,6 +32,8 @@ import uk.gov.hmcts.reform.pcs.ccd.entity.feesandpay.FeePaymentEntity;
 import uk.gov.hmcts.reform.pcs.idam.UserInfo;
 import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
 import uk.gov.hmcts.reform.pcs.ccd.domain.Party;
+import uk.gov.hmcts.reform.pcs.service.FeatureFlag;
+import uk.gov.hmcts.reform.pcs.service.FeatureToggleService;
 import uk.gov.hmcts.reform.pcs.testingsupport.model.TestingSupportAccessCode;
 import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
@@ -84,6 +86,7 @@ public class TestingSupportController {
     private final OrganisationDetailsService organisationDetailsService;
     private final PcsCaseService pcsCaseService;
     private final AccessCodeGenerationService accessCodeGenerationService;
+    private final FeatureToggleService featureToggleService;
 
     @Operation(
         summary = "Schedule a Hello World task",
@@ -393,6 +396,8 @@ public class TestingSupportController {
         content = @Content())
     @ApiResponse(responseCode = "401", description = "Invalid access token",
         content = @Content())
+    @ApiResponse(responseCode = "412", description = "Feature not enabled",
+        content = @Content())
     public ResponseEntity<Void> linkDefendantSolicitorToParty(
         @Parameter(description = "The 12-digit case reference number", required = true)
         @PathVariable long caseReference,
@@ -401,6 +406,13 @@ public class TestingSupportController {
         @RequestHeader(value = AUTHORIZATION) String authorization,
         @RequestHeader(value = "ServiceAuthorization") String serviceAuthorization
     ) {
+
+        if(!this.featureToggleService.isEnabled(FeatureFlag.RELEASE_1_DOT_2)
+            || !this.featureToggleService.isEnabled(FeatureFlag.CUI_RESPOND_TO_CLAIM_LR)) {
+            log.warn("Feature flags are disabled for [{}] [{}]", FeatureFlag.RELEASE_1_DOT_2.key(),
+                     FeatureFlag.CUI_RESPOND_TO_CLAIM_LR.key());
+            return ResponseEntity.status(HttpStatus.PRECONDITION_FAILED).build();
+        }
 
         User user = idamAuthenticator.validateAuthToken(authorization);
         UserInfo userDetails = user.getUserDetails();

--- a/src/main/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportController.java
@@ -407,7 +407,7 @@ public class TestingSupportController {
         @RequestHeader(value = "ServiceAuthorization") String serviceAuthorization
     ) {
 
-        if(!this.featureToggleService.isEnabled(FeatureFlag.RELEASE_1_DOT_2)
+        if (!this.featureToggleService.isEnabled(FeatureFlag.RELEASE_1_DOT_2)
             || !this.featureToggleService.isEnabled(FeatureFlag.CUI_RESPOND_TO_CLAIM_LR)) {
             log.warn("Feature flags are disabled for [{}] [{}]", FeatureFlag.RELEASE_1_DOT_2.key(),
                      FeatureFlag.CUI_RESPOND_TO_CLAIM_LR.key());

--- a/src/test/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportControllerTest.java
@@ -21,6 +21,8 @@ import uk.gov.hmcts.reform.pcs.ccd.domain.Party;
 import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import uk.gov.hmcts.reform.pcs.service.FeatureFlag;
+import uk.gov.hmcts.reform.pcs.service.FeatureToggleService;
 import uk.gov.hmcts.reform.pcs.testingsupport.model.TestingSupportAccessCode;
 import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
@@ -91,7 +93,8 @@ class TestingSupportControllerTest {
     private PcsCaseService pcsCaseService;
     @Mock
     private AccessCodeGenerationService accessCodeGenerationService;
-
+    @Mock
+    private FeatureToggleService featureToggleService;
 
     private TestingSupportController underTest;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -107,7 +110,8 @@ class TestingSupportControllerTest {
                                                  idamAuthenticator,
                                                  organisationDetailsService,
                                                  pcsCaseService,
-                                                 accessCodeGenerationService
+                                                 accessCodeGenerationService,
+                                                 featureToggleService
         );
     }
 
@@ -364,6 +368,8 @@ class TestingSupportControllerTest {
         when(user.getUserDetails()).thenReturn(userInfo);
         when(userInfo.getUid()).thenReturn(userUid);
         when(organisationDetailsService.getOrganisationDetails(userUid.toString())).thenReturn(organisationDetails);
+        when(featureToggleService.isEnabled(FeatureFlag.RELEASE_1_DOT_2)).thenReturn(true);
+        when(featureToggleService.isEnabled(FeatureFlag.CUI_RESPOND_TO_CLAIM_LR)).thenReturn(true);
 
         // when
         ResponseEntity<Void> response = underTest.linkDefendantSolicitorToParty(
@@ -380,6 +386,47 @@ class TestingSupportControllerTest {
             .linkLegalRepresentativeToParty(caseReference, partyId, userInfo, organisationDetails);
 
         assertThat(HttpStatus.OK.equals(response.getStatusCode()));
+    }
+
+    @Test
+    void linkDefendantSolicitorToPartyReleaseFeatureFlagNotSet() {
+        // given
+        long caseReference = 111111111111L;
+        String partyId = "abc";
+        String authToken = "testAuth";
+        when(featureToggleService.isEnabled(FeatureFlag.RELEASE_1_DOT_2)).thenReturn(false);
+
+        // when
+        ResponseEntity<Void> response = underTest.linkDefendantSolicitorToParty(
+            caseReference,
+            partyId,
+            authToken,
+            "testS2S"
+        );
+
+        // then
+        assertThat(HttpStatus.PRECONDITION_FAILED.equals(response.getStatusCode()));
+    }
+
+    @Test
+    void linkDefendantSolicitorToPartyFeatureFlagNotSet() {
+        // given
+        long caseReference = 111111111111L;
+        String partyId = "abc";
+        String authToken = "testAuth";
+        when(featureToggleService.isEnabled(FeatureFlag.RELEASE_1_DOT_2)).thenReturn(true);
+        when(featureToggleService.isEnabled(FeatureFlag.CUI_RESPOND_TO_CLAIM_LR)).thenReturn(false);
+
+        // when
+        ResponseEntity<Void> response = underTest.linkDefendantSolicitorToParty(
+            caseReference,
+            partyId,
+            authToken,
+            "testS2S"
+        );
+
+        // then
+        assertThat(HttpStatus.PRECONDITION_FAILED.equals(response.getStatusCode()));
     }
 
     @Test


### PR DESCRIPTION

See [HDPI-7554](https://tools.hmcts.net/jira/browse/HDPI-7554)

### Change description

Added respond to claim LR journey feature flag, referenced in test support controller to control access to link a defendant to a solicitor endpoint

### Testing done

Tested locally by alternating 'release-1.2-enabled' and 'cui-respond-to-claim-lr-enabled' flag values, tested on preview by toggling flag - https://app.launchdarkly.com/projects/PCS/flags/cui-respond-to-claim-lr-enabled/targeting?env=test&selected-env=test 

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
