### PR TITLE
HDPI-8150: scope the owasp suppressions and remove the obsolete ones

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <!--Please add all the false positives under the below section-->
-  <suppress until="2026-08-15">
+  <suppress until="2026-09-15">
     <notes><![CDATA[file name: httpcore 4.4.16]]></notes>
     <cve>CVE-2026-54399</cve>
     <cve>CVE-2026-54428</cve>
   </suppress>
-  <suppress until="2026-08-15">
+  <suppress until="2026-09-15">
     <notes><![CDATA[jackson-databind-3.1.1.jar]]></notes>
     <cve>CVE-2026-54512</cve>
     <cve>CVE-2026-54513</cve>
@@ -16,13 +16,13 @@
     <cve>CVE-2026-54517</cve>
     <cve>CVE-2026-54518</cve>
   </suppress>
-  <suppress until="2026-08-15">
+  <suppress until="2026-09-15">
     <notes><![CDATA[kotlin-stdlib-1.9.25/kotlin-stdlib-jdk7-1.9.25/kotlin-stdlib-jdk8-1.9.25 ]]></notes>
     <cve>CVE-2020-29582</cve>
     <cve>CVE-2026-53914</cve>
     <cve>CVE-2026-64607</cve>
   </suppress>
-  <suppress until="2026-08-15">
+  <suppress until="2026-09-15">
     <notes><![CDATA[angus-activation-2.0.3.jar]]></notes>
     <cve>CVE-2025-7962</cve>
   </suppress>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -29,6 +29,17 @@
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib(-common|-jdk7|-jdk8)?@.*$</packageUrl>
     <cve>CVE-2026-53914</cve>
   </suppress>
