### PR TITLE
Grant PCS reader access to CCD schema

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -25,7 +25,8 @@ module "postgresql" {
   common_tags   = var.common_tags
   pgsql_databases = [
     {
-      name : var.product
+      name                      = var.product
+      schemas_for_reader_access = ["public", "ccd"]
     }
   ]
   pgsql_server_configuration = [


### PR DESCRIPTION
### Change description

Grant the PCS database reader group access to the `ccd` schema as well as `public`, matching the Special Tribunals database configuration.

Depends on [hmcts/azure-access#7726](https://github.com/hmcts/azure-access/pull/7726) creating the production reader group. The related My Access package is configured in [hmcts/azure-access-packages#131](https://github.com/hmcts/azure-access-packages/pull/131).
