### PR TITLE
HDPI-7989: bump Infrastructure library to 2.4.8 for stash excludes

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -167,11 +167,12 @@ withPipeline(type, product, component) {
   }
 
   // HDPI-7989: slim the workspace between agent hops. withEnvironmentAgent
-  // stashes the whole workspace (767MB observed = ~18 min per stash at
-  // controller upload speed). Gradle build output, scanner caches and report
-  // artefacts are not needed downstream: deploy uses the ACR image, HLDS
-  // recompiles from source. The du listing logs a breakdown for diagnosis.
-  afterAlways('akschartsinstall') {
+  // (lib 2.4.4) stashes the whole workspace on entry and exit of every stage
+  // that switches agent pools. build/ alone is 742MB of a 767MB workspace
+  // (~18 min per stash at degraded controller IO; 22MB after cleanup). Any
+  // stage that runs gradle regenerates build/, so cleanup runs after each:
+  // downstream stages recompile from source and never read a stashed build/.
+  def slimWorkspace = {
     sh '''
       echo "Workspace size breakdown (MB):"
       du -sm * .[!.]* 2>/dev/null | sort -rn | sed -n 1,15p
@@ -182,20 +183,32 @@ withPipeline(type, product, component) {
     '''
   }
 
+  afterAlways('akschartsinstall') {
+    slimWorkspace()
+  }
+
+  afterAlways('highleveldatasetup') {
+    slimWorkspace()
+  }
+
   afterAlways('smoketest:preview') {
     archiveSmokeTestReports()
+    slimWorkspace()
   }
 
   afterAlways('smoketest:aat') {
     archiveSmokeTestReports()
+    slimWorkspace()
   }
 
   afterAlways('functionalTest:preview') {
     archiveFunctionalTestReports()
+    slimWorkspace()
   }
 
   afterAlways('functionalTest:aat') {
     archiveFunctionalTestReports()
+    slimWorkspace()
   }
 
   afterAlways('E2eTest:aat') {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -166,6 +166,18 @@ withPipeline(type, product, component) {
     env.CCD_ENABLED = "true"
   }
 
+  // HDPI-7989: slim the workspace before the High Level Data Setup agent hop.
+  // The HLDS stage stashes the whole workspace (16k+ files, ~19 min observed);
+  // scanner caches and report output are not needed by the gradle HLDS task.
+  // The du listing keeps a size breakdown in the log for future diagnosis.
+  afterAlways('akschartsinstall') {
+    sh '''
+      echo "Workspace size before HLDS stash:"
+      du -sm .[^.]* * 2>/dev/null | sort -rn | head -15 || true
+      rm -rf .scannerwork .sonar build/reports build/test-results test-results allure-results functional-output || true
+    '''
+  }
+
   afterAlways('smoketest:preview') {
     archiveSmokeTestReports()
   }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@2.4.4")
+@Library("Infrastructure@2.4.8")
 
 import uk.gov.hmcts.contino.AppPipelineDsl
 import uk.gov.hmcts.contino.GithubAPI
@@ -166,49 +166,20 @@ withPipeline(type, product, component) {
     env.CCD_ENABLED = "true"
   }
 
-  // HDPI-7989: slim the workspace between agent hops. withEnvironmentAgent
-  // (lib 2.4.4) stashes the whole workspace on entry and exit of every stage
-  // that switches agent pools. build/ alone is 742MB of a 767MB workspace
-  // (~18 min per stash at degraded controller IO; 22MB after cleanup). Any
-  // stage that runs gradle regenerates build/, so cleanup runs after each:
-  // downstream stages recompile from source and never read a stashed build/.
-  def slimWorkspace = {
-    sh '''
-      echo "Workspace size breakdown (MB):"
-      du -sm * .[!.]* 2>/dev/null | sort -rn | sed -n 1,15p
-      rm -rf build .scannerwork .sonar test-results allure-results functional-output e2e-output output
-      echo "After cleanup:"
-      du -sm . 2>/dev/null
-      true
-    '''
-  }
-
-  afterAlways('akschartsinstall') {
-    slimWorkspace()
-  }
-
-  afterAlways('highleveldatasetup') {
-    slimWorkspace()
-  }
-
   afterAlways('smoketest:preview') {
     archiveSmokeTestReports()
-    slimWorkspace()
   }
 
   afterAlways('smoketest:aat') {
     archiveSmokeTestReports()
-    slimWorkspace()
   }
 
   afterAlways('functionalTest:preview') {
     archiveFunctionalTestReports()
-    slimWorkspace()
   }
 
   afterAlways('functionalTest:aat') {
     archiveFunctionalTestReports()
-    slimWorkspace()
   }
 
   afterAlways('E2eTest:aat') {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -166,15 +166,19 @@ withPipeline(type, product, component) {
     env.CCD_ENABLED = "true"
   }
 
-  // HDPI-7989: slim the workspace before the High Level Data Setup agent hop.
-  // The HLDS stage stashes the whole workspace (16k+ files, ~19 min observed);
-  // scanner caches and report output are not needed by the gradle HLDS task.
-  // The du listing keeps a size breakdown in the log for future diagnosis.
+  // HDPI-7989: slim the workspace between agent hops. withEnvironmentAgent
+  // stashes the whole workspace (767MB observed = ~18 min per stash at
+  // controller upload speed). Gradle build output, scanner caches and report
+  // artefacts are not needed downstream: deploy uses the ACR image, HLDS
+  // recompiles from source. The du listing logs a breakdown for diagnosis.
   afterAlways('akschartsinstall') {
     sh '''
-      echo "Workspace size before HLDS stash:"
-      du -sm .[^.]* * 2>/dev/null | sort -rn | head -15 || true
-      rm -rf .scannerwork .sonar build/reports build/test-results test-results allure-results functional-output || true
+      echo "Workspace size breakdown (MB):"
+      du -sm * .[!.]* 2>/dev/null | sort -rn | sed -n 1,15p
+      rm -rf build .scannerwork .sonar test-results allure-results functional-output e2e-output output
+      echo "After cleanup:"
+      du -sm . 2>/dev/null
+      true
     '''
   }
 


### PR DESCRIPTION
### What
One line: `@Library("Infrastructure@2.4.4")` -> `2.4.8`.

### Why
2.4.8 excludes gradle build output from the withEnvironmentAgent workspace stashes at library level (cnp-jenkins-library #1503, HDPI-8019). The Jenkinsfile hooks merged in #2309 cover the stages with callbacks, but three hops have none: E2E aat, Build Infrastructure prod and DB Migration prod. E2E regenerates build/ (742MB of the 767MB workspace), so the prod hops still pay the fat stash - the slow prod steps Saurabh reported.

Library-level excludes cover every hop declaratively. The #2309 hooks stay as a harmless safety net; removal is a follow-up once a master build on 2.4.8 is green.

Also rides 2.4.4 -> 2.4.8: DTSPO-33498 nightly serialisation fix, printVersionInit, sonar toggle (net no-op). pcs-frontend already on 2.4.8 via #1834.

### Validation
First master build after merge: stash nodes in E2E aat and prod infra/migration stages drop from 15+ min to under a minute.

Ticket: HDPI-7989.