### PR TITLE
HDPI-8146: remove leftover geo-redundant backup value from prod.tfvars

### DIFF
--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,1 +1,0 @@
-postgres_geo_redundant_backups = true


### PR DESCRIPTION
### What
Deletes the orphaned `postgres_geo_redundant_backups = true` from `infrastructure/prod.tfvars`.

### Why
#2352 reverted the wiring (database.tf, variables.tf) from #2348 but left this value behind. It is an undeclared-variable warning today, and a landmine tomorrow: re-declaring the variable instantly re-arms a plan in which `geo_redundant_backup_enabled false -> true` **forces replacement of the pcs-prod flexible server** (seen live in master #1775's plan output before the revert).

Geo-redundant backups for prod are a real requirement - but they are create-time-only on flexible servers, so the proper route is a CR with a migration path (or long-term retention via Backup vault), on a module ref that actually declares the input. HDPI-8146 tracks that follow-up.

### Validation
`grep -r geo_redundant infrastructure/` returns nothing; next master build's prod plan shows no replacement diff.