### PR TITLE
HDPI-7989: remove redundant slimWorkspace hooks

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -200,49 +200,21 @@ withPipeline(type, product, component) {
     uploadBpmnDiagram()
   }
 
-  // HDPI-7989: slim the workspace between agent hops. withEnvironmentAgent
-  // (lib 2.4.4) stashes the whole workspace on entry and exit of every stage
-  // that switches agent pools. build/ alone is 742MB of a 767MB workspace
-  // (~18 min per stash at degraded controller IO; 22MB after cleanup). Any
-  // stage that runs gradle regenerates build/, so cleanup runs after each:
-  // downstream stages recompile from source and never read a stashed build/.
-  def slimWorkspace = {
-    sh '''
-      echo "Workspace size breakdown (MB):"
-      du -sm * .[!.]* 2>/dev/null | sort -rn | sed -n 1,15p
-      rm -rf build .scannerwork .sonar test-results allure-results functional-output e2e-output output
-      echo "After cleanup:"
-      du -sm . 2>/dev/null
-      true
-    '''
-  }
-
-  afterAlways('akschartsinstall') {
-    slimWorkspace()
-  }
-
-  afterAlways('highleveldatasetup') {
-    slimWorkspace()
-  }
 
   afterAlways('smoketest:preview') {
     archiveSmokeTestReports()
-    slimWorkspace()
   }
 
   afterAlways('smoketest:aat') {
     archiveSmokeTestReports()
-    slimWorkspace()
   }
 
   afterAlways('functionalTest:preview') {
     archiveFunctionalTestReports()
-    slimWorkspace()
   }
 
   afterAlways('functionalTest:aat') {
     archiveFunctionalTestReports()
-    slimWorkspace()
   }
 
   afterAlways('E2eTest:aat') {


### PR DESCRIPTION
### What
Deletes the `slimWorkspace()` closure and its `afterAlways` registrations from Jenkinsfile_CNP (the #2309 mitigation).

### Why
Superseded at the proper layer: library 2.4.9 excludes gradle `build/` from workspace stashes (HDPI-8019) and no longer hops agents for same-env stages. The hooks now cost a shell step per stage and clean directories the stash never ships. Condition for removal agreed on HDPI-7989 - a green master run on 2.4.9 - is met three times over (#1776, #1777, #1778); PR builds run 13-20 minutes.

### Validation
This PR's own build: same stage times as current master, no `Workspace size breakdown` steps in the log.

Closes the HDPI-7989 pipeline-duration workstream: 2h+ (31 Jul) -> 13-20 min, root causes fixed in the library and controller, temporary scaffolding removed.