### PR TITLE
Remove WA jurisdiction overrides in ExUI as this is now role based

### DIFF
--- a/charts/pcs-api/values.ccd.preview.template.yaml
+++ b/charts/pcs-api/values.ccd.preview.template.yaml
@@ -200,8 +200,6 @@ xui-webapp:
       SERVICES_HEARINGS_COMPONENT_API: http://jurisdiction-hearings-api-aat.service.core-compute-aat.internal
       JURISDICTIONS: PCS
       GLOBAL_SEARCH_SERVICES: PCS,CIVIL,SSCS
-      WA_SUPPORTED_JURISDICTIONS: PCS,CIVIL,SSCS
-      STAFF_SUPPORTED_JURISDICTIONS: PCS,CIVIL,SSCS
       FEATURE_REDIS_ENABLED: false
       REDISCLOUD_URL: http://dummyrediscloudurl
       FEATURE_APP_INSIGHTS_ENABLED: false


### PR DESCRIPTION
### Description

Remove the jurisdiction overrides for WA in ExUI as these should be coming from user roles now. Having them present in the preview chart means that extra tabs appear in ExUI in preview that aren't in AAT and this is causing e2e test failures
