### PR TITLE
HDPI-8150: suppress CVE-2026-66299 (embedded Tomcat) to unblock builds

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -26,4 +26,13 @@
     <cve>CVE-2025-7962</cve>
   </suppress>
   <!--End of false positives section -->
+   <suppress>
+      <notes><![CDATA[
+      HDPI-8150: CVE-2026-66299 against embedded Tomcat 11.0.24. No fixed
+      Tomcat release published yet; suppression is temporary and MUST be
+      removed when tomcatEmbedVersion is bumped to the fixed version.
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*$</packageUrl>
+      <cve>CVE-2026-66299</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
### What
Adds a temporary, ticket-annotated OWASP suppression for CVE-2026-66299 scoped to `org.apache.tomcat.embed/*`.

### Why
The CVE hit the NVD feed ~08:20 today against Tomcat 11.0.24 (our `tomcatEmbedVersion`). Dependency-check is correctly failing master (#1779 Static checks) and every PR built since - the whole team is blocked. **No fixed Tomcat release exists yet** (no 11.0.25 on Maven Central), so a version bump is not currently possible.

Process (agreed 4 Aug forum): suppress to unblock + mandatory fix ticket -> HDPI-8150 tracks the bump and the REMOVAL of this entry. Scoped to the tomcat-embed packages only, not a blanket CVE ignore.

### Validation
This PR's own Static checks stage passes dependency-check with the suppression active.