### PR TITLE
Add CODEOWNERS for functional and contract tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,6 @@ src/e2eTest/.nvmrc
 src/e2eTest/yarn.lock
 
 src/e2eTest @hmcts/possession-claim-service-qa-admins @hmcts/possession-claim-service-admins
+
+src/functionalTest @hmcts/possession-claim-service-da @hmcts/possession-claim-service-admins
+src/contractTest @hmcts/possession-claim--service-da @hmcts/possession-claim-service-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,5 +12,5 @@ src/e2eTest/yarn.lock
 
 src/e2eTest @hmcts/possession-claim-service-qa-admins @hmcts/possession-claim-service-admins
 
-src/functionalTest @hmcts/possession-claim-service-da @hmcts/possession-claim-service-admins
-src/contractTest @hmcts/possession-claim--service-da @hmcts/possession-claim-service-admins
+src/functionalTest @hmcts/possession-claim-service-dev-assurance @hmcts/possession-claim-service-admins
+src/contractTest @hmcts/possession-claim--service-dev-assurance @hmcts/possession-claim-service-admins


### PR DESCRIPTION
Allow Dev Assurance to approve their own PR instead of chasing Backend-Dev