### PR TITLE
Skip CCD role creation in prod during high level data setup

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/config/HighLevelDataSetupApp.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/config/HighLevelDataSetupApp.java
@@ -53,6 +53,11 @@ public class HighLevelDataSetupApp extends DataLoaderToDefinitionStore {
 
     @Override
     public void addCcdRoles() {
+        if (environment == CcdEnvironment.PROD) {
+            // CCD roles are managed centrally in prod; only the definition is imported here.
+            BeftaUtils.defaultLog("PROD environment - skipping CCD role creation");
+            return;
+        }
         for (CcdRoleConfig roleConfig : CCD_ROLES) {
             try {
                 logger.info("\n\nAdding CCD Role {}.", roleConfig);


### PR DESCRIPTION
## What

Early-return from `addCcdRoles()` in `HighLevelDataSetupApp` when the environment is `PROD`, so role creation is skipped in prod while the definition import still runs.

## Why

The prod High Level Data Setup stage runs the full BEFTA data load, which calls `addCcdRoles()` → `addCcdRole()` → `asAutoTestImporter()`. In prod there is no auto-test importer user, so token generation fails:

```
Adding CCD Role CcdRoleConfig(role=caseworker-pcs, securityClassification=PUBLIC).
Generating token for the user: dummy-value   <- fails
```

CCD roles are managed centrally in prod, so role creation should not run there — only the definition import.

## Approach

Gate on `CcdEnvironment.PROD` using the existing `environment` field, mirroring:
- PCS's own `createRoleAssignments()` no-op, and
- civil's in-Java environment gate (the only established precedent for "skip setup steps but still import the definition in prod").

Unlike the Jenkins `skipHighLevelDataSetupProd` flag — which skips the **entire** HLDS stage (import + roles) — this leaves `importDefinitions()` untouched, so the prod definition still imports (which is the intent, now that the prod importer credential is provisioned).