### PR TITLE
HDPI-8514: Put back user ID check for gen app visibility

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/citizen/UploadDocuments.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/citizen/UploadDocuments.java
@@ -67,10 +67,11 @@ public class UploadDocuments implements CCDConfig<PCSCase, State, UserRole> {
         }
 
         PcsCaseEntity pcsCaseEntity = pcsCaseService.loadCase(caseReference);
+        UUID currentUserId = securityContextService.getCurrentUserId();
         String organisationId = organisationService.getOrganisationIdForCurrentUser();
 
         List<ListValue<RelatedApplicationOption>> options =
-            visibleGenAppsForUser(pcsCaseEntity, organisationId).stream()
+            visibleGenAppsForUser(pcsCaseEntity, currentUserId, organisationId).stream()
                 .map(this::toOption)
                 .filter(Objects::nonNull)
                 .toList();
@@ -83,8 +84,15 @@ public class UploadDocuments implements CCDConfig<PCSCase, State, UserRole> {
         return caseData;
     }
 
-    private List<GenAppEntity> visibleGenAppsForUser(PcsCaseEntity pcsCaseEntity, String organisationId) {
-        return genAppVisibilityService.getVisibleGenAppsToUser(pcsCaseEntity.getGenApps(), organisationId);
+    private List<GenAppEntity> visibleGenAppsForUser(PcsCaseEntity pcsCaseEntity,
+                                                     UUID currentUserId,
+                                                     String organisationId) {
+
+        return genAppVisibilityService.getVisibleGenAppsToUser(
+            pcsCaseEntity.getGenApps(),
+            currentUserId,
+            organisationId
+        );
     }
 
     private ListValue<RelatedApplicationOption> toOption(GenAppEntity genApp) {
@@ -123,7 +131,7 @@ public class UploadDocuments implements CCDConfig<PCSCase, State, UserRole> {
         String organisationId = organisationService.getOrganisationIdForCurrentUser();
 
         PartyEntity uploadingParty = partyService.getPartyEntityByIdamId(currentUserId, caseReference);
-        GenAppEntity selectedGenApp = resolveSelectedGenApp(caseData, pcsCaseEntity, organisationId);
+        GenAppEntity selectedGenApp = resolveSelectedGenApp(caseData, pcsCaseEntity, currentUserId, organisationId);
 
         documentService.linkAdditionalDocumentsToCase(
             caseData.getUploadedAdditionalDocuments(),
@@ -135,7 +143,11 @@ public class UploadDocuments implements CCDConfig<PCSCase, State, UserRole> {
         return SubmitResponse.<State>builder().build();
     }
 
-    private GenAppEntity resolveSelectedGenApp(PCSCase caseData, PcsCaseEntity pcsCaseEntity, String organisationId) {
+    private GenAppEntity resolveSelectedGenApp(PCSCase caseData,
+                                               PcsCaseEntity pcsCaseEntity,
+                                               UUID currentUserId,
+                                               String organisationId) {
+
         DocumentUploadDetails details = caseData.getDocumentUploadDetails();
         if (details == null || details.getSelectedRelatedApplicationId() == null) {
             return null;
@@ -146,7 +158,7 @@ public class UploadDocuments implements CCDConfig<PCSCase, State, UserRole> {
         } catch (IllegalArgumentException e) {
             return null;
         }
-        return visibleGenAppsForUser(pcsCaseEntity, organisationId).stream()
+        return visibleGenAppsForUser(pcsCaseEntity, currentUserId, organisationId).stream()
             .filter(genApp -> selectedId.equals(genApp.getId()))
             .findFirst()
             .orElse(null);

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/legalrepdocumentupload/LegalRepDocumentUpload.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/legalrepdocumentupload/LegalRepDocumentUpload.java
@@ -13,9 +13,10 @@ import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
 import uk.gov.hmcts.reform.pcs.ccd.common.PageBuilder;
 import uk.gov.hmcts.reform.pcs.ccd.domain.PCSCase;
 import uk.gov.hmcts.reform.pcs.ccd.domain.State;
+import uk.gov.hmcts.reform.pcs.ccd.domain.genapp.GenAppType;
+import uk.gov.hmcts.reform.pcs.ccd.domain.legalrepdocumentupload.DocumentUploadCategory;
 import uk.gov.hmcts.reform.pcs.ccd.domain.legalrepdocumentupload.LegalRepDocument;
 import uk.gov.hmcts.reform.pcs.ccd.domain.legalrepdocumentupload.LegalRepDocumentUploadDetails;
-import uk.gov.hmcts.reform.pcs.ccd.domain.legalrepdocumentupload.DocumentUploadCategory;
 import uk.gov.hmcts.reform.pcs.ccd.entity.GenAppEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
@@ -26,7 +27,9 @@ import uk.gov.hmcts.reform.pcs.ccd.service.genapp.GenAppVisibilityService;
 import uk.gov.hmcts.reform.pcs.ccd.service.party.LegalRepForDefendantAccessValidator;
 import uk.gov.hmcts.reform.pcs.ccd.type.DynamicStringList;
 import uk.gov.hmcts.reform.pcs.ccd.type.DynamicStringListElement;
+import uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry;
 import uk.gov.hmcts.reform.pcs.reference.service.OrganisationService;
+import uk.gov.hmcts.reform.pcs.security.SecurityContextService;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -34,9 +37,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
-
-import uk.gov.hmcts.reform.pcs.ccd.domain.genapp.GenAppType;
-import uk.gov.hmcts.reform.pcs.postcodecourt.model.LegislativeCountry;
 
 import static uk.gov.hmcts.reform.pcs.ccd.event.EventId.legalRepDocumentUpload;
 
@@ -47,6 +47,7 @@ public class LegalRepDocumentUpload implements CCDConfig<PCSCase, State, UserRol
     private final LegalRepDocumentUploadConfigurer legalRepDocumentUploadConfigurer;
     private final PcsCaseService pcsCaseService;
     private final DocumentService documentService;
+    private final SecurityContextService securityContextService;
     private final GenAppVisibilityService genAppVisibilityService;
     private final OrganisationService organisationService;
     private final LegalRepForDefendantAccessValidator legalRepForDefendantAccessValidator;
@@ -74,6 +75,7 @@ public class LegalRepDocumentUpload implements CCDConfig<PCSCase, State, UserRol
         }
 
         PcsCaseEntity pcsCaseEntity = pcsCaseService.loadCase(caseReference);
+        UUID currentUserId = securityContextService.getCurrentUserId();
         String organisationId = organisationService.getOrganisationIdForCurrentUser();
 
         List<DynamicStringListElement> validCategoryItems =
@@ -83,7 +85,7 @@ public class LegalRepDocumentUpload implements CCDConfig<PCSCase, State, UserRol
                         return Stream.of(buildCategoryItem(category, category.name(), null));
                     }
 
-                    return findGenAppsForCategory(pcsCaseEntity, organisationId, category)
+                    return findGenAppsForCategory(pcsCaseEntity, currentUserId, organisationId, category)
                         .stream()
                         .map(genApp -> buildCategoryItem(
                             category, genApp.getId().toString(), genApp.getApplicationSubmittedDate()));
@@ -119,6 +121,7 @@ public class LegalRepDocumentUpload implements CCDConfig<PCSCase, State, UserRol
 
     List<GenAppEntity> findGenAppsForCategory(
         PcsCaseEntity pcsCaseEntity,
+        UUID currentUserId,
         String organisationId,
         DocumentUploadCategory category
     ) {
@@ -127,7 +130,7 @@ public class LegalRepDocumentUpload implements CCDConfig<PCSCase, State, UserRol
             return List.of();
         }
 
-        return visibleGenAppsForUser(pcsCaseEntity, organisationId).stream()
+        return visibleGenAppsForUser(pcsCaseEntity, currentUserId, organisationId).stream()
             .filter(genApp -> genApp.getType() == mapped)
             .filter(genApp -> genApp.getApplicationSubmittedDate() != null)
             .sorted(Comparator.comparing(GenAppEntity::getApplicationSubmittedDate).reversed())
@@ -143,11 +146,21 @@ public class LegalRepDocumentUpload implements CCDConfig<PCSCase, State, UserRol
         };
     }
 
-    private List<GenAppEntity> visibleGenAppsForUser(PcsCaseEntity pcsCaseEntity, String organisationId) {
-        return genAppVisibilityService.getVisibleGenAppsToUser(pcsCaseEntity.getGenApps(), organisationId);
+    private List<GenAppEntity> visibleGenAppsForUser(PcsCaseEntity pcsCaseEntity,
+                                                     UUID currentUserId,
+                                                     String organisationId) {
+        return genAppVisibilityService.getVisibleGenAppsToUser(
+            pcsCaseEntity.getGenApps(),
+            currentUserId,
+            organisationId
+        );
     }
 
-    private GenAppEntity resolveSelectedGenApp(PCSCase caseData, PcsCaseEntity pcsCaseEntity, String organisationId) {
+    private GenAppEntity resolveSelectedGenApp(PCSCase caseData,
+                                               PcsCaseEntity pcsCaseEntity,
+                                               UUID currentUserId,
+                                               String organisationId) {
+
         LegalRepDocumentUploadDetails details = caseData.getLegalRepDocumentUploadDetails();
 
         if (details == null || details.getValidCategories() == null) {
@@ -163,7 +176,7 @@ public class LegalRepDocumentUpload implements CCDConfig<PCSCase, State, UserRol
         } catch (IllegalArgumentException e) {
             return null;
         }
-        return visibleGenAppsForUser(pcsCaseEntity, organisationId).stream()
+        return visibleGenAppsForUser(pcsCaseEntity, currentUserId, organisationId).stream()
             .filter(genApp -> selectedId.equals(genApp.getId()))
             .findFirst()
             .orElse(null);
@@ -179,8 +192,9 @@ public class LegalRepDocumentUpload implements CCDConfig<PCSCase, State, UserRol
         Long caseReference = eventPayload.caseReference();
         PcsCaseEntity pcsCaseEntity = pcsCaseService.loadCase(caseReference);
         PCSCase pcsCase = eventPayload.caseData();
+        UUID currentUserId = securityContextService.getCurrentUserId();
         String organisationId = organisationService.getOrganisationIdForCurrentUser();
-        GenAppEntity selectedGenApp = resolveSelectedGenApp(pcsCase, pcsCaseEntity, organisationId);
+        GenAppEntity selectedGenApp = resolveSelectedGenApp(pcsCase, pcsCaseEntity, currentUserId, organisationId);
         PartyEntity party;
 
         if (selectedGenApp == null) {

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/task/ApplicationsTaskGroupEvaluator.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/dashboard/task/ApplicationsTaskGroupEvaluator.java
@@ -67,6 +67,7 @@ public class ApplicationsTaskGroupEvaluator implements TaskGroupEvaluator {
 
         return !genAppVisibilityService.getVisibleGenAppsToUser(
             ctx.caseEntity().getGenApps(),
+            userRoles.userId(),
             organisationService.getOrganisationIdForCurrentUser(),
             userRoles.roles()
         ).isEmpty();

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/genapp/GenAppVisibilityService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/genapp/GenAppVisibilityService.java
@@ -63,12 +63,16 @@ public class GenAppVisibilityService {
             return true;
         }
 
-        if (party == null || organisationId == null) {
+        if (party == null || userId == null) {
             return false;
         }
 
         if (userId.equals(party.getIdamId())) {
             return true;
+        }
+
+        if (organisationId == null) {
+            return false;
         }
 
         if (organisationId.equals(party.getOrganisationId())) {

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/genapp/GenAppVisibilityService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/genapp/GenAppVisibilityService.java
@@ -15,6 +15,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -35,11 +36,7 @@ public class GenAppVisibilityService {
     private static final String PCS_SOLICITOR_ROLE = UserRole.PCS_SOLICITOR.getRole();
 
     public boolean isGenAppVisibleToUser(GenAppEntity genAppEntity,
-                                         String organisationId) {
-        return isGenAppVisibleToUser(genAppEntity, organisationId, List.of());
-    }
-
-    public boolean isGenAppVisibleToUser(GenAppEntity genAppEntity,
+                                         UUID userId,
                                          String organisationId,
                                          Collection<String> currentUserRoles) {
         if (genAppEntity == null) {
@@ -54,18 +51,24 @@ public class GenAppVisibilityService {
             return true;
         }
 
-        return isWithoutNoticeVisibleToUser(genAppEntity.getParty(), organisationId, currentUserRoles);
+        return isWithoutNoticeVisibleToUser(genAppEntity.getParty(), userId, organisationId, currentUserRoles);
     }
 
     public boolean isWithoutNoticeVisibleToUser(PartyEntity party,
+                                                UUID userId,
                                                 String organisationId,
                                                 Collection<String> currentUserRoles) {
+
         if (isInternalUser(currentUserRoles)) {
             return true;
         }
 
         if (party == null || organisationId == null) {
             return false;
+        }
+
+        if (userId.equals(party.getIdamId())) {
+            return true;
         }
 
         if (organisationId.equals(party.getOrganisationId())) {
@@ -77,6 +80,7 @@ public class GenAppVisibilityService {
     }
 
     public boolean isGenAppDocumentVisibleToUser(GenAppEntity genAppEntity,
+                                                 UUID userId,
                                                  String organisationId,
                                                  Collection<String> currentUserRoles) {
         if (genAppEntity == null) {
@@ -84,17 +88,20 @@ public class GenAppVisibilityService {
         }
 
         if (genAppEntity.getWithoutNotice() == VerticalYesNo.YES) {
-            return isWithoutNoticeVisibleToUser(genAppEntity.getParty(), organisationId, currentUserRoles);
+            return isWithoutNoticeVisibleToUser(genAppEntity.getParty(), userId, organisationId, currentUserRoles);
         }
 
-        return isGenAppVisibleToUser(genAppEntity, organisationId, currentUserRoles);
-    }
-
-    public List<GenAppEntity> getVisibleGenAppsToUser(Collection<GenAppEntity> genApps, String organisationId) {
-        return getVisibleGenAppsToUser(genApps, organisationId, List.of());
+        return isGenAppVisibleToUser(genAppEntity, userId, organisationId, currentUserRoles);
     }
 
     public List<GenAppEntity> getVisibleGenAppsToUser(Collection<GenAppEntity> genApps,
+                                                      UUID userId,
+                                                      String organisationId) {
+        return getVisibleGenAppsToUser(genApps, userId, organisationId, List.of());
+    }
+
+    public List<GenAppEntity> getVisibleGenAppsToUser(Collection<GenAppEntity> genApps,
+                                                      UUID userId,
                                                       String organisationId,
                                                       Collection<String> currentUserRoles) {
         if (genApps == null || genApps.isEmpty()) {
@@ -107,7 +114,7 @@ public class GenAppVisibilityService {
                 GenAppEntity::getApplicationSubmittedDate,
                 Comparator.nullsLast(Comparator.reverseOrder())
             ))
-            .filter(genAppEntity -> isGenAppVisibleToUser(genAppEntity, organisationId, currentUserRoles))
+            .filter(genAppEntity -> isGenAppVisibleToUser(genAppEntity, userId, organisationId, currentUserRoles))
             .toList();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/DocumentsView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/DocumentsView.java
@@ -70,6 +70,7 @@ public class DocumentsView {
         if (genAppEntity != null) {
             return genAppVisibilityService.isGenAppDocumentVisibleToUser(
                 genAppEntity,
+                userRoles.userId(),
                 organisationId,
                 userRoles.roles()
             );
@@ -77,7 +78,8 @@ public class DocumentsView {
 
         if (documentEntity.getType() == DocumentType.WITHOUT_NOTICE_ORDER) {
             PartyEntity party = documentEntity.getParty();
-            return genAppVisibilityService.isWithoutNoticeVisibleToUser(party, organisationId, userRoles.roles());
+            return genAppVisibilityService
+                .isWithoutNoticeVisibleToUser(party, userRoles.userId(), organisationId, userRoles.roles());
         }
 
         CounterClaimEntity counterClaim = documentEntity.getCounterClaim();

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/GenAppsView.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/view/GenAppsView.java
@@ -47,6 +47,7 @@ public class GenAppsView {
             .sorted(Comparator.comparing(GenAppEntity::getApplicationSubmittedDate).reversed())
             .filter(genAppEntity -> genAppVisibilityService.isGenAppVisibleToUser(
                 genAppEntity,
+                userRoles.userId(),
                 organisationId,
                 userRoles.roles()
             ))

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/citizen/UploadDocumentsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/citizen/UploadDocumentsTest.java
@@ -68,7 +68,7 @@ class UploadDocumentsTest extends BaseEventTest {
 
         // Default: visibility service is identity (returns input unchanged). Individual tests
         // override to simulate hiding without-notice gen apps or to control ordering.
-        lenient().when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any()))
+        lenient().when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any(), any()))
             .thenAnswer(invocation -> {
                 Collection<GenAppEntity> input = invocation.getArgument(0);
                 return input == null ? List.<GenAppEntity>of() : new ArrayList<>(input);
@@ -177,7 +177,7 @@ class UploadDocumentsTest extends BaseEventTest {
             GenAppEntity hidden = mock(GenAppEntity.class);
             lenient().when(hidden.getId()).thenReturn(hiddenId);
             when(pcsCaseEntity.getGenApps()).thenReturn(Set.of(hidden));
-            when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any())).thenReturn(List.of());
+            when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any(), any())).thenReturn(List.of());
 
             PCSCase caseData = PCSCase.builder()
                 .documentUploadDetails(DocumentUploadDetails.builder()
@@ -312,7 +312,7 @@ class UploadDocumentsTest extends BaseEventTest {
             GenAppEntity oldest = stubGenApp(GenAppType.ADJOURN, now.minusDays(10));
 
             // Bypass the identity stub: return entities in the order the service would.
-            when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any()))
+            when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any(), any()))
                 .thenReturn(List.of(newest, middle, oldest));
             when(pcsCaseEntity.getGenApps()).thenReturn(Set.of(newest, middle, oldest));
 
@@ -333,7 +333,7 @@ class UploadDocumentsTest extends BaseEventTest {
             GenAppEntity olderAdjourn = stubGenApp(GenAppType.ADJOURN, older);
             GenAppEntity newerAdjourn = stubGenApp(GenAppType.ADJOURN, newer);
 
-            when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any()))
+            when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any(), any()))
                 .thenReturn(List.of(newerAdjourn, olderAdjourn));
             when(pcsCaseEntity.getGenApps()).thenReturn(Set.of(newerAdjourn, olderAdjourn));
 
@@ -372,7 +372,7 @@ class UploadDocumentsTest extends BaseEventTest {
             // frontend skips the confirm page.
             GenAppEntity hidden = stubGenApp(GenAppType.SOMETHING_ELSE, LocalDateTime.now());
             when(pcsCaseEntity.getGenApps()).thenReturn(Set.of(hidden));
-            when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any())).thenReturn(List.of());
+            when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any(), any())).thenReturn(List.of());
 
             PCSCase result = callStartHandler(PCSCase.builder().build());
 
@@ -388,7 +388,7 @@ class UploadDocumentsTest extends BaseEventTest {
             GenAppEntity visibleWithNotice = stubGenApp(GenAppType.ADJOURN, now);
             GenAppEntity hiddenWithoutNotice = stubGenApp(GenAppType.SOMETHING_ELSE, now.minusDays(1));
             when(pcsCaseEntity.getGenApps()).thenReturn(Set.of(visibleWithNotice, hiddenWithoutNotice));
-            when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any()))
+            when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any(), any()))
                 .thenReturn(List.of(visibleWithNotice));
 
             PCSCase result = callStartHandler(PCSCase.builder().build());

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/legalrepdocumentupload/LegalRepDocumentUploadTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/legalrepdocumentupload/LegalRepDocumentUploadTest.java
@@ -28,6 +28,7 @@ import uk.gov.hmcts.reform.pcs.ccd.service.party.LegalRepForDefendantAccessValid
 import uk.gov.hmcts.reform.pcs.ccd.type.DynamicStringList;
 import uk.gov.hmcts.reform.pcs.ccd.type.DynamicStringListElement;
 import uk.gov.hmcts.reform.pcs.reference.service.OrganisationService;
+import uk.gov.hmcts.reform.pcs.security.SecurityContextService;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -57,6 +58,9 @@ class LegalRepDocumentUploadTest extends BaseEventTest {
 
     @Mock
     private DocumentService documentService;
+
+    @Mock
+    private SecurityContextService securityContextService;
 
     @Mock
     private OrganisationService organisationService;
@@ -126,7 +130,7 @@ class LegalRepDocumentUploadTest extends BaseEventTest {
         when(pcsCaseService.loadCase(TEST_CASE_REFERENCE))
             .thenReturn(PcsCaseEntity.builder().build());
 
-        when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any()))
+        when(genAppVisibilityService.getVisibleGenAppsToUser(any(), any(), any()))
             .thenReturn(List.of(earlierAdjournApp, laterAdjournApp, generalApp, generalAppWithNullDate));
 
         PCSCase result = callStartHandler(PCSCase.builder().build());
@@ -223,6 +227,7 @@ class LegalRepDocumentUploadTest extends BaseEventTest {
 
         assertThat(legalRepDocumentUpload.findGenAppsForCategory(
             PcsCaseEntity.builder().build(),
+            UUID.randomUUID(),
             orgId,
             DocumentUploadCategory.MAIN_CLAIM_OR_COUNTERCLAIM))
             .isEmpty();
@@ -234,6 +239,7 @@ class LegalRepDocumentUploadTest extends BaseEventTest {
         String description = "test description";
         UUID selectedId = UUID.randomUUID();
         UUID currentUserId = UUID.randomUUID();
+        when(securityContextService.getCurrentUserId()).thenReturn(currentUserId);
 
         Document document = Document.builder()
             .filename("test filename")
@@ -269,7 +275,7 @@ class LegalRepDocumentUploadTest extends BaseEventTest {
         when(selectedGenApp.getId()).thenReturn(selectedId);
         when(pcsCaseEntity.getGenApps()).thenReturn(Set.of(selectedGenApp));
         List<GenAppEntity> mockGenAppList = List.of(selectedGenApp);
-        when(genAppVisibilityService.getVisibleGenAppsToUser(Set.of(selectedGenApp), orgId))
+        when(genAppVisibilityService.getVisibleGenAppsToUser(Set.of(selectedGenApp), currentUserId, orgId))
             .thenReturn(mockGenAppList);
         when(selectedGenApp.getParty()).thenReturn(currentUserParty);
 

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/genapp/GenAppVisibilityServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/genapp/GenAppVisibilityServiceTest.java
@@ -81,7 +81,8 @@ class GenAppVisibilityServiceTest {
 
     @ParameterizedTest
     @MethodSource("withoutNoticeScenarios")
-    void shouldBaseVisibilityOfWithoutNoticeGenAppsOnUserIds(String organisationId,
+    void shouldBaseVisibilityOfWithoutNoticeGenAppsOnUserIds(UUID applicantUserId,
+                                                             String organisationId,
                                                              boolean isLegalRepresentativeLinkedToPartyAndActive,
                                                              boolean expectedIsVisible) {
         // Given
@@ -93,6 +94,7 @@ class GenAppVisibilityServiceTest {
 
         UUID applicantPartyId = UUID.randomUUID();
         when(applicantParty.getId()).thenReturn(applicantPartyId);
+        when(applicantParty.getIdamId()).thenReturn(applicantUserId);
         when(applicantParty.getOrganisationId()).thenReturn(organisationId);
 
         when(organisationRepository
@@ -279,23 +281,41 @@ class GenAppVisibilityServiceTest {
     }
 
     private static Stream<Arguments> withoutNoticeScenarios() {
+        UUID differentUserId = UUID.randomUUID();
         String differentOrganisationId = UUID.randomUUID().toString();
 
         return Stream.of(
             Arguments.argumentSet(
-                "current user is applicant",
+                "current user is applicant and not in an org",
+                CURRENT_USER_ID,
+                null,
+                false, // isLegalRepresentativeLinkedToPartyAndActive
+                true
+            ),
+            Arguments.argumentSet(
+                "current user is applicant and in a different org",
+                CURRENT_USER_ID,
+                differentOrganisationId,
+                false, // isLegalRepresentativeLinkedToPartyAndActive
+                true
+            ),
+            Arguments.argumentSet(
+                "current user not applicant but in same org",
+                differentUserId,
                 ORG_ID,
                 false, // isLegalRepresentativeLinkedToPartyAndActive
                 true
             ),
             Arguments.argumentSet(
                 "current user is LR of applicant",
+                differentUserId,
                 differentOrganisationId,
                 true, // isLegalRepresentativeLinkedToPartyAndActive
                 true
             ),
             Arguments.argumentSet(
-                "current user is not LR of applicant",
+                "current user not applicant, nor in same org nor LR of applicant",
+                differentUserId,
                 differentOrganisationId,
                 false, // isLegalRepresentativeLinkedToPartyAndActive
                 false

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/genapp/GenAppVisibilityServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/genapp/GenAppVisibilityServiceTest.java
@@ -18,8 +18,8 @@ import uk.gov.hmcts.reform.pcs.ccd.entity.GenAppEntity;
 import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
 import uk.gov.hmcts.reform.pcs.ccd.repository.legalrepresentative.OrganisationRepository;
 
-import java.util.Arrays;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -35,6 +35,7 @@ import static uk.gov.hmcts.reform.pcs.ccd.domain.genapp.GenAppState.GEN_APP_ISSU
 @ExtendWith(MockitoExtension.class)
 class GenAppVisibilityServiceTest {
 
+    private static final UUID CURRENT_USER_ID = UUID.randomUUID();
     private static final String ORG_ID = "org";
 
     @Mock(strictness = Mock.Strictness.LENIENT)
@@ -56,7 +57,7 @@ class GenAppVisibilityServiceTest {
         when(genAppEntity.getState()).thenReturn(state);
 
         // When
-        boolean genAppVisibleToUser = underTest.isGenAppVisibleToUser(genAppEntity, ORG_ID);
+        boolean genAppVisibleToUser = underTest.isGenAppVisibleToUser(genAppEntity, CURRENT_USER_ID, ORG_ID, List.of());
 
         // Then
         assertThat(genAppVisibleToUser).isFalse();
@@ -72,7 +73,7 @@ class GenAppVisibilityServiceTest {
         when(genAppEntity.getWithoutNotice()).thenReturn(isWithoutNotice);
 
         // When
-        boolean genAppVisibleToUser = underTest.isGenAppVisibleToUser(genAppEntity, ORG_ID);
+        boolean genAppVisibleToUser = underTest.isGenAppVisibleToUser(genAppEntity, CURRENT_USER_ID, ORG_ID, List.of());
 
         // Then
         assertThat(genAppVisibleToUser).isTrue();
@@ -99,7 +100,7 @@ class GenAppVisibilityServiceTest {
                 .thenReturn(isLegalRepresentativeLinkedToPartyAndActive);
 
         // When
-        boolean genAppVisibleToUser = underTest.isGenAppVisibleToUser(genAppEntity, ORG_ID);
+        boolean genAppVisibleToUser = underTest.isGenAppVisibleToUser(genAppEntity, CURRENT_USER_ID, ORG_ID, List.of());
 
         // Then
         assertThat(genAppVisibleToUser).isEqualTo(expectedIsVisible);
@@ -116,6 +117,7 @@ class GenAppVisibilityServiceTest {
         // When
         boolean genAppVisibleToUser = underTest.isGenAppVisibleToUser(
             genAppEntity,
+            CURRENT_USER_ID,
             null,
             List.of(internalRole.getRole())
         );
@@ -132,6 +134,7 @@ class GenAppVisibilityServiceTest {
         // When
         boolean documentVisibleToUser = underTest.isWithoutNoticeVisibleToUser(
             party,
+            CURRENT_USER_ID,
             null,
             List.of(UserRole.PCS_CASE_WORKER.getRole())
         );
@@ -148,6 +151,7 @@ class GenAppVisibilityServiceTest {
         // When
         boolean documentVisibleToUser = underTest.isWithoutNoticeVisibleToUser(
             party,
+            CURRENT_USER_ID,
             null,
             List.of(UserRole.PCS_CASE_WORKER.getRole(), UserRole.PCS_SOLICITOR.getRole())
         );
@@ -174,6 +178,7 @@ class GenAppVisibilityServiceTest {
         // When
         boolean documentVisibleToUser = underTest.isGenAppDocumentVisibleToUser(
             genAppEntity,
+            CURRENT_USER_ID,
             ORG_ID,
             List.of()
         );
@@ -193,7 +198,8 @@ class GenAppVisibilityServiceTest {
             .thenReturn(true);
 
         // When
-        boolean documentVisibleToUser = underTest.isWithoutNoticeVisibleToUser(party, ORG_ID, List.of());
+        boolean documentVisibleToUser
+            = underTest.isWithoutNoticeVisibleToUser(party, CURRENT_USER_ID, ORG_ID, List.of());
 
         // Then
         assertThat(documentVisibleToUser).isTrue();
@@ -201,7 +207,8 @@ class GenAppVisibilityServiceTest {
 
     @Test
     void shouldHideNullGenAppDocument() {
-        assertThat(underTest.isGenAppDocumentVisibleToUser(null, ORG_ID, List.of())).isFalse();
+        assertThat(underTest.isGenAppDocumentVisibleToUser(null, CURRENT_USER_ID,  ORG_ID, List.of()))
+            .isFalse();
     }
 
     @Test
@@ -229,6 +236,7 @@ class GenAppVisibilityServiceTest {
         // When
         List<GenAppEntity> visibleGenApps = underTest.getVisibleGenAppsToUser(
             List.of(pendingGenApp, hiddenWithoutNoticeGenApp, visibleWithNoticeGenApp),
+            CURRENT_USER_ID,
             ORG_ID
         );
 
@@ -255,6 +263,7 @@ class GenAppVisibilityServiceTest {
         // When
         List<GenAppEntity> visibleGenApps = underTest.getVisibleGenAppsToUser(
             Arrays.asList(olderWithoutNoticeGenApp, null, newerWithoutNoticeGenApp),
+            CURRENT_USER_ID,
             ORG_ID,
             List.of(UserRole.JUDGE.getRole())
         );
@@ -265,8 +274,8 @@ class GenAppVisibilityServiceTest {
 
     @Test
     void shouldReturnEmptyVisibleGenAppsWhenInputIsNullOrEmpty() {
-        assertThat(underTest.getVisibleGenAppsToUser(null, ORG_ID)).isEmpty();
-        assertThat(underTest.getVisibleGenAppsToUser(List.of(), ORG_ID, List.of())).isEmpty();
+        assertThat(underTest.getVisibleGenAppsToUser(null, CURRENT_USER_ID, ORG_ID)).isEmpty();
+        assertThat(underTest.getVisibleGenAppsToUser(List.of(), CURRENT_USER_ID, ORG_ID, List.of())).isEmpty();
     }
 
     private static Stream<Arguments> withoutNoticeScenarios() {

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/DocumentsViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/DocumentsViewTest.java
@@ -206,11 +206,13 @@ class DocumentsViewTest {
     void shouldFilterGenAppDocumentsBasedOnVisibility() {
         // Given
         GenAppEntity genAppEntity1 = mock(GenAppEntity.class);
-        when(genAppVisibilityService.isGenAppDocumentVisibleToUser(genAppEntity1, ORGANISATION_ID, List.of()))
+        when(genAppVisibilityService
+                 .isGenAppDocumentVisibleToUser(genAppEntity1, CURRENT_USER_ID, ORGANISATION_ID, List.of()))
             .thenReturn(true);
 
         GenAppEntity genAppEntity2 = mock(GenAppEntity.class);
-        when(genAppVisibilityService.isGenAppDocumentVisibleToUser(genAppEntity2, ORGANISATION_ID, List.of()))
+        when(genAppVisibilityService
+                 .isGenAppDocumentVisibleToUser(genAppEntity2, CURRENT_USER_ID, ORGANISATION_ID, List.of()))
             .thenReturn(false);
 
         UUID document1Id = UUID.randomUUID();
@@ -259,7 +261,8 @@ class DocumentsViewTest {
     void shouldHideDocumentLinkedToWithoutNoticeGenAppWhenGenAppIsNotVisibleToUser() {
         // Given
         GenAppEntity withoutNoticeGenApp = mock(GenAppEntity.class);
-        when(genAppVisibilityService.isGenAppDocumentVisibleToUser(withoutNoticeGenApp, ORGANISATION_ID, List.of()))
+        when(genAppVisibilityService
+                 .isGenAppDocumentVisibleToUser(withoutNoticeGenApp, CURRENT_USER_ID, ORGANISATION_ID, List.of()))
             .thenReturn(false);
 
         DocumentEntity documentEntity = DocumentEntity.builder()
@@ -282,7 +285,8 @@ class DocumentsViewTest {
     void shouldHideStandaloneWithoutNoticeOrderWhenPartyScopedRuleDoesNotAllowAccess() {
         // Given
         PartyEntity relatedParty = PartyEntity.builder().id(UUID.randomUUID()).build();
-        when(genAppVisibilityService.isWithoutNoticeVisibleToUser(relatedParty, ORGANISATION_ID, List.of()))
+        when(genAppVisibilityService
+                 .isWithoutNoticeVisibleToUser(relatedParty, CURRENT_USER_ID, ORGANISATION_ID, List.of()))
             .thenReturn(false);
 
         DocumentEntity documentEntity = DocumentEntity.builder()
@@ -306,7 +310,8 @@ class DocumentsViewTest {
     void shouldShowStandaloneWithoutNoticeOrderWhenPartyScopedRuleAllowsAccess() {
         // Given
         PartyEntity relatedParty = PartyEntity.builder().id(UUID.randomUUID()).build();
-        when(genAppVisibilityService.isWithoutNoticeVisibleToUser(relatedParty, ORGANISATION_ID, List.of()))
+        when(genAppVisibilityService
+                 .isWithoutNoticeVisibleToUser(relatedParty, CURRENT_USER_ID, ORGANISATION_ID, List.of()))
             .thenReturn(true);
 
         DocumentEntity documentEntity = DocumentEntity.builder()

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/GenAppsViewTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/view/GenAppsViewTest.java
@@ -61,6 +61,7 @@ class GenAppsViewTest {
             .thenReturn(new UserRoles(CURRENT_USER_IDAM_ID, List.of()));
         lenient().when(genAppVisibilityService.isGenAppVisibleToUser(
             isA(GenAppEntity.class),
+            eq(CURRENT_USER_IDAM_ID),
             eq(ORGANISATION_ID),
             eq(List.of())
         ))
@@ -131,19 +132,22 @@ class GenAppsViewTest {
         UUID genApp1Id = UUID.randomUUID();
         LocalDateTime genApp1SubmittedDate = LocalDateTime.parse("2026-05-02T15:00:00");
         GenAppEntity genAppEntity1 = createGenAppEntity(genApp1Id, genApp1SubmittedDate);
-        when(genAppVisibilityService.isGenAppVisibleToUser(genAppEntity1, ORGANISATION_ID, List.of()))
+        when(genAppVisibilityService
+                 .isGenAppVisibleToUser(genAppEntity1, CURRENT_USER_IDAM_ID, ORGANISATION_ID, List.of()))
             .thenReturn(true);
 
         UUID genApp2Id = UUID.randomUUID();
         LocalDateTime genApp2SubmittedDate = LocalDateTime.parse("2026-05-04T10:00:00");
         GenAppEntity genAppEntity2 = createGenAppEntity(genApp2Id, genApp2SubmittedDate);
-        when(genAppVisibilityService.isGenAppVisibleToUser(genAppEntity2, ORGANISATION_ID, List.of()))
+        when(genAppVisibilityService
+                 .isGenAppVisibleToUser(genAppEntity2, CURRENT_USER_IDAM_ID, ORGANISATION_ID, List.of()))
             .thenReturn(false);
 
         UUID genApp3Id = UUID.randomUUID();
         LocalDateTime genApp3SubmittedDate = LocalDateTime.parse("2026-05-04T09:00:00");
         GenAppEntity genAppEntity3 = createGenAppEntity(genApp3Id, genApp3SubmittedDate);
-        when(genAppVisibilityService.isGenAppVisibleToUser(genAppEntity3, ORGANISATION_ID, List.of()))
+        when(genAppVisibilityService
+                 .isGenAppVisibleToUser(genAppEntity3, CURRENT_USER_IDAM_ID, ORGANISATION_ID, List.of()))
             .thenReturn(true);
 
         when(pcsCaseEntity.getGenApps()).thenReturn(Set.of(genAppEntity1, genAppEntity2, genAppEntity3));


### PR DESCRIPTION
### Jira link

See [HDPI-8514](https://tools.hmcts.net/jira/browse/HDPI-8514)

### Change description

A recently merged PR https://github.com/hmcts/pcs-api/pull/1848 changed the gen app visibility logic to use the current users organisation ID rather than their individual IDAM ID. This is fine for professional users, but not citizens who won't have an organisation ID. This PR adds the individual user IDAM ID logic back in so that citizens can see their own Without Notice gen apps again.

pcs-frontend PR for testing: https://github.com/hmcts/pcs-frontend/pull/1948

### Testing done

Build run with e2e regression tests enabled.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

### PCS checklist

- [ ] New functional test classes carry the gating annotations (`@EnabledIfEnvironmentVariable(named = "CCD_ENABLED", ...)` + shutter guard) unless they must run on unlabelled PRs (HDPI-8084)
- [ ] Infrastructure / chart / suppression changes have a second pair of eyes from the service admins (HDPI-8153)
