### PR TITLE
fix: avoid Sonar S2259 on exempt landlord resolver

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/respondpossessionclaim/ExemptLandlordResolver.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/respondpossessionclaim/ExemptLandlordResolver.java
@@ -14,9 +14,6 @@ public final class ExemptLandlordResolver {
     }
 
     public static YesNoNotSure fromResponses(DefendantResponses responses) {
-        if (responses == null) {
-            return null;
-        }
         if (responses.getExemptLandlord() != null) {
             return responses.getExemptLandlord();
         }
@@ -24,9 +21,6 @@ public final class ExemptLandlordResolver {
     }
 
     public static YesNoNotSure fromEntity(DefendantResponseEntity entity) {
-        if (entity == null) {
-            return null;
-        }
         return entity.getLandlordRegistered();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/respondpossessionclaim/ExemptLandlordResolverTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/respondpossessionclaim/ExemptLandlordResolverTest.java
@@ -10,16 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ExemptLandlordResolverTest {
 
     @Test
-    void shouldReturnNullWhenResponsesAreNull() {
-        assertThat(ExemptLandlordResolver.fromResponses(null)).isNull();
-    }
-
-    @Test
-    void shouldReturnNullWhenEntityIsNull() {
-        assertThat(ExemptLandlordResolver.fromEntity(null)).isNull();
-    }
-
-    @Test
     void shouldPreferExemptLandlordWhenBothPresentInResponses() {
         DefendantResponses responses = DefendantResponses.builder()
             .exemptLandlord(YesNoNotSure.NO)
@@ -39,11 +29,25 @@ class ExemptLandlordResolverTest {
     }
 
     @Test
+    void shouldReturnNullWhenNeitherAnswerPresentInResponses() {
+        DefendantResponses responses = DefendantResponses.builder().build();
+
+        assertThat(ExemptLandlordResolver.fromResponses(responses)).isNull();
+    }
+
+    @Test
     void shouldReadLandlordRegisteredFromEntityDuringCompatPhase() {
         DefendantResponseEntity entity = DefendantResponseEntity.builder()
             .landlordRegistered(YesNoNotSure.YES)
             .build();
 
         assertThat(ExemptLandlordResolver.fromEntity(entity)).isEqualTo(YesNoNotSure.YES);
+    }
+
+    @Test
+    void shouldReturnNullWhenEntityHasNoLandlordRegistered() {
+        DefendantResponseEntity entity = DefendantResponseEntity.builder().build();
+
+        assertThat(ExemptLandlordResolver.fromEntity(entity)).isNull();
     }
 }


### PR DESCRIPTION
## Summary
- Unblocks master after HDPI-7249 compat (#2233) by removing defensive null guards from `ExemptLandlordResolver`.
- Those guards made Sonar treat `entity`/`responses` as nullable at call sites and raise Blocker **S2259** on later access (e.g. `entity.getTenancyTypeConfirmation()` in `DefendantResponseReadMapper`).
- Callers already always pass non-null arguments; runtime behaviour for FE/API is unchanged.

## Test plan
- [x] `./gradlew test --tests 'uk.gov.hmcts.reform.pcs.ccd.service.respondpossessionclaim.ExemptLandlordResolverTest'`
- [ ] Confirm master Sonar quality gate is green after merge