### PR TITLE
Stop CASE_TYPE_SUFFIX leaking into the prod definition import

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -127,6 +127,9 @@ withPipeline(type, product, component) {
         env.SHUTTER_SERVICE = true
         env.DATA_STORE_URL_BASE="http://ccd-data-store-api-prod.service.core-compute-prod.internal"
         env.CASE_API_URL = "https://pcs-api.prod.platform.hmcts.net"
+        // The AAT smoketest hook sets CASE_TYPE_SUFFIX=staging and never clears it. env is
+        // build-scoped, so without this reset prod imports CCD_Definition_PCS-staging_prod.xlsx.
+        env.CASE_TYPE_SUFFIX=""
       } else {
         env.DEFINITION_STORE_URL_BASE = "http://ccd-definition-store-api-aat.service.core-compute-aat.internal"
         env.DATA_STORE_URL_BASE="http://ccd-data-store-api-aat.service.core-compute-aat.internal"

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CaseType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/CaseType.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.EnumSet;
 
 import static java.lang.System.getenv;
-import static java.util.Optional.ofNullable;
 import static uk.gov.hmcts.reform.pcs.ccd.ShowConditions.NEVER_SHOW;
 import static uk.gov.hmcts.reform.pcs.ccd.domain.State.AWAITING_SUBMISSION_TO_HMCTS;
 
@@ -74,9 +73,11 @@ public class CaseType implements CCDConfig<PCSCase, State, AccessProfile> {
     }
 
     private static String withSuffix(String base, String separator) {
-        return ofNullable(getenv().get("CASE_TYPE_SUFFIX"))
-            .map(changeId -> base + separator + changeId)
-            .orElse(base);
+        return withSuffix(base, separator, getenv().get("CASE_TYPE_SUFFIX"));
+    }
+
+    static String withSuffix(String base, String separator, String suffix) {
+        return isSuffixed(suffix) ? base + separator + suffix : base;
     }
 
     private static AccessProfile[] nonInternalHistoryRoles() {

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/CaseTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/CaseTypeTest.java
@@ -61,6 +61,23 @@ class CaseTypeTest {
     }
 
     @Test
+    void shouldNotAppendSeparatorWhenSuffixAbsentOrBlank() {
+        // The pipeline clears CASE_TYPE_SUFFIX with "" rather than unsetting it, so a blank
+        // suffix must yield the canonical name - not a trailing separator (PCS-, "Possession ").
+        assertThat(CaseType.withSuffix("PCS", "-", null)).isEqualTo("PCS");
+        assertThat(CaseType.withSuffix("PCS", "-", "")).isEqualTo("PCS");
+        assertThat(CaseType.withSuffix("PCS", "-", "   ")).isEqualTo("PCS");
+        assertThat(CaseType.withSuffix("Possession", " ", "")).isEqualTo("Possession");
+    }
+
+    @Test
+    void shouldAppendSuffixWhenSuffixSet() {
+        assertThat(CaseType.withSuffix("PCS", "-", "staging")).isEqualTo("PCS-staging");
+        assertThat(CaseType.withSuffix("PCS", "-", "1234")).isEqualTo("PCS-1234");
+        assertThat(CaseType.withSuffix("Possession", " ", "1234")).isEqualTo("Possession 1234");
+    }
+
+    @Test
     void shouldGetJurisdictionId() {
         // When
         String jurisdictionId = CaseType.getJurisdictionId();


### PR DESCRIPTION
## Problem

The prod High Level Data Setup stage imports a **staging-suffixed case type into prod**:

```
Importing build/definitions/CCD_Definition_PCS-staging_prod.xlsx...
```

## Cause

`before('smoketest:aat')` sets the suffix and never clears it:

```groovy
before('smoketest:aat') {
  env.CASE_TYPE_SUFFIX="staging"
  env.CCD_ENABLED = "true"
}
```

`env` is build-scoped and both HLDS passes run in the same build (AAT at `withPipeline.groovy:199`, prod at `:242`). The AAT branch of `before('highleveldatasetup')` does reset it to `""` at line 137, but `smoketest:aat` runs *after* that and re-sets it. The prod branch never touched it, so the prod pass inherited `staging`, and `HighLevelDataSetupApp.getAllDefinitionFilesToLoadAt()` builds the filename from `CaseType.getCaseType()`.

## Changes

**1. Reset the suffix in the prod branch** of `before('highleveldatasetup')`.

**2. Make `withSuffix` agree with `isSuffixed` on blank input.** The pipeline clears the suffix with `""` rather than unsetting it, but `withSuffix` used `ofNullable`, so `""` yielded `PCS-` and `"Possession "` — while `isSuffixed` already treated blank as unsuffixed. Without this, the reset in change 1 would have produced `CCD_Definition_PCS-_prod.xlsx`. Extracted a package-private overload taking the suffix so both paths share one definition:

```java
static String withSuffix(String base, String separator, String suffix) {
    return isSuffixed(suffix) ? base + separator + suffix : base;
}
```

**3. Tests** covering blank/null/whitespace and the populated case for both separators.

## Verification

`./gradlew test --tests '*CaseTypeTest*'` and `checkstyleMain checkstyleTest` both pass locally. The pipeline behaviour itself can only be confirmed on a master build.

## Still needs a decision

This makes prod import `CCD_Definition_PCS_prod.xlsx` instead of the staging variant. Worth confirming that's the intent — the canonical `PCS` case type is presumably what prod should hold, but if `PCS` has never been imported to prod's definition store this will be a first-time create rather than an update.

Note `getAllDefinitionFilesToLoadAt()` only adds the extra `-staging` file for `aat`, so prod was previously importing the staging definition as its *only* file, having generated it under a prod filename.

## Related

hmcts/pcs-shared-infrastructure#31 fixes the 401 in the same stage (the importer credential was copied from a superseded civil-prod secret holding `dummy-value`). Both need to land for the prod import to work — this PR alone will still fail auth.