+  <suppress until="2026-09-15">
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@2\.17(\..*)?$</packageUrl>
+    <cve>CVE-2026-54512</cve>
+    <cve>CVE-2026-54513</cve>
+    <cve>CVE-2026-54514</cve>
+    <cve>CVE-2026-54515</cve>
+  </suppress>
+  <suppress until="2026-09-15">
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@2\.21\.4$</packageUrl>
+    <cve>CVE-2026-54515</cve>
+  </suppress>
    <suppress>
       <notes><![CDATA[
       HDPI-8150: CVE-2026-66299 against embedded Tomcat 11.0.24. No fixed

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,32 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <!--Please add all the false positives under the below section-->
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@4\..*$</packageUrl>
+    <cve>CVE-2026-54399</cve>
+    <cve>CVE-2026-54428</cve>
+  </suppress>
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.angus/angus-activation@.*$</packageUrl>
+    <cve>CVE-2025-7962</cve>
+  </suppress>
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib(-common|-jdk7|-jdk8)?@.*$</packageUrl>
+    <cve>CVE-2020-29582</cve>
+  </suppress>
+  <!--End of false positives section -->
+
   <suppress until="2026-09-15">
-    <notes><![CDATA[file name: httpcore 4.4.16]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents\.core5/httpcore5(-h2)?@5\.([0-3](\..*)?|4(\.[0-2])?)$</packageUrl>
     <cve>CVE-2026-54399</cve>
     <cve>CVE-2026-54428</cve>
   </suppress>
   <suppress until="2026-09-15">
-    <notes><![CDATA[jackson-databind-3.1.1.jar]]></notes>
-    <cve>CVE-2026-54512</cve>
-    <cve>CVE-2026-54513</cve>
-    <cve>CVE-2026-54514</cve>
-    <cve>CVE-2026-54515</cve>
-    <cve>CVE-2026-54516</cve>
-    <cve>CVE-2026-54517</cve>
-    <cve>CVE-2026-54518</cve>
-  </suppress>
-  <suppress until="2026-09-15">
-    <notes><![CDATA[kotlin-stdlib-1.9.25/kotlin-stdlib-jdk7-1.9.25/kotlin-stdlib-jdk8-1.9.25 ]]></notes>
-    <cve>CVE-2020-29582</cve>
-    <cve>CVE-2026-53914</cve>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents\.client5/httpclient5@5\.([0-5](\..*)?|6(\.[0-2])?)$</packageUrl>
     <cve>CVE-2026-64607</cve>
   </suppress>
-  <suppress until="2026-09-15">
-    <notes><![CDATA[angus-activation-2.0.3.jar]]></notes>
-    <cve>CVE-2025-7962</cve>
+  <suppress until="2026-10-15">
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib(-common|-jdk7|-jdk8)?@.*$</packageUrl>
+    <cve>CVE-2026-53914</cve>
   </suppress>
-  <!--End of false positives section -->
    <suppress>
       <notes><![CDATA[
       HDPI-8150: CVE-2026-66299 against embedded Tomcat 11.0.24. No fixed


### PR DESCRIPTION
### Jira link

See [HDPI-8150](https://tools.hmcts.net/jira/browse/HDPI-8150)

### Change description

All four suppression blocks expired on 15 August, so dependency-check went red. Rather than roll the shared date forward again, this splits them by what they actually are.

**Deleted — jackson-databind (CVE-2026-54512…54518).** Obsolete. Every configuration already resolves jackson 2.21.4 and 3.1.4/3.2.1; the fixes landed in 2.18.8 / 2.21.4 / 3.1.4. There is no 3.1.1 jar in the tree.

**Now permanent, scoped false positives (no expiry).** These matches will never become true, so a date only re-breaks the build on a schedule:

- `httpcore@4.*` — CVE-2026-54399 / CVE-2026-54428 are HttpComponents Core 5 defects (affected 5.0-alpha1 to 5.4.2) matched to the 4.x jar via the shared `apache:httpcomponents_core` CPE. Upstream FP: DependencyCheck#8653
- `angus-activation` — CVE-2025-7962 is an SMTP injection in angus-mail / :smtp (fixed 2.0.4). This build pulls no angus-mail or jakarta.mail at all. Upstream FP: DependencyCheck#8144
- `kotlin-stdlib` CVE-2020-29582 — fixed in Kotlin 1.4.21, well below the resolved 1.9.25

**Now individually dated deferrals**, each scoped to the affected version range:

- `httpcore5(-h2) ≤5.4.2` (until 15 Sep) — genuinely affected at the resolved 5.3.6. Fixed in 5.4.3; httpclient5 5.6.4 already requests it, but the Spring Boot BOM pulled in by decentralised-runtime pins it back. Upgrade to follow as its own PR.
- `httpclient5 ≤5.6.2` (until 15 Sep) — the application classpath is already on the fixed 5.6.4; pact drags httpclient5 down to 5.5.2 on the contract-test classpath only, which is where this is reported.
- `kotlin-stdlib` CVE-2026-53914 (until 15 Oct) — unsafe deserialisation of Kotlin build cache metadata in the compiler / build tooling, not the shipped stdlib runtime; this build consumes no Kotlin build caches. Fixed in Kotlin 2.4.20, currently RC only.

Every block previously carried bare `<cve>` elements with no `packageUrl`, which suppresses that CVE across the entire dependency graph rather than the named jar. That is why the httpcore block was also hiding the genuine httpcore5 5.3.6 finding. All blocks are now scoped, and the version ranges deliberately exclude the fixed releases so the eventual upgrades still get verified rather than silently suppressed.

### Testing done

- `xmllint` validates the file against the suppression schema namespace.
- Each `packageUrl` regex was tested against real purls: matches the vulnerable versions (`httpcore5@5.3.6`, `httpcore5-h2@5.3.6`, `httpclient5@5.5.2`, `httpclient5@5.6.2`) and excludes the fixed ones (`httpcore5@5.4.3`, `httpclient5@5.6.3`, `httpclient5@5.6.4`). Also confirmed the kotlin regex does not catch `kotlin-reflect` and the angus regex does not catch `angus-mail`.
- Resolved dependency versions confirmed with `./gradlew dependencies` across all configurations (this is how the jackson block was shown to be obsolete and the httpcore5 downgrade found).
- The dependency-check run in CI is the real gate.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

**Suppressed as false positives** (no expiry): CVE-2026-54399, CVE-2026-54428 (scoped to httpcore 4.x only), CVE-2025-7962, CVE-2020-29582.
Reason: CPE / artifact mismatches, each with an upstream DependencyCheck FP reference above. Not exploitable because the affected code is not present in the matched artifact.

**Suppressed temporarily, with an expiry date**: CVE-2026-54399, CVE-2026-54428 (httpcore5), CVE-2026-64607, CVE-2026-53914.
Mitigating factors: all four are denial-of-service / availability issues rather than RCE. CVE-2026-64607 affects only the contract-test classpath, not the deployed application. CVE-2026-53914 is in build tooling, not the shipped runtime. The two httpcore5 CVEs have a fix available (5.4.3) and an upgrade PR to follow; the suppression expires before it is due.

**No longer suppressed**: CVE-2026-54512 through CVE-2026-54518 — the resolved jackson versions already contain the fixes.

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

### PCS checklist

- [ ] New functional test classes carry the gating annotations (`@EnabledIfEnvironmentVariable(named = "CCD_ENABLED", ...)` + shutter guard) unless they must run on unlabelled PRs (HDPI-8084)
- [ ] Infrastructure / chart / suppression changes have a second pair of eyes from the service admins (HDPI-8153)
