### PR TITLE
HDPI-7213: Add prod NOTIFY_URL to values.yaml

### DIFF
--- a/charts/pcs-api/Chart.yaml
+++ b/charts/pcs-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for pcs-api App
 name: pcs-api
 home: https://github.com/hmcts/pcs-api
-version: 0.0.78
+version: 0.0.79
 maintainers:
   - name: HMCTS pcs team
 dependencies:

--- a/charts/pcs-api/values.yaml
+++ b/charts/pcs-api/values.yaml
@@ -53,6 +53,7 @@ java:
     LAUNCHDARKLY_ENV: "{{ .Values.global.environment }}"
     CCD_DATA_STORE_URL: "http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     CASE_DOCUMENT_AM_URL: "http://ccd-case-document-am-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    NOTIFY_URL: "https://api.notifications.service.gov.uk"
     RD_PROFESSIONAL_API_URL: "http://rd-professional-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
 servicebus:
   enabled: false


### PR DESCRIPTION
### Jira link

See [HDPI-7213](https://tools.hmcts.net/jira/browse/HDPI-7213)

### Change description

Add the prod Gov Notify URL to the default values.yaml. This was missed out of https://github.com/hmcts/pcs-api/pull/2033 when the default URL was changed to a local Wiremock server

### Testing done

Pipeline run

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

### PCS checklist

- [ ] New functional test classes carry the gating annotations (`@EnabledIfEnvironmentVariable(named = "CCD_ENABLED", ...)` + shutter guard) unless they must run on unlabelled PRs (HDPI-8084)
- [ ] Infrastructure / chart / suppression changes have a second pair of eyes from the service admins (HDPI-8153)
