### PR TITLE
Set upload_timestamp on every document surfaced in Case File View

### DIFF
--- a/charts/pcs-api/values.ccd.preview.template.yaml
+++ b/charts/pcs-api/values.ccd.preview.template.yaml
@@ -111,6 +111,9 @@ ccd:
         ELASTIC_SEARCH_HOSTS: "http://{{ .Release.Name }}-es-master:9200"
         CCD_S2S_AUTHORISED_SERVICES_CASE_USER_ROLES: "aac_manage_case_assignment,pcs_api,pcs_frontend"
         CASE_DOCUMENT_AM_URL: http://${SERVICE_NAME}-cdam
+        # Case File View 1.1. Harmless for PCS (we set upload_timestamp ourselves on the read path)
+        # but keeps preview consistent with the AAT/prod whitelist we will request.
+        UPLOAD_TIMESTAMP_FEATURED_CASE_TYPES: "PCS"
       ingressHost: ccd-data-store-api-${SERVICE_FQDN}
       autoscaling:
         enabled: false

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/ClaimView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/ClaimView.java
@@ -149,6 +149,7 @@ public class ClaimView {
                     .filename(documentEntity.getFileName())
                     .binaryUrl(documentEntity.getBinaryUrl())
                     .categoryId(documentEntity.getCategoryId())
+                    .uploadTimestamp(DocumentViewUtil.uploadTimestamp(documentEntity))
                     .build()
             ).build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/DocumentViewUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/DocumentViewUtil.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.pcs.ccd.view;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.pcs.ccd.entity.DocumentEntity;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DocumentViewUtil {
+
+    /**
+     * The upload timestamp shown in Case File View. As a decentralised service PCS owns this value,
+     * so it is set on every Document we return to CCD rather than being populated by ccd-data-store.
+     */
+    public static LocalDateTime uploadTimestamp(DocumentEntity documentEntity) {
+        if (documentEntity.getSubmittedDate() == null) {
+            return null;
+        }
+
+        return documentEntity.getSubmittedDate().atZone(ZoneOffset.UTC).toLocalDateTime();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/DocumentsView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/DocumentsView.java
@@ -48,10 +48,7 @@ public class DocumentsView {
                            .url(entity.getUrl())
                            .binaryUrl(entity.getBinaryUrl())
                            .categoryId(entity.getCategoryId())
-                           .uploadTimestamp(entity.getSubmittedDate() == null
-                                                ? null
-                                                : entity.getSubmittedDate()
-                               .atZone(java.time.ZoneOffset.UTC).toLocalDateTime())
+                           .uploadTimestamp(DocumentViewUtil.uploadTimestamp(entity))
                            .build())
                 .build())
             .collect(Collectors.toList());

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/NoticeOfPossessionView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/NoticeOfPossessionView.java
@@ -113,6 +113,7 @@ public class NoticeOfPossessionView {
                     .filename(documentEntity.getFileName())
                     .binaryUrl(documentEntity.getBinaryUrl())
                     .categoryId(documentEntity.getCategoryId())
+                    .uploadTimestamp(DocumentViewUtil.uploadTimestamp(documentEntity))
                     .build()
             ).build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/RentArrearsView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/RentArrearsView.java
@@ -65,6 +65,7 @@ public class RentArrearsView {
                     .filename(documentEntity.getFileName())
                     .binaryUrl(documentEntity.getBinaryUrl())
                     .categoryId(documentEntity.getCategoryId())
+                    .uploadTimestamp(DocumentViewUtil.uploadTimestamp(documentEntity))
                     .build()
             ).build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/TenancyLicenceView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/TenancyLicenceView.java
@@ -108,6 +108,7 @@ public class TenancyLicenceView {
                     .filename(documentEntity.getFileName())
                     .binaryUrl(documentEntity.getBinaryUrl())
                     .categoryId(documentEntity.getCategoryId())
+                    .uploadTimestamp(DocumentViewUtil.uploadTimestamp(documentEntity))
                     .build()
             ).build();
     }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/ClaimViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/ClaimViewTest.java
