### PR TITLE
HDPI-6585: Schedule Camunda task creation via db-scheduler

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/camunda/CamundaRequestTaskComponent.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/camunda/CamundaRequestTaskComponent.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.reform.pcs.camunda;
+
+import com.github.kagkarlsson.scheduler.task.CompletionHandler;
+import com.github.kagkarlsson.scheduler.task.FailureHandler;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
+import com.github.kagkarlsson.scheduler.task.helper.CustomTask;
+import com.github.kagkarlsson.scheduler.task.helper.Tasks;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+public class CamundaRequestTaskComponent {
+
+    private static final String CAMUNDA_REQUEST_TASK_NAME = "camunda-request-task";
+
+    public static final TaskDescriptor<CamundaRequestTaskData> CAMUNDA_REQUEST_TASK_DESCRIPTOR =
+        TaskDescriptor.of(CAMUNDA_REQUEST_TASK_NAME, CamundaRequestTaskData.class);
+
+    private final CamundaService camundaService;
+    private final int maxRetries;
+    private final Duration backoffDelay;
+
+    public CamundaRequestTaskComponent(CamundaService camundaService,
+                                       @Value("${camunda.request.max-retries}") int maxRetries,
+                                       @Value("${camunda.request.backoff-delay-duration}") Duration backoffDelay) {
+
+        this.camundaService = camundaService;
+        this.maxRetries = maxRetries;
+        this.backoffDelay = backoffDelay;
+    }
+
+    @Bean
+    public CustomTask<CamundaRequestTaskData> camundaRequestTask() {
+        return Tasks.custom(CAMUNDA_REQUEST_TASK_DESCRIPTOR)
+            .onFailure(
+                FailureHandler.<CamundaRequestTaskData>maxRetries(maxRetries)
+                    .withBackoff(backoffDelay)
+                    .thenRemove(complete ->
+                                    log.warn(
+                                        "Execution has failed {} times. Giving up.",
+                                        complete.getExecution().consecutiveFailures
+                                    )
+            ))
+            .execute((taskInstance, executionContext) -> {
+                CamundaRequestTaskData taskData = taskInstance.getData();
+                log.debug("Executing Camunda request task for {}", taskData);
+                try {
+                    camundaService.handleRequest(taskData);
+                    return new CompletionHandler.OnCompleteRemove<>();
+                } catch (Exception e) {
+                    log.error("Failed to create Camunda request for: {}. Attempt {}/{}",
+                              taskData, executionContext.getExecution().consecutiveFailures + 1, maxRetries, e);
+                    throw e;
+                }
+            });
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/camunda/CamundaRequestTaskData.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/camunda/CamundaRequestTaskData.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.pcs.camunda;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class CamundaRequestTaskData {
+
+    enum Action {
+        CREATE,
+        CANCEL
+    }
+
+    private final Action action;
+
+    private final long caseReference;
+
+    private final TaskType taskType;
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/camunda/CamundaService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/camunda/CamundaService.java
@@ -1,19 +1,24 @@
 package uk.gov.hmcts.reform.pcs.camunda;
 
+import com.github.kagkarlsson.scheduler.SchedulerClient;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.pcs.camunda.CamundaRequestTaskData.Action;
 import uk.gov.hmcts.reform.pcs.ccd.CaseType;
 import uk.gov.hmcts.reform.pcs.service.FeatureFlag;
 import uk.gov.hmcts.reform.pcs.service.FeatureToggleService;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static uk.gov.hmcts.reform.pcs.camunda.CamundaRequestTaskComponent.CAMUNDA_REQUEST_TASK_DESCRIPTOR;
 
 @Slf4j
 @AllArgsConstructor
@@ -22,6 +27,7 @@ public class CamundaService {
 
     private final CamundaApi camundaApi;
     private final AuthTokenGenerator authTokenGenerator;
+    private final SchedulerClient schedulerClient;
     private final FeatureToggleService featureToggleService;
 
     private static final String CREATE = "createTaskMessage";
@@ -31,7 +37,37 @@ public class CamundaService {
     private static final String CANCELLATION_PROCESS = "CASE_EVENT_CANCELLATION";
     private final Clock utcClock;
 
-    public void createTask(Long caseId, TaskType taskType) {
+    public void createTask(long caseId, TaskType taskType) {
+        scheduleCamundaRequest(Action.CREATE, caseId, taskType);
+
+    }
+
+    public void cancelTask(long caseId, TaskType taskType) {
+        scheduleCamundaRequest(Action.CANCEL, caseId, taskType);
+    }
+
+    void handleRequest(CamundaRequestTaskData taskData) {
+        switch (taskData.getAction()) {
+            case CREATE -> requestTaskCreation(taskData.getCaseReference(), taskData.getTaskType());
+            case CANCEL -> requestTaskCancellation(taskData.getCaseReference(), taskData.getTaskType());
+        }
+    }
+
+    private void scheduleCamundaRequest(Action action, long caseId, TaskType taskType) {
+        CamundaRequestTaskData taskData = CamundaRequestTaskData.builder()
+            .action(action)
+            .caseReference(caseId)
+            .taskType(taskType)
+            .build();
+
+        schedulerClient.scheduleIfNotExists(
+            CAMUNDA_REQUEST_TASK_DESCRIPTOR
+                .instance(UUID.randomUUID().toString())
+                .data(taskData)
+                .scheduledTo(Instant.now(utcClock)));
+    }
+
+    private void requestTaskCreation(Long caseId, TaskType taskType) {
         if (!featureToggleService.isEnabled(FeatureFlag.CASEWORKER_WA)) {
             log.info("Skipped creating task for {}", caseId);
             return;
@@ -64,7 +100,7 @@ public class CamundaService {
         sendCamundaRequest(request, caseId);
     }
 
-    public void cancelTask(Long caseId, TaskType taskType) {
+    private void requestTaskCancellation(Long caseId, TaskType taskType) {
         if (!featureToggleService.isEnabled(FeatureFlag.CASEWORKER_WA)) {
             log.info("Skipped cancelling task for {}", caseId);
             return;
@@ -108,4 +144,5 @@ public class CamundaService {
     private DmnValue<Boolean> dmnBooleanValue(Boolean value) {
         return DmnValue.<Boolean>builder().value(value).type("Boolean").build();
     }
+
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -344,6 +344,9 @@ caseApi:
 
 camunda:
   url: ${CAMUNDA_BASE_URL:http://camunda-local-bpm/engine-rest}
+  request:
+    max-retries: ${CAMUNDA_REQUEST_TASK_MAX_RETRIES:3}
+    backoff-delay-duration: ${CAMUNDA_REQUEST_TASK_BACKOFF_DURATION:20m}
 
 shutter:
   service: ${SHUTTER_SERVICE:false}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/camunda/CamundaRequestTaskComponentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/camunda/CamundaRequestTaskComponentTest.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.pcs.camunda;
+
+import com.github.kagkarlsson.scheduler.task.CompletionHandler;
+import com.github.kagkarlsson.scheduler.task.Execution;
+import com.github.kagkarlsson.scheduler.task.ExecutionContext;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CamundaRequestTaskComponentTest {
+
+    @Mock
+    private CamundaService camundaService;
+    @Mock
+    private TaskInstance<CamundaRequestTaskData> taskInstance;
+    @Mock
+    private ExecutionContext executionContext;
+
+    private CamundaRequestTaskComponent underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new CamundaRequestTaskComponent(camundaService, 3, Duration.of(2, MINUTES));
+    }
+
+    @Test
+    void shouldCallCamundaService() {
+        // Given
+        CamundaRequestTaskData taskData = mock(CamundaRequestTaskData.class);
+        when(taskInstance.getData()).thenReturn(taskData);
+
+        // When
+        underTest.camundaRequestTask().execute(taskInstance, executionContext);
+
+        // Then
+        verify(camundaService).handleRequest(taskData);
+    }
+
+    @Test
+    void shouldRemoveTaskAfterSuccessfulExecution() {
+        // When
+        CompletionHandler<CamundaRequestTaskData> completionHandler
+            = underTest.camundaRequestTask().execute(taskInstance, executionContext);
+
+        // Then
+        assertThat(completionHandler).isInstanceOf(CompletionHandler.OnCompleteRemove.class);
+    }
+
+    @Test
+    void shouldPropagateExceptionForFailedExecution() {
+        // Given
+        CamundaRequestTaskData taskData = mock(CamundaRequestTaskData.class);
+        when(taskInstance.getData()).thenReturn(taskData);
+
+        Execution execution = mock(Execution.class);
+        when(executionContext.getExecution()).thenReturn(execution);
+
+        RuntimeException expectedException = mock(RuntimeException.class);
+        doThrow(expectedException).when(camundaService).handleRequest(taskData);
+
+        // When
+        Throwable throwable = catchThrowable(() -> underTest.camundaRequestTask().execute(
+            taskInstance,
+            executionContext
+        ));
+
+        // Then
+        assertThat(throwable).isEqualTo(expectedException);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/camunda/CamundaServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/camunda/CamundaServiceTest.java
@@ -1,12 +1,17 @@
 package uk.gov.hmcts.reform.pcs.camunda;
 
+import com.github.kagkarlsson.scheduler.SchedulerClient;
+import com.github.kagkarlsson.scheduler.task.SchedulableInstance;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.pcs.camunda.CamundaRequestTaskData.Action;
 import uk.gov.hmcts.reform.pcs.service.FeatureFlag;
 import uk.gov.hmcts.reform.pcs.service.FeatureToggleService;
 
@@ -19,6 +24,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -27,6 +33,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class CamundaServiceTest {
 
+    private static final long CASE_REFERENCE = 1234L;
+
     @Mock
     private CamundaApi camundaApi;
 
@@ -34,10 +42,16 @@ public class CamundaServiceTest {
     private AuthTokenGenerator authTokenGenerator;
 
     @Mock
+    private SchedulerClient schedulerClient;
+
+    @Mock(strictness = LENIENT)
     private Clock utcClock;
 
     @Mock
     private FeatureToggleService featureToggleService;
+
+    @Captor
+    private ArgumentCaptor<SchedulableInstance<CamundaRequestTaskData>> schedulableInstanceCaptor;
 
     @InjectMocks
     private CamundaService camundaService;
@@ -45,19 +59,56 @@ public class CamundaServiceTest {
     private static final LocalDateTime TEST_UTC_DATE_TIME = LocalDate.of(2025, 8, 27)
         .atTime(12, 51, 19);
 
+    @BeforeEach
+    void setUp() {
+        when(utcClock.instant()).thenReturn(TEST_UTC_DATE_TIME.toInstant(ZoneOffset.UTC));
+        when(utcClock.getZone()).thenReturn(ZoneOffset.UTC);
+    }
+
+    @Test
+    void shouldScheduleCamundaRequestTask() {
+        // When
+        camundaService.createTask(CASE_REFERENCE, TaskType.NEW_CLAIM_CREATE_NEW_HEARING);
+
+        // Then
+        verify(schedulerClient).scheduleIfNotExists(schedulableInstanceCaptor.capture());
+
+        SchedulableInstance<CamundaRequestTaskData> schedulableInstance = schedulableInstanceCaptor.getValue();
+
+        CamundaRequestTaskData taskData = schedulableInstance.getTaskInstance().getData();
+        assertThat(taskData.getAction()).isEqualTo(Action.CREATE);
+        assertThat(taskData.getCaseReference()).isEqualTo(CASE_REFERENCE);
+        assertThat(taskData.getTaskType()).isEqualTo(TaskType.NEW_CLAIM_CREATE_NEW_HEARING);
+    }
+
+    @Test
+    void shouldScheduleCamundaCancelTask() {
+        // When
+        camundaService.cancelTask(CASE_REFERENCE, TaskType.NEW_CLAIM_CREATE_NEW_HEARING);
+
+        // Then
+        verify(schedulerClient).scheduleIfNotExists(schedulableInstanceCaptor.capture());
+
+        SchedulableInstance<CamundaRequestTaskData> schedulableInstance = schedulableInstanceCaptor.getValue();
+
+        CamundaRequestTaskData taskData = schedulableInstance.getTaskInstance().getData();
+        assertThat(taskData.getAction()).isEqualTo(Action.CANCEL);
+        assertThat(taskData.getCaseReference()).isEqualTo(CASE_REFERENCE);
+        assertThat(taskData.getTaskType()).isEqualTo(TaskType.NEW_CLAIM_CREATE_NEW_HEARING);
+    }
+
     @Test
     void shouldSendCreateTaskTestToCamunda() {
         // Given
-        final Long caseId = 1234L;
         final TaskType taskType = TaskType.NEW_CLAIM_CREATE_NEW_HEARING;
 
         when(authTokenGenerator.generate()).thenReturn("authToken");
-        when(utcClock.instant()).thenReturn(TEST_UTC_DATE_TIME.toInstant(ZoneOffset.UTC));
-        when(utcClock.getZone()).thenReturn(ZoneOffset.UTC);
         when(featureToggleService.isEnabled(FeatureFlag.CASEWORKER_WA)).thenReturn(true);
 
+        CamundaRequestTaskData taskData = buildTaskDataForCreate(taskType);
+
         // When
-        camundaService.createTask(caseId, taskType);
+        camundaService.handleRequest(taskData);
 
         // Then
         ArgumentCaptor<SendMessageRequest> requestArgumentCaptor = ArgumentCaptor.forClass(SendMessageRequest.class);
@@ -83,7 +134,7 @@ public class CamundaServiceTest {
         assertThat(processVariables.get("name").getType()).isEqualTo("String");
         assertThat(processVariables.get("taskId").getValue()).isEqualTo("NewClaimCreateNewHearing");
         assertThat(processVariables.get("taskId").getType()).isEqualTo("String");
-        assertThat(processVariables.get("caseId").getValue()).isEqualTo(caseId.toString());
+        assertThat(processVariables.get("caseId").getValue()).isEqualTo(Long.toString(CASE_REFERENCE));
         assertThat(processVariables.get("caseId").getType()).isEqualTo("String");
         assertThat(processVariables.get("delayUntil").getValue()).isEqualTo("2025-08-27T12:51:19");
         assertThat(processVariables.get("delayUntil").getType()).isEqualTo("String");
@@ -96,13 +147,14 @@ public class CamundaServiceTest {
     @Test
     void shouldSkipCreatingTaskIfWaIsNotEnabled() {
         // Given
-        final Long caseId = 1234L;
         final TaskType taskType = TaskType.NEW_CLAIM_CREATE_NEW_HEARING;
 
         when(featureToggleService.isEnabled(FeatureFlag.CASEWORKER_WA)).thenReturn(false);
 
+        CamundaRequestTaskData taskData = buildTaskDataForCreate(taskType);
+
         // When
-        camundaService.createTask(caseId, taskType);
+        camundaService.handleRequest(taskData);
 
         // Then
         verify(camundaApi, never()).sendMessage(any(), any());
@@ -111,16 +163,23 @@ public class CamundaServiceTest {
     @Test
     void shouldHandleFailedRequestToCamunda() {
         // Given
-        final Long caseId = 1234L;
         final TaskType taskType = TaskType.NEW_CLAIM_CREATE_NEW_HEARING;
 
         when(authTokenGenerator.generate()).thenReturn("authToken");
-        when(utcClock.instant()).thenReturn(TEST_UTC_DATE_TIME.toInstant(ZoneOffset.UTC));
-        when(utcClock.getZone()).thenReturn(ZoneOffset.UTC);
         when(featureToggleService.isEnabled(FeatureFlag.CASEWORKER_WA)).thenReturn(true);
         doThrow(new RuntimeException()).when(camundaApi).sendMessage(any(), any());
 
+        CamundaRequestTaskData taskData = buildTaskDataForCreate(taskType);
+
         // When
-        camundaService.createTask(caseId, taskType);
+        camundaService.handleRequest(taskData);
+    }
+
+    private static CamundaRequestTaskData buildTaskDataForCreate(TaskType taskType) {
+        return CamundaRequestTaskData.builder()
+            .action(Action.CREATE)
+            .caseReference(CASE_REFERENCE)
+            .taskType(taskType)
+            .build();
     }
 }


### PR DESCRIPTION
### Jira link

See [HDPI-6585](https://tools.hmcts.net/jira/browse/HDPI-6585)

### Change description

Schedule Camunda task creation via db-scheduler to make it transactional and asynchronous

### Testing done

Unit tests updated and manual task creation tests performed.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
