### PR TITLE
[DO NOT MERGE] HDPI-7686: preview at PR #2113 to verify the reported coversheet defect

### DIFF
--- a/charts/pcs-api/values.preview.template.yaml
+++ b/charts/pcs-api/values.preview.template.yaml
@@ -33,9 +33,12 @@ java:
     SPRING_FLYWAY_LOCATIONS: "classpath:db/migration,classpath:db/testdata"
     SPRING_LOGGING_LEVEL_ROOT: "DEBUG"
     ENABLE_TESTING_SUPPORT: true
-    LAUNCHDARKLY_ENV: "${SERVICE_NAME}"
+    # HDPI-7686 verification only: bulk-print-enabled has no wildcard rule for previews, only a "contains
+    # pr-2113" clause. Suffixing the LD environment inherits it so this preview actually posts defence packs.
+    LAUNCHDARKLY_ENV: "${SERVICE_NAME}-pr-2113"
     DB_SCHEDULER_EXECUTOR_ENABLED: true
-    BULK_PRINT_SCHEDULE: "FIXED_DELAY|300s"
+    # HDPI-7686 verification only: 300s makes waiting for a pack impractical.
+    BULK_PRINT_SCHEDULE: "FIXED_DELAY|30s"
     BULK_PRINT_LOOKBACK_HOURS: "1"
     DOC_ASSEMBLY_URL: http://dg-docassembly-aat.service.core-compute-aat.internal
     SEND_LETTER_URL: http://rpe-send-letter-service-aat.service.core-compute-aat.internal


### PR DESCRIPTION
Throwaway preview, not for merge. Branched from the #2113 merge commit — the code HDPI-7686 was raised against — with one chart change so bulk print actually runs (LaunchDarkly env inherits the leftover `contains pr-2113` rule, sweep every 30s). No application code touched.

Purpose: confirm empirically that on that code the defence pack coversheet showed "Persons unknown" (Issue 1) and the pre-correction name (Issue 2), which `ClaimResponseService.updatePartyContactDetails` explains — it gated the name update on `defendantNameConfirmation == null` and never set `nameKnown`. #2114 changed both an hour after the ticket was filed.

Close once verified.