### PR TITLE
HDPI-8153: require review on infrastructure paths; test-gating checklist

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,13 @@ src/e2eTest @hmcts/possession-claim-service-qa-admins @hmcts/possession-claim-se
 
 src/functionalTest @hmcts/possession-claim-dev-assurance @hmcts/possession-claim-service-admins
 src/contractTest @hmcts/possession-claim-dev-assurance @hmcts/possession-claim-service-admins
+
+# Infrastructure paths: prod-affecting terraform and pipeline config require
+# review from the DevOps owners before merge (HDPI-8146 near-miss, 5 Aug:
+# a self-merged terraform change produced a forces-replacement plan against
+# the production database server; caught by pipeline failure, not process).
+/infrastructure/  @hmcts/possession-claim-service-admins
+/charts/          @hmcts/possession-claim-service-admins
+Jenkinsfile_CNP   @hmcts/possession-claim-service-admins
+Jenkinsfile_nightly @hmcts/possession-claim-service-admins
+/config/owasp/    @hmcts/possession-claim-service-admins

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,2 @@
+### Checklist
+- [ ] New functional test classes carry the gating annotations (`@EnabledIfEnvironmentVariable(named = "CCD_ENABLED", ...)` + shutter guard) unless they must run on unlabelled PRs (HDPI-8084)


### PR DESCRIPTION
### What
- `.github/CODEOWNERS`: `infrastructure/`, `charts/`, both Jenkinsfiles and `config/owasp/` now require review from `@hmcts/possession-claim-service-admins`.
- PR template: checklist line for functional-test gating annotations (the HDPI-8084 class - fourth occurrence this month).

### Why
Tuesday's near-miss (HDPI-8146): a self-merged terraform change produced a `forces replacement` plan against the production database server - caught by pipeline failure, not by process. This makes the review structural for the paths where a single line can be destructive, including OWASP suppressions (mandatory-ticket process).

### Note for the Wednesday call
CODEOWNERS only bites if branch protection enables "Require review from Code Owners" on master - repo admin toggle, proposed for decision today. Ticket: HDPI-8153.