### PR TITLE
fix: avoid Sonar S2259 on exempt landlord resolver

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/respondpossessionclaim/ExemptLandlordResolver.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/respondpossessionclaim/ExemptLandlordResolver.java
@@ -14,9 +14,6 @@ public final class ExemptLandlordResolver {
     }
 
     public static YesNoNotSure fromResponses(DefendantResponses responses) {
-        if (responses == null) {
-            return null;
-        }
         if (responses.getExemptLandlord() != null) {
             return responses.getExemptLandlord();
         }
@@ -24,9 +21,6 @@ public final class ExemptLandlordResolver {
     }
 
     public static YesNoNotSure fromEntity(DefendantResponseEntity entity) {
-        if (entity == null) {
-            return null;
-        }
         return entity.getLandlordRegistered();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/respondpossessionclaim/ExemptLandlordResolverTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/respondpossessionclaim/ExemptLandlordResolverTest.java
@@ -10,16 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ExemptLandlordResolverTest {
 
     @Test
-    void shouldReturnNullWhenResponsesAreNull() {
-        assertThat(ExemptLandlordResolver.fromResponses(null)).isNull();
-    }
-
-    @Test
-    void shouldReturnNullWhenEntityIsNull() {
-        assertThat(ExemptLandlordResolver.fromEntity(null)).isNull();
-    }
-
-    @Test
     void shouldPreferExemptLandlordWhenBothPresentInResponses() {
         DefendantResponses responses = DefendantResponses.builder()
             .exemptLandlord(YesNoNotSure.NO)
@@ -39,11 +29,25 @@ class ExemptLandlordResolverTest {
     }
 
     @Test
+    void shouldReturnNullWhenNeitherAnswerPresentInResponses() {
+        DefendantResponses responses = DefendantResponses.builder().build();
+
+        assertThat(ExemptLandlordResolver.fromResponses(responses)).isNull();
+    }
+
+    @Test
     void shouldReadLandlordRegisteredFromEntityDuringCompatPhase() {
         DefendantResponseEntity entity = DefendantResponseEntity.builder()
             .landlordRegistered(YesNoNotSure.YES)
             .build();
 
         assertThat(ExemptLandlordResolver.fromEntity(entity)).isEqualTo(YesNoNotSure.YES);
+    }
+
+    @Test
+    void shouldReturnNullWhenEntityHasNoLandlordRegistered() {
+        DefendantResponseEntity entity = DefendantResponseEntity.builder().build();
+
+        assertThat(ExemptLandlordResolver.fromEntity(entity)).isNull();
     }
 }


### PR DESCRIPTION
## Summary
- Removes null guards from `ExemptLandlordResolver` that made Sonar treat `entity`/`responses` as nullable at call sites (S2259 on `DefendantResponseReadMapper`).
- Callers already pass non-null arguments; behaviour unchanged for valid inputs.
- Updates unit tests to match the clarified contract.

## Context
Master failed Sonar after merging HDPI-7249 compat (#2233). This is a static-analysis false positive from defensive null checks in the resolver, not a runtime NPE.

## Test plan
- [x] `ExemptLandlordResolverTest` unit tests pass
- [ ] Master Sonar / pipeline green after merge
- [ ] Rebase #2234 / #2235 onto this fix once merged