### PR TITLE
Case Linking- Button is renamed from 'Submit' to 'Save and Continue' …

### DIFF
--- a/src/e2eTest/data/page-data/beforeYouStart.page.data.ts
+++ b/src/e2eTest/data/page-data/beforeYouStart.page.data.ts
@@ -3,6 +3,6 @@ export const beforeYouStart = {
   mainHeader: 'Before you start',
   ifAGroupParagraph: 'If a group of linked cases has a lead case, you must start from the lead case.',
   ifTheCaseParagraph: 'If the cases to be linked has no lead, you can start the linking journey from any of those cases.',
-  submitButton: 'Submit',
+  saveAndContinueButton: 'Save and continue',
   cancel: 'Cancel',
 }

--- a/src/e2eTest/data/page-data/checkYourAnswersCaseLinking.page.data.ts
+++ b/src/e2eTest/data/page-data/checkYourAnswersCaseLinking.page.data.ts
@@ -1,5 +1,5 @@
 export const checkYourAnswersCaseLinking = {
   mainHeader: 'Check your answers',
-  submitButton: 'Submit',
+  saveAndContinueButton: 'Save and continue',
   cancel: 'Cancel'
 };

--- a/src/e2eTest/data/page-data/selectCaseToLink.page.data.ts
+++ b/src/e2eTest/data/page-data/selectCaseToLink.page.data.ts
@@ -14,6 +14,6 @@ export const selectCasesToLink = {
   otherDescriptionInputLabel: 'otherDescription',
   otherDescriptionInputText: 'Input for other reason testing purpose',
   proposeLinkButton: 'Propose case link',
-  submitButton: 'Submit',
+  saveAndContinueButton: 'Save and continue',
   cancel: 'Cancel',
 }

--- a/src/e2eTest/data/page-data/selectCasesToUnLink.page.data.ts
+++ b/src/e2eTest/data/page-data/selectCasesToUnLink.page.data.ts
@@ -1,6 +1,6 @@
 export const selectCasesToUnLink = {
   title: 'Create a case - HM Courts & Tribunals Service - GOV.UK',
   mainHeader: 'Select the cases you want to unlink from this case',
-  submitButton: 'Submit',
+  saveAndContinueButton: 'Save and continue',
   cancel: 'Cancel',
 }

--- a/src/e2eTest/tests/CommonComponent/caseLinking.spec.ts
+++ b/src/e2eTest/tests/CommonComponent/caseLinking.spec.ts
@@ -58,7 +58,7 @@ test.describe('[Common Component Case Linking] @nightly @caseLinking', async () 
     await performAction('select', caseSummary.nextStepEventList, caseSummary.linkCaseEvent);
     await performAction('clickButton', caseSummary.go);
     await performValidation('mainHeader', beforeYouStart.mainHeader);
-    await performAction('clickButton', beforeYouStart.submitButton);
+    await performAction('clickButton', beforeYouStart.saveAndContinueButton);
     await performValidation('mainHeader', selectCasesToLink.mainHeader);
     await performAction('selectCasesToLink', {
       caseRefInput: caseNumbers,
@@ -72,16 +72,16 @@ test.describe('[Common Component Case Linking] @nightly @caseLinking', async () 
       proposeButton: selectCasesToLink.proposeLinkButton
     });
     await performValidation('mainHeader', checkYourAnswersCaseLinking.mainHeader);
-    await performAction('clickButton', checkYourAnswersCaseLinking.submitButton);
+    await performAction('clickButton', checkYourAnswersCaseLinking.saveAndContinueButton);
     await performValidation('bannerAlert', 'Case #.* has been updated with event: Link cases');
     await performAction('select', caseSummary.nextStepEventList, caseSummary.manageCaseEvent);
     await performAction('clickButton', caseSummary.go);
     await performValidation('mainHeader', beforeYouStart.mainHeader);
-    await performAction('clickButton', beforeYouStart.submitButton);
+    await performAction('clickButton', beforeYouStart.saveAndContinueButton);
     await performValidation('mainHeader', selectCasesToUnLink.mainHeader);
     await performAction('selectCasesToUnLink', { caseRefInput: caseNumbers });
     await performValidation('mainHeader', checkYourAnswersCaseLinking.mainHeader);
-    await performAction('clickButton', checkYourAnswersCaseLinking.submitButton);
+    await performAction('clickButton', checkYourAnswersCaseLinking.saveAndContinueButton);
     await performValidation('bannerAlert', 'Case #.* has been updated with event: Manage case links');
     await performAction('verifyLinkedCases', { caseRefInput: caseNumbers });
   });

--- a/src/e2eTest/utils/actions/custom-actions/commonComponent/caseLinking.action.ts
+++ b/src/e2eTest/utils/actions/custom-actions/commonComponent/caseLinking.action.ts
@@ -24,7 +24,7 @@ export class CaseLinking implements IAction {
       await performAction('clickButton', caseData.proposeButton);
       console.log(`selected Case ${i}: ${caseRefs[i]}`);
     }
-    await performAction('clickButton', selectCasesToLink.submitButton);
+    await performAction('clickButton', selectCasesToLink.saveAndContinueButton);
 
   }
 
@@ -37,7 +37,7 @@ export class CaseLinking implements IAction {
       );
       await selectBox.check();
     }
-    await performAction('clickButton', selectCasesToUnLink.submitButton);;
+    await performAction('clickButton', selectCasesToUnLink.saveAndContinueButton);;
   }
 
   private async verifyLinkedCases(caseData: actionRecord, page: Page) {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/HDPI-7625

**Change description**

case flag CC team has updated button name from 'Submit' to 'Save and continue' so automation needs to updated to use correct button name

**Testing done**
Tested locally as case linking doesnt work on preview
<img width="1719" height="1032" alt="image" src="https://github.com/user-attachments/assets/7745eb1e-d8ce-4d90-aae7-4212daba77d0" />

<img width="1728" height="1024" alt="image" src="https://github.com/user-attachments/assets/cf6699b3-ce7b-47c1-baf9-68bfa2f497b8" />
<img width="1728" height="1024" alt="image" src="https://github.com/user-attachments/assets/9c9d7875-9a6c-41b4-b7b6-3cb5551221aa" />

**Checklist**

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
