### PR TITLE
Cut preview DB pool sizes for the WA services

### DIFF
--- a/charts/pcs-api/values.wa.preview.template.yaml
+++ b/charts/pcs-api/values.wa.preview.template.yaml
@@ -48,6 +48,11 @@ wa:
   camunda-bpm:
     java:
       image: hmctsprod.azurecr.io/camunda/bpm:latest
+      environment:
+        SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "4"
+        SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "1"
+        CAMUNDA_BPM_JOB_EXECUTION_CORE_POOL_SIZE: "1"
+        CAMUNDA_BPM_JOB_EXECUTION_MAX_POOL_SIZE: "2"
 
   wa-case-event-handler:
     java:
@@ -59,6 +64,8 @@ wa:
         AZURE_SERVICE_BUS_TOPIC_NAME: ${SERVICE_NAME}-asb-ccd-case-events
         AZURE_SERVICE_BUS_SUBSCRIPTION_NAME: ${SERVICE_NAME}-asb-ccd-case-events
         AZURE_SERVICE_BUS_CCD_CASE_EVENTS_SUBSCRIPTION_NAME: ${SERVICE_NAME}-asb-ccd-case-events
+        SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "4"
+        SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "1"
       keyVaults:
         wa:
           secrets:
@@ -77,6 +84,8 @@ wa:
       environment:
         ALLOWED_CASE_TYPES: pcs-${CHANGE_ID}
         ALLOWED_JURISDICTIONS: pcs
+        SPRING_DATASOURCE_MAXIMUM_POOL_SIZE: "4"
+        SPRING_DATASOURCE_MINIMUM_IDLE: "1"
       keyVaults:
         wa:
           secrets:
@@ -114,6 +123,8 @@ wa:
     java:
       environment:
         DB_READER_USERNAME: "hmcts"
+        SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "4"
+        SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: "1"
       keyVaults:
         wa:
           secrets:


### PR DESCRIPTION
Stacked on `HDPI-wa-preview-chart`, since `values.wa.preview.template.yaml`
is not on master yet. Companion to #2340, which does the same for pcs-api,
ccd-data-store-api and ccd-definition-store-api.

## Why

The `pcs-preview` flexible server was carrying ~1150 connections, almost all
idle JDBC pool connections, across ~180 databases on a 2 vCPU / 8 GiB SKU.
That pushed it into refusing new work, and ASO could no longer create
databases for new preview PRs — pods crashlooped on
`FATAL: database "pr-NNNN-pcs" does not exist`.

Measured on the live server, each WA stack holds **30 idle connections**:

```
camunda|idle|60|6
task-mgmt|idle|60|6
workflow-api|idle|60|6
```

60 connections across 6 databases = 10 per stack per service, entirely from
Hikari defaults. Nothing sets a pool size for any WA service today.

## What this changes

Caps every WA pool at 4 connections with a single idle one: `camunda-bpm`,
`wa-case-event-handler`, `wa-task-management-api`, `wa-workflow-api`.

Two things worth flagging, both verified against upstream source rather than
assumed:

**wa-task-management-api takes unprefixed keys.** Its `DatasourceConfiguration`
binds `@ConfigurationProperties(prefix = "spring.datasource")` directly onto a
`DataSourceBuilder`, and `application.yaml` uses `jdbcUrl` rather than `url`
for exactly that reason. `SPRING_DATASOURCE_HIKARI_*` would not bind, so it
gets `SPRING_DATASOURCE_MAXIMUM_POOL_SIZE` / `SPRING_DATASOURCE_MINIMUM_IDLE`.
HikariCP is on the classpath via `spring-boot-starter-data-jpa`.

**Camunda's job executor needed capping alongside the pool.** Each job executor
thread holds a connection while it runs, and the default max pool is 10 — with
a Hikari pool of 4 the threads would contend and time out. Cut to 1 core / 2 max.

## Not changed

`wa-task-monitor` has no datasource of its own, so there is nothing to set.

`wa-task-management-api`'s replica pool is `@Profile("replica | preview")` — I
checked the live deployment and no Spring profile is active (`ENVIRONMENT=aat`
is not a profile), so only the primary pool exists. Consistent with the
measured 10 connections per stack rather than 20.

ORM and RAS are out of scope; they are being removed and PCS deploys neither.

## Expected impact

Per WA stack: 30 idle connections → 3. Across the 6 currently deployed WA
stacks that is 180 → ~18, with a worst case of 12 rather than 30.