### PR TITLE
Enable prod definition import: map importer secrets + drop skip-prod flag

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -23,6 +23,8 @@ def secrets = [
     secret('pcs-prd-admin-password', 'PCS_PRD_ADMIN_PASSWORD'),
     secret('idam-expired-user-token', 'IDAM_EXPIRED_USER_TOKEN'),
     secret('s2s-expired-service-token', 'S2S_EXPIRED_TOKEN'),
+    secret('definition-importer-username', 'DEFINITION_IMPORTER_USERNAME'),
+    secret('definition-importer-password', 'DEFINITION_IMPORTER_PASSWORD'),
   ]
 ]
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -89,7 +89,7 @@ withPipeline(type, product, component) {
       AppPipelineDsl.PactRoles.CONSUMER,
       AppPipelineDsl.PactRoles.CONSUMER_DEPLOY_CHECK
     ])
-    enableHighLevelDataSetup("", true)
+    enableHighLevelDataSetup()
     setAatEnvVars()
     // The e2e journeys all create cases, which is blocked while the service is shuttered.
     if (!shutterService) {


### PR DESCRIPTION
## What

Two changes to make the prod High Level Data Setup stage actually import the CCD definition:

1. **Map the importer secrets** — load `definition-importer-username` / `definition-importer-password` from the `pcs-${env}` vault and map them to `DEFINITION_IMPORTER_USERNAME` / `DEFINITION_IMPORTER_PASSWORD`.
2. **Drop the skip-prod flag** — change `onMaster`'s `enableHighLevelDataSetup("", true)` back to `enableHighLevelDataSetup()`.
