### PR TITLE
HDPI-5794: skip rd-professional org lookup for citizens

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/reference/service/OrganisationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/reference/service/OrganisationService.java
@@ -4,8 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ccd.sdk.type.AddressUK;
+import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
 import uk.gov.hmcts.reform.pcs.exception.OrganisationDetailsException;
 import uk.gov.hmcts.reform.pcs.exception.SecurityContextException;
+import uk.gov.hmcts.reform.pcs.idam.UserInfo;
 import uk.gov.hmcts.reform.pcs.security.SecurityContextService;
 
 import java.util.UUID;
@@ -32,7 +34,7 @@ public class OrganisationService {
      */
     public String getOrganisationNameForCurrentUser() {
         try {
-            UUID userId = resolveUserId();
+            UUID userId = resolveProfessionalUserId();
 
             if (userId == null) {
                 return null;
@@ -61,7 +63,7 @@ public class OrganisationService {
      */
     public String getOrganisationIdForCurrentUser() {
         try {
-            UUID userId = resolveUserId();
+            UUID userId = resolveProfessionalUserId();
 
             if (userId == null) {
                 return null;
@@ -86,7 +88,7 @@ public class OrganisationService {
     public AddressUK getOrganisationAddressForCurrentUser() {
 
         try {
-            UUID userId = resolveUserId();
+            UUID userId = resolveProfessionalUserId();
 
             if (userId == null) {
                 return null;
@@ -109,12 +111,21 @@ public class OrganisationService {
         }
     }
 
-    private UUID resolveUserId() {
+    private UUID resolveProfessionalUserId() {
+        if (currentUserIsCitizen()) {
+            return null;
+        }
         UUID userId = securityContextService.getCurrentUserId();
         if (userId == null) {
             log.warn("User ID is null from security context, cannot fetch organisation details");
         }
         return userId;
+    }
+
+    private boolean currentUserIsCitizen() {
+        UserInfo details = securityContextService.getCurrentUserDetails();
+        return details != null && details.getRoles() != null
+            && details.getRoles().contains(UserRole.CITIZEN.getRole());
     }
 
     private boolean keyAddressFieldsEmpty(AddressUK organisationAddress) {

--- a/src/test/java/uk/gov/hmcts/reform/pcs/reference/service/OrganisationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/reference/service/OrganisationServiceTest.java
@@ -7,10 +7,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.sdk.type.AddressUK;
+import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
 import uk.gov.hmcts.reform.pcs.exception.OrganisationDetailsException;
 import uk.gov.hmcts.reform.pcs.exception.SecurityContextException;
+import uk.gov.hmcts.reform.pcs.idam.UserInfo;
 import uk.gov.hmcts.reform.pcs.security.SecurityContextService;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -228,5 +231,17 @@ class OrganisationServiceTest {
         assertThat(result).isEqualTo(orgAddress);
         verify(securityContextService).getCurrentUserId();
         verify(organisationDetailsService).getOrganisationAddress(USER_ID.toString());
+    }
+
+    @Test
+    @DisplayName("Should skip the rd-professional lookup for a citizen user")
+    void shouldSkipOrganisationLookupForCitizen() {
+        when(securityContextService.getCurrentUserDetails())
+            .thenReturn(UserInfo.builder().roles(List.of(UserRole.CITIZEN.getRole())).build());
+
+        String result = organisationService.getOrganisationIdForCurrentUser();
+
+        assertThat(result).isNull();
+        verify(organisationDetailsService, never()).getOrganisationIdentifier(anyString());
     }
 }


### PR DESCRIPTION
### Jira link

See [HDPI-5794](https://tools.hmcts.net/jira/browse/HDPI-5794)

### Change description

Citizens have no professional organisation, so skip the rd-professional lookup for them on case
load — it returned a benign `404` that was logged as an error, filling `pcs-aat` App Insights.

### Testing done

`OrganisationServiceTest` — 14 tests green (13 existing + 1 new `shouldSkipOrganisationLookupForCitizen`,
asserting a citizen returns `null` and `organisationDetailsService` is never called).

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change — No

### PCS checklist

- [x] New functional test classes carry the gating annotations (`@EnabledIfEnvironmentVariable(named = "CCD_ENABLED", ...)` + shutter guard) unless they must run on unlabelled PRs (HDPI-8084) — N/A, unit test only
- [x] Infrastructure / chart / suppression changes have a second pair of eyes from the service admins (HDPI-8153) — N/A, no chart/infra changes
