### PR TITLE
HDPI-7212: Fix hardcoded case type in makeAnApplication functional tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcs/functional/tests/MakeAnApplicationEventCallbackTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcs/functional/tests/MakeAnApplicationEventCallbackTests.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInstance;
+import uk.gov.hmcts.reform.pcs.ccd.CaseType;
 import uk.gov.hmcts.reform.pcs.functional.config.TestConstants;
 import uk.gov.hmcts.reform.pcs.functional.steps.ApiSteps;
 import uk.gov.hmcts.reform.pcs.functional.steps.BaseApi;
@@ -25,6 +26,8 @@ import uk.gov.hmcts.reform.pcs.functional.testutils.PcsIdamTokenClient;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class MakeAnApplicationEventCallbackTests extends BaseApi {
+
+    private static final String caseType = CaseType.getCaseType();
 
     @Steps
     ApiSteps apiSteps;
@@ -46,6 +49,7 @@ public class MakeAnApplicationEventCallbackTests extends BaseApi {
         String makeApplicationRequestBody = PayloadLoader.load(
             "/payloads/makeAnApplication-startEventCallbackRequest.json",
             Map.of(
+                "caseTypeId", caseType,
                 "caseId", caseReference
             )
         );
@@ -71,6 +75,7 @@ public class MakeAnApplicationEventCallbackTests extends BaseApi {
         String submitApplicationRequestBody = PayloadLoader.load(
             "/payloads/makeAnApplication-submitEventCallbackRequest.json",
             Map.of(
+                "caseTypeId", caseType,
                 "caseId", String.valueOf(caseReference),
                 "internalCaseId", decodedCaseId
             )

--- a/src/functionalTest/resources/payloads/makeAnApplication-startEventCallbackRequest.json
+++ b/src/functionalTest/resources/payloads/makeAnApplication-startEventCallbackRequest.json
@@ -1,7 +1,7 @@
 {"event_id": "makeAnApplication",
   "case_details": {
     "id": "${caseId}",
-    "case_type_id": "PCS",
+    "case_type_id": "${caseTypeId}",
     "state": "PENDING_CASE_ISSUED",
     "security_classification": "PUBLIC",
     "data": {

--- a/src/functionalTest/resources/payloads/makeAnApplication-submitEventCallbackRequest.json
+++ b/src/functionalTest/resources/payloads/makeAnApplication-submitEventCallbackRequest.json
@@ -12,7 +12,7 @@
     "jurisdiction": "PCS",
     "state": "PENDING_CASE_ISSUED",
     "version": 2,
-    "case_type_id": "PCS",
+    "case_type_id": "${caseTypeId}",
     "security_classification": "PUBLIC",
     "case_data": {
       "featureFlags": {


### PR DESCRIPTION


### Jira link


See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

 Change: MakeAnApplicationEventCallbackTests payloads hardcoded "case_type_id": "PCS". Every other functional payload templates ${caseTypeId} from CaseType.getCaseType(). Switched these two to match.


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
