### PR TITLE
Dispose of inactive drafts after 30 days

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -451,15 +451,15 @@ dependencies {
   functionalTestImplementation sourceSets.main.runtimeClasspath
   functionalTestImplementation sourceSets.test.runtimeClasspath
 
-  testImplementation group: 'org.junit.platform', name: 'junit-platform-suite-api', version: '6.1.2'
+  testImplementation group: 'org.junit.platform', name: 'junit-platform-suite-api', version: '1.12.2'
 
   contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: pactVersion
   contractTestImplementation group: 'org.hamcrest', name: 'java-hamcrest', version: '2.0.0.0'
-  contractTestImplementation('org.junit.jupiter:junit-jupiter-api:6.1.2')
+  contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.12.2')
   contractTestImplementation sourceSets.main.runtimeClasspath
   contractTestImplementation sourceSets.test.runtimeClasspath
 
-  testImplementation(platform('org.junit:junit-bom:6.1.2'))
+  testImplementation(platform('org.junit:junit-bom:5.12.2'))
   testImplementation group: 'org.springframework.security', name: 'spring-security-test', version: springSecurityVersion
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springFrameworkBootVersion) {
@@ -478,6 +478,9 @@ dependencies {
 
   // cftlib does not pull oauth2-client transitively from `implementation`; needed by OAuth2ClientConfig
   cftlibImplementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+  // Keep CFTLib's bundled console launcher aligned with the JUnit platform used by PCS tests.
+  cftlibTestImplementation 'org.junit.platform:junit-platform-console-standalone:1.12.2'
 
   mockitoAgentConfig group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
   mockitoAgent 'org.mockito:mockito-core'
@@ -568,6 +571,8 @@ tasks.withType(CftlibExec).configureEach {
   environment 'CASE_DOCUMENT_S2S_AUTHORISED_SERVICES', 'ccd_case_document_am_api,ccd_gw,xui_webapp,ccd_data,pcs_frontend,pcs_api'
   environment 'DATA_STORE_S2S_AUTHORISED_SERVICES', 'ccd_data,ccd_gw,pcs_frontend,pcs_api'
   environment 'CCD_S2S-AUTHORISED_SERVICES_CASE_USER_ROLES', 'aac_manage_case_assignment,pcs_api'
+  environment 'CCD_RETAIN_AND_DISPOSE_MODE', 'live'
+  environment 'CCD_RETAIN_AND_DISPOSE_CRON', '-'
 }
 
 cftlibTest {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
   id 'org.flywaydb.flyway' version "$flywayVersion"
   id 'org.sonarqube' version '7.3.1.8318'
   id 'net.serenity-bdd.serenity-gradle-plugin' version "$serenityBddVersion"
-  id 'hmcts.ccd.sdk' version '6.13.0'
+  id 'hmcts.ccd.sdk' version '6.28.0'
   id 'com.github.hmcts.rse-cft-lib' version '0.19.2220'
   id 'io.freefair.lombok' version '9.5.0'
   id 'au.com.dius.pact' version '4.7.3'

--- a/build.gradle
+++ b/build.gradle
@@ -569,6 +569,7 @@ tasks.withType(CftlibExec).configureEach {
   environment 'DATA_STORE_S2S_AUTHORISED_SERVICES', 'ccd_data,ccd_gw,pcs_frontend,pcs_api'
   environment 'CCD_S2S-AUTHORISED_SERVICES_CASE_USER_ROLES', 'aac_manage_case_assignment,pcs_api'
   environment 'CCD_RETAIN_AND_DISPOSE_MODE', 'live'
+  // Spring treats "-" as a disabled cron expression; CFTLib tests invoke the live task explicitly.
   environment 'CCD_RETAIN_AND_DISPOSE_CRON', '-'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -451,15 +451,15 @@ dependencies {
   functionalTestImplementation sourceSets.main.runtimeClasspath
   functionalTestImplementation sourceSets.test.runtimeClasspath
 
-  testImplementation group: 'org.junit.platform', name: 'junit-platform-suite-api', version: '1.12.2'
+  testImplementation group: 'org.junit.platform', name: 'junit-platform-suite-api', version: '6.1.2'
 
   contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: pactVersion
   contractTestImplementation group: 'org.hamcrest', name: 'java-hamcrest', version: '2.0.0.0'
-  contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.12.2')
+  contractTestImplementation('org.junit.jupiter:junit-jupiter-api:6.1.2')
   contractTestImplementation sourceSets.main.runtimeClasspath
   contractTestImplementation sourceSets.test.runtimeClasspath
 
-  testImplementation(platform('org.junit:junit-bom:5.12.2'))
+  testImplementation(platform('org.junit:junit-bom:6.1.2'))
   testImplementation group: 'org.springframework.security', name: 'spring-security-test', version: springSecurityVersion
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springFrameworkBootVersion) {
@@ -478,9 +478,6 @@ dependencies {
 
   // cftlib does not pull oauth2-client transitively from `implementation`; needed by OAuth2ClientConfig
   cftlibImplementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-
-  // Keep CFTLib's bundled console launcher aligned with the JUnit platform used by PCS tests.
-  cftlibTestImplementation 'org.junit.platform:junit-platform-console-standalone:1.12.2'
 
   mockitoAgentConfig group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
   mockitoAgent 'org.mockito:mockito-core'

--- a/src/cftlibTest/java/uk/gov/hmcts/reform/pcs/DraftRetentionPolicyTest.java
+++ b/src/cftlibTest/java/uk/gov/hmcts/reform/pcs/DraftRetentionPolicyTest.java
@@ -1,0 +1,140 @@
+package uk.gov.hmcts.reform.pcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.pcs.ccd.domain.State.AWAITING_SUBMISSION_TO_HMCTS;
+import static uk.gov.hmcts.reform.pcs.ccd.domain.State.PendingDisposal;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import uk.gov.hmcts.ccd.sdk.type.AddressUK;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.client.CcdClient;
+import uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry;
+import uk.gov.hmcts.rse.ccd.lib.Database;
+import uk.gov.hmcts.rse.ccd.lib.test.CftlibTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DraftRetentionPolicyTest extends CftlibTest {
+
+    @Autowired
+    private CcdClient ccdClient;
+
+    @Autowired
+    private IdamClient idamClient;
+
+    @Autowired
+    private NamedParameterJdbcTemplate jdbc;
+
+    @Autowired
+    @Qualifier("retainAndDisposeTask")
+    private Runnable retainAndDisposeTask;
+
+    private String solicitorToken;
+    private String systemUserToken;
+
+    @BeforeAll
+    void setup() {
+        solicitorToken = idamClient.getAccessToken("pcs-solicitor1@test.com", "password");
+        systemUserToken = idamClient.getAccessToken("pcs-system-user@localhost", "password");
+    }
+
+    @Test
+    void deletesDraftsAfterMoreThanThirtyDaysOfInactivity() throws Exception {
+        long inactiveDraft = createDraft();
+        long thirtyDayOldDraft = createDraft();
+
+        setLastModified(inactiveDraft, 31);
+        setLastModified(thirtyDayOldDraft, 30);
+
+        retainAndDisposeTask.run();
+
+        assertThat(ccdClient.getCaseDetails(inactiveDraft, systemUserToken).getState())
+            .isEqualTo(PendingDisposal.name());
+        assertThat(ccdClient.getCaseDetails(thirtyDayOldDraft, solicitorToken).getState())
+            .isEqualTo(AWAITING_SUBMISSION_TO_HMCTS.name());
+        assertThat(localCaseValue(
+            "select resolved_ttl = current_date from ccd.case_data where reference = :reference",
+            inactiveDraft,
+            Boolean.class
+        )).isTrue();
+        assertThat(localCaseValue(
+            "select resolved_ttl is null from ccd.case_data where reference = :reference",
+            thirtyDayOldDraft,
+            Boolean.class
+        )).isTrue();
+
+        expireLocalTtl(inactiveDraft);
+        deleteCentralCasePointer(inactiveDraft);
+
+        retainAndDisposeTask.run();
+
+        assertThat(localCaseCount("ccd.case_data", "reference", inactiveDraft)).isZero();
+        assertThat(localCaseCount("pcs_case", "case_reference", inactiveDraft)).isZero();
+    }
+
+    private long createDraft() {
+        PCSCase caseData = PCSCase.builder()
+            .propertyAddress(AddressUK.builder()
+                .addressLine1("123 Baker Street")
+                .postTown("London")
+                .postCode("NW1 6XE")
+                .build())
+            .legislativeCountry(LegislativeCountry.ENGLAND)
+            .build();
+
+        CaseDetails caseDetails = ccdClient.createCase(caseData, solicitorToken);
+        assertThat(caseDetails.getState()).isEqualTo(AWAITING_SUBMISSION_TO_HMCTS.name());
+        return caseDetails.getId();
+    }
+
+    private void setLastModified(long caseReference, int daysAgo) {
+        int updated = jdbc.update(
+            """
+                update ccd.case_data
+                set last_modified = current_date - :daysAgo
+                where reference = :reference
+                """,
+            Map.of("reference", caseReference, "daysAgo", daysAgo)
+        );
+        assertThat(updated).isOne();
+    }
+
+    private void expireLocalTtl(long caseReference) {
+        int updated = jdbc.update(
+            "update ccd.case_data set resolved_ttl = current_date - 1 where reference = :reference",
+            Map.of("reference", caseReference)
+        );
+        assertThat(updated).isOne();
+    }
+
+    private void deleteCentralCasePointer(long caseReference) throws Exception {
+        try (Connection connection = cftlib().getConnection(Database.Datastore);
+             PreparedStatement statement = connection.prepareStatement("delete from case_data where reference = ?")) {
+            statement.setLong(1, caseReference);
+            assertThat(statement.executeUpdate()).isOne();
+        }
+    }
+
+    private int localCaseCount(String table, String referenceColumn, long caseReference) {
+        return localCaseValue(
+            "select count(*) from " + table + " where " + referenceColumn + " = :reference",
+            caseReference,
+            Integer.class
+        );
+    }
+
+    private <T> T localCaseValue(String sql, long caseReference, Class<T> resultType) {
+        return jdbc.queryForObject(sql, Map.of("reference", caseReference), resultType);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/SystemUserAccess.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/SystemUserAccess.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.pcs.ccd.accesscontrol;
+
+import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.SYSTEM_USER;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+import uk.gov.hmcts.ccd.sdk.api.HasAccessControl;
+import uk.gov.hmcts.ccd.sdk.api.HasRole;
+import uk.gov.hmcts.ccd.sdk.api.Permission;
+
+public class SystemUserAccess implements HasAccessControl {
+
+    @Override
+    public SetMultimap<HasRole, Permission> getGrants() {
+        SetMultimap<HasRole, Permission> grants = HashMultimap.create();
+        grants.putAll(SYSTEM_USER, Permission.CRU);
+        return grants;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/PCSCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/PCSCase.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.ccd.sdk.type.FlagLauncher;
 import uk.gov.hmcts.ccd.sdk.type.Flags;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.ccd.sdk.type.SearchCriteria;
+import uk.gov.hmcts.ccd.sdk.type.TTL;
 import uk.gov.hmcts.ccd.sdk.type.WaysToPay;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.CaseLinkingAccess;
@@ -31,6 +32,7 @@ import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.InternalCaseFlagAccess;
 import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.InternalTabAccess;
 import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.PartyVisibleTabAccess;
 import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.RasValidationAccess;
+import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.SystemUserAccess;
 import uk.gov.hmcts.reform.pcs.ccd.domain.dashboard.DashboardData;
 import uk.gov.hmcts.reform.pcs.ccd.domain.documentupload.DocumentUploadDetails;
 import uk.gov.hmcts.reform.pcs.ccd.domain.documentamend.DocumentAmendDetails;
@@ -727,6 +729,10 @@ public class PCSCase {
 
     @CCD
     private String dateIssuedString;
+
+    @JsonProperty("TTL")
+    @CCD(typeOverride = FieldType.TTL, access = {SystemUserAccess.class})
+    private TTL timeToLive;
 
     @CCD(label = "Which state are you moving the case to?",
         typeOverride = FixedList,

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/PCSCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/PCSCase.java
@@ -731,7 +731,7 @@ public class PCSCase {
     private String dateIssuedString;
 
     @JsonProperty("TTL")
-    @CCD(typeOverride = FieldType.TTL, access = {SystemUserAccess.class})
+    @CCD(access = {SystemUserAccess.class})
     private TTL timeToLive;
 
     @CCD(label = "Which state are you moving the case to?",

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/State.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/domain/State.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.DefendantAccess;
 import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.GlobalSearchAccess;
 import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.InternalCaseFlagAccess;
 import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.RasValidationAccess;
+import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.SystemUserAccess;
 
 /**
  * All possible PCS case states.
@@ -104,6 +105,11 @@ public enum State {
             GlobalSearchAccess.class},
         hint = "${caseTitleMarkdown}"
     )
-    BREATHING_SPACE
-}
+    BREATHING_SPACE,
 
+    @CCD(
+        label = "Pending Disposal",
+        access = {SystemUserAccess.class}
+    )
+    PendingDisposal
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/RetainAndDispose.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/RetainAndDispose.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.pcs.ccd.event;
+
+import static uk.gov.hmcts.ccd.sdk.RetainAndDisposePolicy.CONFIRM_DISPOSAL_EVENT_ID;
+import static uk.gov.hmcts.ccd.sdk.RetainAndDisposePolicy.DISPOSAL_EVENT_ID;
+import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.SYSTEM_USER;
+import static uk.gov.hmcts.reform.pcs.ccd.domain.State.AWAITING_SUBMISSION_TO_HMCTS;
+import static uk.gov.hmcts.reform.pcs.ccd.domain.State.PendingDisposal;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.ccd.sdk.api.Permission;
+import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
+import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
+import uk.gov.hmcts.reform.pcs.ccd.domain.State;
+
+@Component
+public class RetainAndDispose implements CCDConfig<PCSCase, State, UserRole> {
+
+    @Override
+    public void configure(ConfigBuilder<PCSCase, State, UserRole> configBuilder) {
+        configBuilder
+            .event(DISPOSAL_EVENT_ID)
+            .forStateTransition(AWAITING_SUBMISSION_TO_HMCTS, PendingDisposal)
+            .name("Mark draft for disposal")
+            .description("Move an inactive draft into its disposal state")
+            .grant(Permission.CRU, SYSTEM_USER);
+
+        configBuilder
+            .event(CONFIRM_DISPOSAL_EVENT_ID)
+            .forStateTransition(PendingDisposal, PendingDisposal)
+            .ttlIncrement(0)
+            .name("Confirm draft disposal")
+            .description("Set the disposal TTL after verifying the case is readable")
+            .grant(Permission.CRU, SYSTEM_USER);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/retention/PcsRetainAndDisposePolicy.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/retention/PcsRetainAndDisposePolicy.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.reform.pcs.ccd.retention;
+
+import static uk.gov.hmcts.reform.pcs.ccd.CaseType.getCaseType;
+import static uk.gov.hmcts.reform.pcs.ccd.domain.State.AWAITING_SUBMISSION_TO_HMCTS;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.RetainAndDisposePolicy;
+import uk.gov.hmcts.reform.pcs.ccd.repository.PcsCaseRepository;
+
+@Component
+@RequiredArgsConstructor
+public class PcsRetainAndDisposePolicy implements RetainAndDisposePolicy {
+
+    static final int DRAFT_INACTIVITY_DAYS = 30;
+
+    private final NamedParameterJdbcTemplate jdbc;
+    private final PcsCaseRepository pcsCaseRepository;
+
+    @Override
+    public Set<String> caseTypes() {
+        return Set.of(getCaseType());
+    }
+
+    @Override
+    public List<Long> findCandidatesForDisposal() {
+        return jdbc.queryForList(
+            """
+                select reference
+                from ccd.case_data
+                where case_type_id in (:caseTypeIds)
+                  and state = :draftState
+                  and last_modified::date + :inactivityDays < current_date
+                order by reference asc
+                """,
+            Map.of(
+                "caseTypeIds", caseTypes(),
+                "draftState", AWAITING_SUBMISSION_TO_HMCTS.name(),
+                "inactivityDays", DRAFT_INACTIVITY_DAYS
+            ),
+            Long.class
+        );
+    }
+
+    @Override
+    public void dispose(long caseReference) {
+        pcsCaseRepository.findByCaseReference(caseReference)
+            .ifPresent(pcsCaseRepository::delete);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -107,6 +107,15 @@ spring:
 flyway:
   noop:
     strategy: ${FLYWAY_NOOP_STRATEGY:false}
+ccd:
+  decentralised-runtime:
+    retain-and-dispose:
+      mode: ${CCD_RETAIN_AND_DISPOSE_MODE:off}
+      cron: ${CCD_RETAIN_AND_DISPOSE_CRON:0 0 2 * * *}
+      zone: ${CCD_RETAIN_AND_DISPOSE_ZONE:UTC}
+      system-user:
+        username: ${PCS_IDAM_SYSTEM_USERNAME:pcs-system-user@localhost}
+        password: ${PCS_IDAM_SYSTEM_PASSWORD:password}
 idam:
   api:
     url: ${IDAM_API_URL:http://localhost:5062}


### PR DESCRIPTION
Adds disposal for draft cases inactive for more than 30 days.

  - Identifies inactive draft cases.
  - SDK scheduled task will move them to PendingDisposal.
  - Sets the CCD disposal TTL to trigger central disposal
  - Deletes locally held PCS case data after central disposal.

See [sdk documentation](https://github.com/hmcts/dtsse-ccd-config-generator/blob/master/docs/retain-and-dispose.md) for more details including dry runs & live operations.