### PR TITLE
HDPI-8153: restore full PR template (org content + PCS checklist)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,2 +1,53 @@
+### Jira link
+
+<!-- 
+Replace PROJ-XXXXXX with your Jira key
+Remove this section if its not applicable, or replace it with another reference link
+-->
+See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)
+
+### Change description
+
+<!--
+Provide a description of what change you are proposing.
+A short summary here and then you can add comments in your pull request explaining your change to others.
+-->
+
+### Testing done
+
+<!-- Comment:
+Provide a clear description of how this change was tested.
+At minimum this should include proof that a computer has executed the changed lines.
+Ideally this should include an automated test or an explanation as to why this change has no tests.
+Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
+If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
+For frontend changes, include screenshots of the relevant page(s) before and after the change.
+For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
+-->
+
+### Security Vulnerability Assessment ###
+
+<!-- Comment:
+If Yes to the below question, please provide details below:
+CVE ID(s): (List all suppressed or relevant CVE IDs)
+Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
+Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
+-->
+
+**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
+  * [ ] Yes
+  * [ ] No
+
 ### Checklist
+
+<!-- Check each box by removing the space and adding an x, e.g. [x] -->
+
+- [ ] commit messages are meaningful and follow good commit message guidelines
+- [ ] README and other documentation has been updated / added (if needed)
+- [ ] tests have been updated / new tests has been added (if needed)
+- [ ] Does this PR introduce a breaking change
+
+### PCS checklist
+
 - [ ] New functional test classes carry the gating annotations (`@EnabledIfEnvironmentVariable(named = "CCD_ENABLED", ...)` + shutter guard) unless they must run on unlabelled PRs (HDPI-8084)
+- [ ] Infrastructure / chart / suppression changes have a second pair of eyes from the service admins (HDPI-8153)


### PR DESCRIPTION
### Change description
#2357's checklist addition accidentally shadowed the hmcts org-wide PR template: the repo file had been EMPTY since Oct 2024 ("fix template references"), so GitHub was silently serving the org default. Making the file non-empty overrode it - losing the Jira link / change description / testing sections (Scott's report).

This vendors the org template into the repo verbatim and appends the PCS checklist section, so the template is complete and the repo owns it explicitly (no more invisible fallback behaviour).

### Testing done
Rendered locally; the file now contains the org sections (Jira link, change description, testing done, checklist) plus the PCS additions. Verify on this PR itself - its description box was created from the new template.