### PR TITLE
fix input text action

### DIFF
--- a/src/e2eTest/utils/actions/element-actions/inputText.action.ts
+++ b/src/e2eTest/utils/actions/element-actions/inputText.action.ts
@@ -6,7 +6,8 @@ export class InputTextAction implements IAction {
 
     let locator;
     if (typeof fieldParams !== 'string' && fieldParams.index !== null) {
-      locator = page.locator(`//span[text()="${fieldParams.textLabel}"]/parent::label/following-sibling::*[self::textarea or self::input][not(@disabled)]`);
+      const labelText = fieldParams.textLabel ?? fieldParams.text;
+      locator = page.locator(`//span[text()="${labelText}"]/parent::label/following-sibling::*[self::textarea or self::input][not(@disabled)]`);
 
       locator = (await locator.count()) > 1
         ? locator.nth(Number(fieldParams.index))
@@ -14,7 +15,7 @@ export class InputTextAction implements IAction {
     } else {
       locator = typeof fieldParams === 'string'
         ? await this.getStringFieldLocator(page, fieldParams)
-        : page.locator(`fieldset:has(h2:has-text("${fieldParams.textLabel}")) textarea:visible:enabled,
+        : page.locator(`fieldset:has(h2:has-text("${fieldParams.text}")) textarea:visible:enabled,
       :has-text("${fieldParams.text}") ~ input:visible:enabled,
       label:has-text("${fieldParams.text}") ~ textarea,
       :has-text("${fieldParams.text}") ~ textarea:visible:enabled`).first();


### PR DESCRIPTION
### Jira link

Fix inputText action failure
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

Updated the inputText Action
### Testing done

<img width="1728" height="1117" alt="Screenshot 2026-08-17 at 20 04 03" src="https://github.com/user-attachments/assets/caf7a6e3-9a8e-4502-8411-6ec5ef4eac83" />
<img width="1728" height="1117" alt="Screenshot 2026-08-17 at 20 03 44" src="https://github.com/user-attachments/assets/acb9544d-c22d-4c86-9abb-387c1a41732d" />




### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

### PCS checklist

- [ ] New functional test classes carry the gating annotations (`@EnabledIfEnvironmentVariable(named = "CCD_ENABLED", ...)` + shutter guard) unless they must run on unlabelled PRs (HDPI-8084)
- [ ] Infrastructure / chart / suppression changes have a second pair of eyes from the service admins (HDPI-8153)
