### PR TITLE
HDPI-8003: exclude Helm charts from Fortify scan payload

### DIFF
--- a/config/fortify-client.properties
+++ b/config/fortify-client.properties
@@ -1,1 +1,7 @@
 fortify.client.releaseId=168509
+# Exclude Helm chart templates from the scan payload: they are deployment configuration,
+# not application source, and values files trigger config-class false positives
+# (HDPI-8003: "Hardcoded Password" flagged on postgresSecret, which is a Kubernetes
+# secret NAME consumed by the CCD preview chart, not a credential).
+# NOTE: this property REPLACES the library default, so the default exclusions are restated here.
+fortify.exclude.pattern=*.jar|*.zip|*.tar|*.key|*.lock|/build|/.gradle|/.git|/node_modules|/test|/dist|/functionalTest|/integrationTest|/charts


### PR DESCRIPTION
### What
Adds `/charts` to the Fortify exclude pattern in `config/fortify-client.properties` (restating the library defaults, since this property replaces rather than extends them).

### Why
The nightly Fortify gate fails on High 45702143 "Password Management: Hardcoded Password" at `charts/pcs-api/values.ccd.preview.template.yaml:9`. That line is `postgresSecret: postgres` - the **name** of the Kubernetes secret consumed by the CCD preview chart (standard CNP preview template), not a credential. Helm charts are deployment configuration, not application source; scanning them produces config-class false positives.

### Validation
Next nightly run: the finding drops out of the scan payload and the Fortify gate passes. The existing portal finding (release 168509) auto-resolves as removed on the next scan.

### Ticket
HDPI-8003 (full analysis in the ticket comments).
