### PR TITLE
HDPI-6586: Remove rogue space that wasn't obvious in the modeller UI

### DIFF
--- a/src/main/resources/dmn/wa-task-configuration-possession_service.dmn
+++ b/src/main/resources/dmn/wa-task-configuration-possession_service.dmn
@@ -477,7 +477,7 @@ Short name</description>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1tvak6q">
-          <text>"NewClaimCreateNewHearing", "Review DefendantResponseAndCounterclaim", "ReviewAdditionalDocumentsClaim", "ReviewAdditionalDocumentsGenApp", "ReviewAdditionalDocumentsCounterclaim", "ReviewCaseFlagRequest", "ReviewCaseFlag", "ReviewFailedPayment", "ReviewDateDue", "TranslateDefendantSubmittedDocument", "TranslateClaimantSubmittedDocument", "TranslateCaseworkerUploadedDocument"</text>
+          <text>"NewClaimCreateNewHearing", "ReviewDefendantResponseAndCounterclaim", "ReviewAdditionalDocumentsClaim", "ReviewAdditionalDocumentsGenApp", "ReviewAdditionalDocumentsCounterclaim", "ReviewCaseFlagRequest", "ReviewCaseFlag", "ReviewFailedPayment", "ReviewDateDue", "TranslateDefendantSubmittedDocument", "TranslateClaimantSubmittedDocument", "TranslateCaseworkerUploadedDocument"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_14ewc8f">
           <text>"dueDateIntervalDays"</text>


### PR DESCRIPTION
### Jira link

See [HDPI-6586](https://tools.hmcts.net/jira/browse/HDPI-6586)

### Change description

Remove a rogue space that wasn't obvious in Camunda Modeller as it was on a line wrap. This space means that the `dueDateIntervalDays` row does not match the task type and it is given a due date of today instead of in 5 days

### Testing done

Tested in preview

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

### PCS checklist

- [ ] New functional test classes carry the gating annotations (`@EnabledIfEnvironmentVariable(named = "CCD_ENABLED", ...)` + shutter guard) unless they must run on unlabelled PRs (HDPI-8084)
- [ ] Infrastructure / chart / suppression changes have a second pair of eyes from the service admins (HDPI-8153)
