### PR TITLE
HDPI-8264: fixes for GroupAccess in NoC process

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,3 +381,5 @@ so it still runs locally; local and `cftlibTest` set `LAUNCHDARKLY_OFFLINE=true`
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
+
+<!-- HDPI-8264: placeholder commit to open the stacked fix PR -->

--- a/README.md
+++ b/README.md
@@ -381,5 +381,3 @@ so it still runs locally; local and `cftlibTest` set `LAUNCHDARKLY_OFFLINE=true`
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
-
-<!-- HDPI-8264: placeholder commit to open the stacked fix PR -->

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessGrants.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessGrants.java
@@ -14,6 +14,7 @@ import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT_SOLICITOR;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.FEE_PAID_JUDGE;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_CLAIMANT_SOLICITOR;
+import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_DEFENDANT_SOLICITOR;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.HEARING_CENTRE_ADMIN;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.JUDGE;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.LEADERSHIP_JUDGE;
@@ -67,6 +68,7 @@ final class AccessGrants {
         grants.putAll(CLAIMANT_SOLICITOR, Permission.CR);
         grants.putAll(GA_CLAIMANT_SOLICITOR, Permission.CR);
         grants.putAll(DEFENDANT_SOLICITOR, Permission.CR);
+        grants.putAll(GA_DEFENDANT_SOLICITOR, Permission.CR);
         addReadAccess(grants, INTERNAL_READ_ROLES);
         return grants;
     }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DefendantAccess.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DefendantAccess.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.ccd.sdk.api.Permission;
 
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT_SOLICITOR;
+import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_DEFENDANT_SOLICITOR;
 
 
 public class DefendantAccess implements HasAccessControl {
@@ -17,6 +18,7 @@ public class DefendantAccess implements HasAccessControl {
         SetMultimap<HasRole, Permission> grants = HashMultimap.create();
         grants.putAll(DEFENDANT, Permission.CRU);
         grants.putAll(DEFENDANT_SOLICITOR, Permission.CRU);
+        grants.putAll(GA_DEFENDANT_SOLICITOR, Permission.CRU);
         return grants;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DefendantReadAccess.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DefendantReadAccess.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.ccd.sdk.api.Permission;
 
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT_SOLICITOR;
+import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_DEFENDANT_SOLICITOR;
 
 public class DefendantReadAccess implements HasAccessControl {
 
@@ -16,6 +17,7 @@ public class DefendantReadAccess implements HasAccessControl {
         SetMultimap<HasRole, Permission> grants = HashMultimap.create();
         grants.put(DEFENDANT, Permission.R);
         grants.put(DEFENDANT_SOLICITOR, Permission.R);
+        grants.put(GA_DEFENDANT_SOLICITOR, Permission.R);
         return grants;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DefendantSolicitorAccess.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DefendantSolicitorAccess.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Permission;
 
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT_SOLICITOR;
+import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_DEFENDANT_SOLICITOR;
 
 
 public class DefendantSolicitorAccess implements HasAccessControl {
@@ -15,6 +16,7 @@ public class DefendantSolicitorAccess implements HasAccessControl {
     public SetMultimap<HasRole, Permission> getGrants() {
         SetMultimap<HasRole, Permission> grants = HashMultimap.create();
         grants.putAll(DEFENDANT_SOLICITOR, Permission.CRUD);
+        grants.putAll(GA_DEFENDANT_SOLICITOR, Permission.CRUD);
         return grants;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/RespondPossessionClaim.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/RespondPossessionClaim.java
@@ -48,6 +48,7 @@ public class RespondPossessionClaim implements CCDConfig<PCSCase, State, UserRol
             .description("Save defendants response as draft or to a case based on flag")
             .grant(Permission.CRU, UserRole.DEFENDANT)
             .grant(Permission.CRU, UserRole.DEFENDANT_SOLICITOR)
+            .grant(Permission.CRU, UserRole.GA_DEFENDANT_SOLICITOR)
             .grantHistoryOnly(JUDICIAL_HISTORY_ROLES);
         new PageBuilder(eventBuilder)
             .add(respondToPossessionDraftSavePage);

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/MakeAnApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/MakeAnApplication.java
@@ -52,6 +52,7 @@ public class MakeAnApplication implements CCDConfig<PCSCase, State, UserRole> {
             .name("Make an application")
             .grant(Permission.CRUD, UserRole.DEFENDANT)
             .grant(Permission.CRUD, UserRole.DEFENDANT_SOLICITOR)
+            .grant(Permission.CRUD, UserRole.GA_DEFENDANT_SOLICITOR)
             .grantHistoryOnly(JUDICIAL_HISTORY_ROLES)
             .endButtonLabel("Submit")
             .showSummary();

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/legalrepcontactdetails/LegalRepresentativeContactDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/legalrepcontactdetails/LegalRepresentativeContactDetails.java
@@ -37,6 +37,7 @@ public class LegalRepresentativeContactDetails implements CCDConfig<PCSCase, Sta
                 .forState(State.CASE_ISSUED)
                 .name("Amend representative’s details")
                 .grant(Permission.CRUD, UserRole.DEFENDANT_SOLICITOR)
+                .grant(Permission.CRUD, UserRole.GA_DEFENDANT_SOLICITOR)
                 .endButtonLabel("Submit");
 
         new PageBuilder(eventBuilder)

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/legalrepdocumentupload/LegalRepDocumentUpload.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/legalrepdocumentupload/LegalRepDocumentUpload.java
@@ -59,6 +59,7 @@ public class LegalRepDocumentUpload implements CCDConfig<PCSCase, State, UserRol
                 .forAllStates()
                 .name("Upload additional documents")
                 .grant(Permission.CRUD, UserRole.DEFENDANT_SOLICITOR)
+                .grant(Permission.CRUD, UserRole.GA_DEFENDANT_SOLICITOR)
                 .showSummary()
                 .endButtonLabel("Submit");
         legalRepDocumentUploadConfigurer.configurePages(new PageBuilder(eventBuilder));

--- a/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/event/ClaimIssuePayment.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/feesandpay/event/ClaimIssuePayment.java
@@ -52,6 +52,7 @@ public class ClaimIssuePayment implements CCDConfig<PCSCase, State, UserRole> {
             .grant(Permission.R, UserRole.DEFENDANT)
             .grant(Permission.R, UserRole.PCS_CASE_WORKER)
             .grant(Permission.R, UserRole.DEFENDANT_SOLICITOR)
+            .grant(Permission.R, UserRole.GA_DEFENDANT_SOLICITOR)
             .grant(Permission.R, UserRole.HEARING_CENTRE_ADMIN)
             .grant(Permission.R, UserRole.HEARING_CENTRE_TEAM_LEADER)
             .grant(Permission.R, UserRole.JUDGE)

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DefendantAccessTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DefendantAccessTest.java
@@ -22,5 +22,6 @@ class DefendantAccessTest {
         // then
         assertThat(grants.get(UserRole.DEFENDANT_SOLICITOR)).isEqualTo(Permission.CRU);
         assertThat(grants.get(UserRole.DEFENDANT)).isEqualTo(Permission.CRU);
+        assertThat(grants.get(UserRole.GA_DEFENDANT_SOLICITOR)).isEqualTo(Permission.CRU);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DefendantReadAccessTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DefendantReadAccessTest.java
@@ -17,5 +17,6 @@ class DefendantReadAccessTest {
 
         assertThat(grants.get(UserRole.DEFENDANT)).containsExactly(Permission.R);
         assertThat(grants.get(UserRole.DEFENDANT_SOLICITOR)).containsExactly(Permission.R);
+        assertThat(grants.get(UserRole.GA_DEFENDANT_SOLICITOR)).containsExactly(Permission.R);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DefendantSolicitorAccessTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DefendantSolicitorAccessTest.java
@@ -22,6 +22,7 @@ class DefendantSolicitorAccessTest {
 
         // then
         assertThat(grants.get(UserRole.DEFENDANT_SOLICITOR)).isEqualTo(Permission.CRUD);
+        assertThat(grants.get(UserRole.GA_DEFENDANT_SOLICITOR)).isEqualTo(Permission.CRUD);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DocumentAccessTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DocumentAccessTest.java
@@ -12,6 +12,7 @@ import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.CITIZEN;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT_SOLICITOR;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_CLAIMANT_SOLICITOR;
+import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_DEFENDANT_SOLICITOR;
 
 class DocumentAccessTest {
 
@@ -19,7 +20,8 @@ class DocumentAccessTest {
         CITIZEN,
         DEFENDANT,
         DEFENDANT_SOLICITOR,
-        GA_CLAIMANT_SOLICITOR
+        GA_CLAIMANT_SOLICITOR,
+        GA_DEFENDANT_SOLICITOR
     };
 
     private final DocumentAccess underTest = new DocumentAccess();


### PR DESCRIPTION
Stacked fix branch off `HDPI-8264-apply-groupAccess-toNoC` (PR #2423).

Currently empty apart from a placeholder README line — fixes to follow.