### PR TITLE
HDPI-8305: Add idempotencyKey for Camunda tasks

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/camunda/CamundaRequestTaskData.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/camunda/CamundaRequestTaskData.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.UUID;
+
 @Data
 @Builder
 @AllArgsConstructor
@@ -21,5 +23,7 @@ public class CamundaRequestTaskData {
     private final TaskType taskType;
 
     private final String taskDescription;
+
+    private final UUID idempotencyKey;
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/camunda/CamundaService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/camunda/CamundaService.java
@@ -66,6 +66,7 @@ public class CamundaService {
             .caseReference(caseId)
             .taskType(taskType)
             .taskDescription(taskDescription)
+            .idempotencyKey(UUID.randomUUID())
             .build();
 
         scheduleCamundaRequest(taskData, scheduledTo);
@@ -83,9 +84,17 @@ public class CamundaService {
     void handleRequest(CamundaRequestTaskData taskData) {
         switch (taskData.getAction()) {
             case CREATE ->
-                requestTaskCreation(taskData.getCaseReference(), taskData.getTaskType(), taskData.getTaskDescription());
+                requestTaskCreation(
+                    taskData.getCaseReference(),
+                    taskData.getTaskType(),
+                    taskData.getTaskDescription(),
+                    taskData.getIdempotencyKey()
+                );
             case CANCEL ->
-                requestTaskCancellation(taskData.getCaseReference(), taskData.getTaskType());
+                requestTaskCancellation(
+                    taskData.getCaseReference(),
+                    taskData.getTaskType()
+                );
         }
     }
 
@@ -102,7 +111,7 @@ public class CamundaService {
                 .scheduledTo(scheduledTo));
     }
 
-    private void requestTaskCreation(Long caseId, TaskType taskType, String taskDescription) {
+    private void requestTaskCreation(long caseId, TaskType taskType, String taskDescription, UUID idempotencyKey) {
         if (!featureToggleService.isEnabled(FeatureFlag.CASEWORKER_WA)) {
             log.info("Skipped creating task for {}", caseId);
             return;
@@ -125,11 +134,16 @@ public class CamundaService {
         processVariables.put("name", dmnStringValue(taskType.getName()));
         processVariables.put("taskDescription", dmnStringValue(taskDescription));
         processVariables.put("taskId", dmnStringValue(taskType.getId()));
-        processVariables.put("caseId", dmnStringValue(caseId.toString()));
+        processVariables.put("caseId", dmnStringValue(Long.toString(caseId)));
         processVariables.put("delayUntil", dmnStringValue(delayUntil.format(ISO_LOCAL_DATE_TIME)));
         processVariables.put("hasWarnings", dmnBooleanValue(false));
         processVariables.put("warningList", dmnStringValue(EMPTY_WARNINGS_LIST));
         processVariables.put("__processCategory__" + taskType.getId(), dmnBooleanValue(true));
+        if (idempotencyKey != null) {
+            processVariables.put("idempotencyKey", dmnStringValue(idempotencyKey.toString()));
+        } else {
+            log.warn("No idempotency key provided for task of type {}", taskType);
+        }
 
         // Default values - WA task due date is configured in configuration dmn
         LocalDateTime dueDate = LocalDateTime.of(2050, 1, 1, 17, 0, 0);

--- a/src/main/resources/templates/workallocation/claim-review-additional-docs.peb
+++ b/src/main/resources/templates/workallocation/claim-review-additional-docs.peb
@@ -1,14 +1,13 @@
-### Review Documents
+### Review additional documents - claim
 
-Additional documents have been uploaded to the claim by {{partyLabel}}:
+Additional documents have been uploaded to the claim by {{partyLabel}}. Review the additional documents submitted on the claim in
+<a href="/cases/case-details/PCS/PCS/{{caseReference}}#Case%20File%20View">Case File View</a>, check whether any
+further case action is required, and take the appropriate action. Only mark the task as complete once the documents
+have been reviewed and any required action has been completed.
 
+Documents:
 <ul class="govuk-list govuk-list--bullet">
   {% for filename in filenames %}
   <li class="govuk-!-font-size-19">{{filename}}</li>
   {% endfor %}
 </ul>
-
-Review the additional documents submitted on the claim in
-<a href="/cases/case-details/PCS/PCS/{{caseReference}}#Case%20File%20View">Case File View</a>, check whether any
-further case action is required, and take the appropriate action. Only mark the task as complete once the documents
-have been reviewed and any required action has been completed.

--- a/src/main/resources/templates/workallocation/gen-app-review-additional-docs.peb
+++ b/src/main/resources/templates/workallocation/gen-app-review-additional-docs.peb
@@ -1,14 +1,14 @@
-### Review Documents
+### Review additional documents – gen app
 
-Additional documents have been uploaded to general application GA{{genAppRank}} by {{partyLabel}}:
+Additional documents have been uploaded to general application GA{{genAppRank}} by {{partyLabel}}, Review the
+additional documents submitted for the general application in
+<a href="/cases/case-details/PCS/PCS/{{caseReference}}#Case%20File%20View">Case File View</a>, check whether any
+further case action is required, and take the appropriate action. Only mark the task as complete once the documents
+have been reviewed and any required action has been completed.
 
+Documents:
 <ul class="govuk-list govuk-list--bullet">
   {% for filename in filenames %}
   <li class="govuk-!-font-size-19">{{filename}}</li>
   {% endfor %}
 </ul>
-
-Review the additional documents submitted for the general application in
-<a href="/cases/case-details/PCS/PCS/{{caseReference}}#Case%20File%20View">Case File View</a>, check whether any
-further case action is required, and take the appropriate action. Only mark the task as complete once the documents
-have been reviewed and any required action has been completed.

--- a/src/main/resources/templates/workallocation/gen-app-review-additional-docs.peb
+++ b/src/main/resources/templates/workallocation/gen-app-review-additional-docs.peb
@@ -1,6 +1,6 @@
 ### Review additional documents – gen app
 
-Additional documents have been uploaded to general application GA{{genAppRank}} by {{partyLabel}}, Review the
+Additional documents have been uploaded to general application GA{{genAppRank}} by {{partyLabel}}. Review the
 additional documents submitted for the general application in
 <a href="/cases/case-details/PCS/PCS/{{caseReference}}#Case%20File%20View">Case File View</a>, check whether any
 further case action is required, and take the appropriate action. Only mark the task as complete once the documents

--- a/src/test/java/uk/gov/hmcts/reform/pcs/camunda/CamundaServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/camunda/CamundaServiceTest.java
@@ -35,6 +35,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -151,6 +152,23 @@ public class CamundaServiceTest {
     }
 
     @Test
+    void shouldScheduleCamundaCreateRequestTaskWithIdempotencyKey() {
+        // Given
+        stubWaFeatureFlag(true);
+
+        // When
+        camundaService.createTask(CASE_REFERENCE, TaskType.NEW_CLAIM_CREATE_NEW_HEARING);
+
+        // Then
+        verify(schedulerClient).scheduleIfNotExists(schedulableInstanceCaptor.capture());
+
+        SchedulableInstance<CamundaRequestTaskData> schedulableInstance = schedulableInstanceCaptor.getValue();
+
+        CamundaRequestTaskData taskData = schedulableInstance.getTaskInstance().getData();
+        assertThat(taskData.getIdempotencyKey()).isNotNull();
+    }
+
+    @Test
     void shouldScheduleCamundaCancelRequestTask() {
         // Given
         stubWaFeatureFlag(true);
@@ -255,6 +273,43 @@ public class CamundaServiceTest {
         assertThat(processVariables.get("taskLocationName").getType()).isEqualTo("String");
         assertThat(processVariables.get("taskRegion").getValue()).isEqualTo(2);
         assertThat(processVariables.get("taskRegion").getType()).isEqualTo("Integer");
+        assertThat(processVariables.get("idempotencyKey").getValue()).isNotNull();
+        assertThat(processVariables.get("idempotencyKey").getType()).isEqualTo("String");
+    }
+
+    @Test
+    void shouldHandleNoIdempotencyKeyWhenCreatingTask() {
+        // Given
+        final TaskType taskType = TaskType.NEW_CLAIM_CREATE_NEW_HEARING;
+
+        when(authTokenGenerator.generate()).thenReturn("authToken");
+        when(pcsCaseRepository.findByCaseReference(CASE_REFERENCE)).thenReturn(
+            Optional.ofNullable(PcsCaseEntity.builder().baseLocation(1).regionId(2).build())
+        );
+        when(locationReferenceService.getCourtVenues(List.of(1))).thenReturn(List.of());
+        stubWaFeatureFlag(true);
+
+        CamundaRequestTaskData taskData = CamundaRequestTaskData.builder()
+            .action(Action.CREATE)
+            .caseReference(CASE_REFERENCE)
+            .taskType(taskType)
+            .taskDescription("some description")
+            .idempotencyKey(null)
+            .build();
+
+        // When
+        camundaService.handleRequest(taskData);
+
+        // Then
+        ArgumentCaptor<SendMessageRequest> requestArgumentCaptor = ArgumentCaptor.forClass(SendMessageRequest.class);
+        verify(camundaApi).sendMessage(eq("authToken"), requestArgumentCaptor.capture());
+        SendMessageRequest sendMessageRequest = requestArgumentCaptor.getValue();
+
+        assertThat(sendMessageRequest).isNotNull();
+        assertThat(sendMessageRequest.getMessageName()).isEqualTo("createTaskMessage");
+
+        Map<String, DmnValue<?>> processVariables = sendMessageRequest.getProcessVariables();
+        assertThat(processVariables.get("idempotencyKey")).isNull();
     }
 
     @Test
@@ -475,6 +530,7 @@ public class CamundaServiceTest {
             .caseReference(CASE_REFERENCE)
             .taskType(taskType)
             .taskDescription(taskDescription)
+            .idempotencyKey(UUID.randomUUID())
             .build();
     }
 


### PR DESCRIPTION
### Jira link

See [HDPI-8305](https://tools.hmcts.net/jira/browse/HDPI-8305)

### Change description

Add idempotencyKey for Camunda tasks to enable it to prevent duplicate WA tasks being created. Also adding a content tweaks to a couple of the task descriptions.

### Testing done

Tested in preview

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

### PCS checklist

- [ ] New functional test classes carry the gating annotations (`@EnabledIfEnvironmentVariable(named = "CCD_ENABLED", ...)` + shutter guard) unless they must run on unlabelled PRs (HDPI-8084)
- [ ] Infrastructure / chart / suppression changes have a second pair of eyes from the service admins (HDPI-8153)
