### PR TITLE
HDPI-7878: add additional postcodes for nightly global search

### DIFF
--- a/src/e2eTest/package.json
+++ b/src/e2eTest/package.json
@@ -6,7 +6,7 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "test:pr": "yarn playwright install && yarn playwright test --project chrome --grep '@PR'; EXIT_CODE=$?; allure generate -o ../../e2e-output --clean; tsx ./config/clean-attachments.config.ts; exit $EXIT_CODE",
+    "test:pr": "yarn playwright install && yarn playwright test --project chrome --grep '@globalSearch'; EXIT_CODE=$?; allure generate -o ../../e2e-output --clean; tsx ./config/clean-attachments.config.ts; exit $EXIT_CODE",
     "test:regression": "yarn playwright install && yarn playwright test --project chrome --grep '@regression'; EXIT_CODE=$?; allure generate -o ../../e2e-output --clean; tsx ./config/clean-attachments.config.ts; exit $EXIT_CODE",
     "test:makeAClaim": "yarn playwright install && yarn playwright test --project chrome --grep '@MAC'; EXIT_CODE=$?; allure generate -o ../../e2e-output --clean; tsx ./config/clean-attachments.config.ts; exit $EXIT_CODE",
     "test:commonComponent": "yarn playwright install && yarn playwright test --project chrome --grep '@CC'; EXIT_CODE=$?; allure generate -o ../../e2e-output --clean; tsx ./config/clean-attachments.config.ts; exit $EXIT_CODE",

--- a/src/e2eTest/package.json
+++ b/src/e2eTest/package.json
@@ -6,7 +6,7 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "test:pr": "yarn playwright install && yarn playwright test --project chrome --grep '@globalSearch'; EXIT_CODE=$?; allure generate -o ../../e2e-output --clean; tsx ./config/clean-attachments.config.ts; exit $EXIT_CODE",
+    "test:pr": "yarn playwright install && yarn playwright test --project chrome --grep '@PR'; EXIT_CODE=$?; allure generate -o ../../e2e-output --clean; tsx ./config/clean-attachments.config.ts; exit $EXIT_CODE",
     "test:regression": "yarn playwright install && yarn playwright test --project chrome --grep '@regression'; EXIT_CODE=$?; allure generate -o ../../e2e-output --clean; tsx ./config/clean-attachments.config.ts; exit $EXIT_CODE",
     "test:makeAClaim": "yarn playwright install && yarn playwright test --project chrome --grep '@MAC'; EXIT_CODE=$?; allure generate -o ../../e2e-output --clean; tsx ./config/clean-attachments.config.ts; exit $EXIT_CODE",
     "test:commonComponent": "yarn playwright install && yarn playwright test --project chrome --grep '@CC'; EXIT_CODE=$?; allure generate -o ../../e2e-output --clean; tsx ./config/clean-attachments.config.ts; exit $EXIT_CODE",

--- a/src/e2eTest/utils/common/string.utils.ts
+++ b/src/e2eTest/utils/common/string.utils.ts
@@ -154,6 +154,6 @@ export function formatCaseStateText(input: string): string {
 
 export function randomPostcode()
 {
-  const postcodes = ['M1 1AE', 'B1 1AA', 'CF10 1EP'];
+  const postcodes = ['W3 6RS', 'W3 6RT', 'CF61 1ZH'];
   return postcodes[Math.floor(Math.random() * postcodes.length)];
 }

--- a/src/e2eTest/utils/common/string.utils.ts
+++ b/src/e2eTest/utils/common/string.utils.ts
@@ -154,6 +154,6 @@ export function formatCaseStateText(input: string): string {
 
 export function randomPostcode()
 {
-  const postcodes = ['W3 6RS', 'W3 6RT', 'CF61 1ZH'];
+  const postcodes = ['M1 1AE', 'B1 1AA', 'CF10 1EP'];
   return postcodes[Math.floor(Math.random() * postcodes.length)];
 }

--- a/src/main/resources/db/testdata/V001.2__add_additional_postcodes.sql
+++ b/src/main/resources/db/testdata/V001.2__add_additional_postcodes.sql
@@ -1,0 +1,15 @@
+-- HDPI-7878: additional postcodes/courts for nightly e2e, avoiding the stale global_search index orphans.
+
+INSERT INTO postcode_court_mapping (postcode, epims_id, legislative_country, effective_from, effective_to, audit)
+VALUES
+    ('M1 1AE', 701411, 'England', CURRENT_DATE, NULL, '{"created_by": "admin", "change_reason": "HDPI-7878"}'::jsonb),
+    ('B1 1AA', 231596, 'England', CURRENT_DATE, NULL, '{"created_by": "admin", "change_reason": "HDPI-7878"}'::jsonb),
+    ('CF10 1EP', 234850, 'Wales', CURRENT_DATE, NULL, '{"created_by": "admin", "change_reason": "HDPI-7878"}'::jsonb)
+ON CONFLICT (postcode, epims_id) DO NOTHING;
+
+INSERT INTO eligibility_whitelisted_epim (epims_id, eligible_from, audit)
+VALUES
+    (701411, CURRENT_DATE, '{"created_by": "admin", "change_reason": "HDPI-7878"}'::jsonb),
+    (231596, CURRENT_DATE, '{"created_by": "admin", "change_reason": "HDPI-7878"}'::jsonb),
+    (234850, CURRENT_DATE, '{"created_by": "admin", "change_reason": "HDPI-7878"}'::jsonb)
+ON CONFLICT (epims_id) DO NOTHING;


### PR DESCRIPTION
### Jira link

HDPI-7878

### Change description

Adds M1 1AE (701411 Manchester), B1 1AA (231596 Birmingham) and CF10 1EP (234850 Cardiff) with their court whitelisting, so nightly global search tests can use postcodes clear of the stale global_search index orphans.
### Testing done

PR Pipeline added with correct label 
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/48f55735-126f-4e8f-ba57-6c9ec50d161f" />

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