@@ -21,6 +21,9 @@ import uk.gov.hmcts.reform.pcs.ccd.entity.ClaimEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.DocumentEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -31,6 +34,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ClaimViewTest {
+
+    private static final Instant DOCUMENT_SUBMITTED_DATE = Instant.parse("2026-05-14T09:30:00Z");
 
     private PCSCase pcsCase;
     @Mock
@@ -273,6 +278,7 @@ class ClaimViewTest {
             .binaryUrl("http://dm-store/documents/" + fileName + "/binary")
             .fileName(fileName)
             .categoryId("category-" + fileName)
+            .submittedDate(DOCUMENT_SUBMITTED_DATE)
             .build();
     }
 
@@ -291,6 +297,9 @@ class ClaimViewTest {
                 assertThat(document.getUrl()).isEqualTo("http://dm-store/documents/" + fileName);
                 assertThat(document.getBinaryUrl()).isEqualTo("http://dm-store/documents/" + fileName + "/binary");
                 assertThat(document.getCategoryId()).isEqualTo("category-" + fileName);
+                // Case File View 1.1 sorts on upload_timestamp - PCS must set it, CCD will not
+                assertThat(document.getUploadTimestamp())
+                    .isEqualTo(LocalDateTime.ofInstant(DOCUMENT_SUBMITTED_DATE, ZoneOffset.UTC));
             });
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/NoticeOfPossessionViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/NoticeOfPossessionViewTest.java
@@ -21,8 +21,10 @@ import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.claim.NoticeOfPossessionEntity;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 
@@ -41,6 +43,8 @@ import static uk.gov.hmcts.reform.pcs.ccd.domain.NoticeServiceMethod.PERSONALLY_
 
 @ExtendWith(MockitoExtension.class)
 class NoticeOfPossessionViewTest {
+
+    private static final Instant DOCUMENT_SUBMITTED_DATE = Instant.parse("2026-05-14T09:30:00Z");
 
     @Mock
     private PCSCase pcsCase;
@@ -282,6 +286,7 @@ class NoticeOfPossessionViewTest {
                 DocumentEntity.builder()
                     .id(noticeDocumentId)
                     .type(DocumentType.POSSESSION_NOTICE)
+                    .submittedDate(DOCUMENT_SUBMITTED_DATE)
                     .build()
             )
         );
@@ -298,6 +303,9 @@ class NoticeOfPossessionViewTest {
         List<ListValue<Document>> noticeDocuments = noticeServedDetails.getDocuments();
         assertThat(noticeDocuments).hasSize(1);
         assertThat(noticeDocuments.getFirst().getId()).isEqualTo(noticeDocumentId.toString());
+        // Case File View 1.1 sorts on upload_timestamp - PCS must set it, CCD will not
+        assertThat(noticeDocuments.getFirst().getValue().getUploadTimestamp())
+            .isEqualTo(LocalDateTime.ofInstant(DOCUMENT_SUBMITTED_DATE, ZoneOffset.UTC));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/RentArrearsViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/RentArrearsViewTest.java
@@ -18,6 +18,9 @@ import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.claim.RentArrearsEntity;
 
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 
@@ -29,6 +32,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RentArrearsViewTest {
+
+    private static final Instant DOCUMENT_SUBMITTED_DATE = Instant.parse("2026-05-14T09:30:00Z");
 
     @Mock
     private PCSCase pcsCase;
@@ -90,6 +95,7 @@ class RentArrearsViewTest {
                 DocumentEntity.builder()
                     .id(rentDocumentId)
                     .type(DocumentType.RENT_STATEMENT)
+                    .submittedDate(DOCUMENT_SUBMITTED_DATE)
                     .build()
             )
         );
@@ -109,6 +115,9 @@ class RentArrearsViewTest {
         List<ListValue<Document>> statementDocuments = rentArrears.getStatementDocuments();
         assertThat(statementDocuments).hasSize(1);
         assertThat(statementDocuments.getFirst().getId()).isEqualTo(rentDocumentId.toString());
+        // Case File View 1.1 sorts on upload_timestamp - PCS must set it, CCD will not
+        assertThat(statementDocuments.getFirst().getValue().getUploadTimestamp())
+            .isEqualTo(LocalDateTime.ofInstant(DOCUMENT_SUBMITTED_DATE, ZoneOffset.UTC));
 
         verify(pcsCase).setArrearsJudgmentWanted(VerticalYesNo.YES);
     }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/TenancyLicenceViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/TenancyLicenceViewTest.java
@@ -21,7 +21,10 @@ import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.TenancyLicenceEntity;
 import uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 
@@ -35,6 +38,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class TenancyLicenceViewTest {
+
+    private static final Instant DOCUMENT_SUBMITTED_DATE = Instant.parse("2026-05-14T09:30:00Z");
 
     @Mock
     private PCSCase pcsCase;
@@ -136,6 +141,7 @@ class TenancyLicenceViewTest {
                 DocumentEntity.builder()
                     .id(tenancyLicenceDocumentId)
                     .type(DocumentType.TENANCY_AGREEMENT)
+                    .submittedDate(DOCUMENT_SUBMITTED_DATE)
                     .build()
             )
         );
@@ -160,6 +166,9 @@ class TenancyLicenceViewTest {
         List<ListValue<Document>> tenancyLicenceDocuments = tenancyLicenceDetails.getTenancyLicenceDocuments();
         assertThat(tenancyLicenceDocuments).hasSize(1);
         assertThat(tenancyLicenceDocuments.getFirst().getId()).isEqualTo(tenancyLicenceDocumentId.toString());
+        // Case File View 1.1 sorts on upload_timestamp - PCS must set it, CCD will not
+        assertThat(tenancyLicenceDocuments.getFirst().getValue().getUploadTimestamp())
+            .isEqualTo(LocalDateTime.ofInstant(DOCUMENT_SUBMITTED_DATE, ZoneOffset.UTC));
     }
 
     @Test
@@ -181,6 +190,7 @@ class TenancyLicenceViewTest {
                 DocumentEntity.builder()
                     .id(tenancyLicenceDocumentId)
                     .type(DocumentType.OCCUPATION_LICENCE)
+                    .submittedDate(DOCUMENT_SUBMITTED_DATE)
                     .build()
             )
         );
