### PR TITLE
HDPI-8115: cap preview connection pools against the shared flexible server

### DIFF
--- a/charts/pcs-api/values.ccd.preview.template.yaml
+++ b/charts/pcs-api/values.ccd.preview.template.yaml
@@ -15,6 +15,10 @@ global:
 java:
   environment:
     PCS_DB_NAME: "{{ .Values.global.databaseNamePrefix }}pcs"
+    # HDPI-8115: preview shares one small flexible server across ~70 releases;
+    # shrink per-pod pools so idle stacks hold no connections.
+    PCS_DB_POOL_MIN_IDLE: "0"
+    PCS_DB_POOL_MAX_SIZE: "2"
     PCS_DB_HOST: '{{ tpl .Values.global.postgresHostname $}}'
     PCS_DB_USER_NAME: "{{ .Values.global.postgresUsername}}"
     ELASTIC_SEARCH_HOSTS: "http://{{ .Release.Name }}-es-master:9200"

--- a/charts/pcs-api/values.preview.template.yaml
+++ b/charts/pcs-api/values.preview.template.yaml
@@ -27,6 +27,10 @@ java:
           alias: LAUNCHDARKLY_SDK_KEY
   environment:
     PCS_DB_HOST: "{{ .Release.Name }}-postgresql"
+    # HDPI-8115: preview shares one small flexible server across ~70 releases;
+    # shrink per-pod pools so idle stacks hold no connections.
+    PCS_DB_POOL_MIN_IDLE: "0"
+    PCS_DB_POOL_MAX_SIZE: "2"
     PCS_DB_USER_NAME: "{{ .Values.postgresql.auth.username}}"
     PCS_DB_NAME: "{{ .Values.postgresql.auth.database}}"
     SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "4"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,8 +56,8 @@ spring:
     properties:
       charSet: UTF-8
     hikari:
-      minimumIdle: 2
-      maximumPoolSize: 10
+      minimumIdle: ${PCS_DB_POOL_MIN_IDLE:2}
+      maximumPoolSize: ${PCS_DB_POOL_MAX_SIZE:10}
       idleTimeout: 10000
       poolName: PCSHikariCP
       maxLifetime: 7200000


### PR DESCRIPTION
### What
- `application.yaml`: `minimumIdle` / `maximumPoolSize` become env-parametrised (`PCS_DB_POOL_MIN_IDLE` default 2, `PCS_DB_POOL_MAX_SIZE` default 10 - real environments unchanged).
- Both preview chart variants set min 0 / max 2.

### Why
pcs-preview flexible server (2 vCPU / 8GB) saturated again today: ~10 -> 1022 active connections at CI peak, memory errors and timeouts (Scott's report, second occurrence after 31 Jul). 73 preview releases each pin idle pools. With min 0, idle stacks hold zero connections (idleTimeout is already 10s); with max 2, a busy stack tops at 2. Effect arrives as PRs redeploy.

Notes: the CCD variant (shared server) had no cap at all. The poddb variant already caps at 4 via `SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE`, which out-precedences the yaml placeholder, and its database is the in-pod postgres regardless.

Follow-ups on HDPI-8115: CCD component pools (upstream charts), PgBouncer, SKU right-size, zombie sweep (pr-1307's orphaned CRs purged tonight).

### Validation
This PR's own preview deploy: pg_stat_activity for its release should show at most 2 connections per java pod, zero when idle.