### PR TITLE
Update CFTLib to 0.19.2346

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
   id 'org.sonarqube' version '7.3.1.8318'
   id 'net.serenity-bdd.serenity-gradle-plugin' version "$serenityBddVersion"
   id 'hmcts.ccd.sdk' version '6.33.0'
-  id 'com.github.hmcts.rse-cft-lib' version '0.19.2315'
+  id 'com.github.hmcts.rse-cft-lib' version '0.19.2346'
   id 'io.freefair.lombok' version '9.5.0'
   id 'au.com.dius.pact' version '4.7.4'
   id "com.avast.gradle.docker-compose" version "0.17.21"


### PR DESCRIPTION
Update to the CFTLib release containing aligned JUnit Platform dependencies, preventing the PCS CFTLib test runtime from loading incompatible embedded Platform classes.