### PR TITLE
Remove postcode from court allocation info log

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/postcodecourt/service/PostCodeCourtService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/postcodecourt/service/PostCodeCourtService.java
@@ -39,7 +39,6 @@ public class PostCodeCourtService {
             log.error("EpimId not found for postcode: {}", postCode);
             return null;
         }
-        log.info("Court management location allocated for postcode {}", postCode);
         return results.getFirst().getId().getEpimsId();
     }
 


### PR DESCRIPTION
## What

Removes the `INFO`-level log line in `PostCodeCourtService.getCourtManagementLocation` that emitted the property postcode on every successful court allocation:

```java
log.info("Court management location allocated for postcode {}", postCode);
```