@@ -203,6 +213,9 @@ class TenancyLicenceViewTest {
         List<ListValue<Document>> licenceDocuments = occupationLicenceDetails.getLicenceDocuments();
         assertThat(licenceDocuments).hasSize(1);
         assertThat(licenceDocuments.getFirst().getId()).isEqualTo(tenancyLicenceDocumentId.toString());
+        // Case File View 1.1 sorts on upload_timestamp - PCS must set it, CCD will not
+        assertThat(licenceDocuments.getFirst().getValue().getUploadTimestamp())
+            .isEqualTo(LocalDateTime.ofInstant(DOCUMENT_SUBMITTED_DATE, ZoneOffset.UTC));
     }
 
     @Test


### PR DESCRIPTION
## What

Case File View 1.1 adds chronological (upload date) and alphabetical sort, both inside folders and in a new flat "date only" view. The sort is driven by the `upload_timestamp` attribute added to the CCD `Document` type in 1.1.

The [CFV 1.1 how-to guide](https://tools.hmcts.net/confluence/spaces/RCCD/pages/1764268327/How+To+Guide+-+Case+File+View+1.1) lists three onboarding steps. This PR covers the PCS side of all three.

## Why CCD can't populate it for us

For a centralised service, `ccd-data-store`'s `CaseDocumentTimestampService` stamps `upload_timestamp` on every event submission: it diffs `document_url` values between the stored case and the modified case, and stamps `now` on anything new.

PCS is decentralised. Our `Document` fields are **read-path projections** — rebuilt from `DocumentEntity` rows every time CCD asks for the case. Anything `ccd-data-store` writes into them is discarded on the next read. So PCS has to set the value itself, which we can do better anyway: `DocumentEntity.submittedDate` is a `@CreationTimestamp` recording the actual upload time, not an inference from a URL diff.

## The gap this fixes

`DocumentsView` already set `uploadTimestamp` on `allDocuments`. The other four views did not.

That matters because `CategoriesAndDocumentsService.buildCategorisedDocumentDictionary()` walks **every** `Document`-typed field on the case, not just `allDocuments`. And `DocumentsView.isNotInCaseDetailsTab()` deliberately *excludes* these types from `allDocuments` (unless they carry a description):

- `TENANCY_AGREEMENT`, `OCCUPATION_LICENCE`
- `POSSESSION_NOTICE`
- `RENT_STATEMENT`
- `ENERGY_PERFORMANCE_CERTIFICATE`, `EICR_REPORT`, `GAS_SAFETY_CERTIFICATE`

So those documents reach Case File View **only** through `ClaimView`, `RentArrearsView`, `NoticeOfPossessionView` and `TenancyLicenceView` — and without this change they'd have arrived with no timestamp and sorted as "older".

## Changes

| File | Change |
|---|---|
| `view/DocumentViewUtil.java` (new) | Shared `Instant` → `LocalDateTime` (UTC) conversion, so the five call sites don't repeat it |
| `view/DocumentsView.java` | Refactored onto the helper — no behaviour change |
| `view/ClaimView.java` | Set `uploadTimestamp` (EPC / gas safety / EICR / Wales docs) |
| `view/RentArrearsView.java` | Set `uploadTimestamp` (`RentArrearsSection.statementDocuments`) |
| `view/NoticeOfPossessionView.java` | Set `uploadTimestamp` (`NoticeServedDetails.documents`) |
| `view/TenancyLicenceView.java` | Set `uploadTimestamp` (tenancy licence + Wales occupation licence docs) |
| `charts/pcs-api/values.ccd.preview.template.yaml` | `UPLOAD_TIMESTAMP_FEATURED_CASE_TYPES: "PCS"` |

## On the whitelist entry

Preview only, as requested. It is **consistency rather than necessity**: the `ccd.upload-timestamp-featured-case-types` flag gates exactly one thing in `ccd-data-store` — the `addUploadTimestamps` call — and for PCS that call's write is discarded regardless. It's here so preview matches the AAT/prod whitelist we'll ask the CCD team to add, and so the config difference doesn't look like an oversight later. `PCS` with no suffix is correct for preview: `CASE_TYPE_SUFFIX` is only set (to `staging`) in `values.aat.template.yaml`.

**Still needed outside this repo:** a request to the CCD team to add PCS to `UPLOAD_TIMESTAMP_FEATURED_CASE_TYPES` in `cnp-flux-config` for AAT and prod, if we want the config to be consistent there too.

## Testing

Unit tests extended in all four view tests to assert the timestamp round-trips as UTC — including both `TenancyLicenceView` paths (England `TENANCY_AGREEMENT` and Wales `OCCUPATION_LICENCE`).

```
./gradlew compileJava compileTestJava checkstyleMain checkstyleTest   BUILD SUCCESSFUL
./gradlew test --tests '*ViewTest'                                    BUILD SUCCESSFUL
```

No backfill of historical documents — matching the product decision taken for CFV 1.1 centrally. Documents uploaded before this ships keep sorting as "older".