### PR TITLE
HDPI-7052: set devMode memory limits — staging/preview pods are OOMKilled at the chart's 1Gi default

### DIFF
--- a/charts/pcs-api/Chart.yaml
+++ b/charts/pcs-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for pcs-api App
 name: pcs-api
 home: https://github.com/hmcts/pcs-api
-version: 0.0.89
+version: 0.0.90
 maintainers:
   - name: HMCTS pcs team
 dependencies:

--- a/charts/pcs-api/values.yaml
+++ b/charts/pcs-api/values.yaml
@@ -3,7 +3,7 @@ java:
   memoryRequests: '2Gi'
   memoryLimits: '2.5Gi'
   # devMode (AAT staging / previews) reads these dev* keys, not the pair above
-  devmemoryRequests: '1Gi'
+  devmemoryRequests: '2Gi'
   devmemoryLimits: '2Gi'
   image: 'hmctsprod.azurecr.io/pcs/api:latest'
   ingressHost: pcs-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal

--- a/charts/pcs-api/values.yaml
+++ b/charts/pcs-api/values.yaml
@@ -2,6 +2,12 @@ java:
   applicationPort: 3206
   memoryRequests: '2Gi'
   memoryLimits: '2.5Gi'
+  # AAT staging and PR previews deploy with global.devMode=true, and in devMode the java chart
+  # reads the dev* keys instead of the pair above (library/_container.tpl), defaulting to a 1Gi
+  # limit. That default is what the E2E runs have been OOMKilled (exit 137) against - the two
+  # earlier raises (#1578, #2485) only moved the non-dev keys, which devMode never reads.
+  devmemoryRequests: '1Gi'
+  devmemoryLimits: '2Gi'
   image: 'hmctsprod.azurecr.io/pcs/api:latest'
   ingressHost: pcs-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
   aadIdentityName: pcs

--- a/charts/pcs-api/values.yaml
+++ b/charts/pcs-api/values.yaml
@@ -2,10 +2,7 @@ java:
   applicationPort: 3206
   memoryRequests: '2Gi'
   memoryLimits: '2.5Gi'
-  # AAT staging and PR previews deploy with global.devMode=true, and in devMode the java chart
-  # reads the dev* keys instead of the pair above (library/_container.tpl), defaulting to a 1Gi
-  # limit. That default is what the E2E runs have been OOMKilled (exit 137) against - the two
-  # earlier raises (#1578, #2485) only moved the non-dev keys, which devMode never reads.
+  # devMode (AAT staging / previews) reads these dev* keys, not the pair above
   devmemoryRequests: '1Gi'
   devmemoryLimits: '2Gi'
   image: 'hmctsprod.azurecr.io/pcs/api:latest'


### PR DESCRIPTION
Sets the devMode memory keys (used by AAT staging and PR previews) so those pods get a 2Gi limit instead of the java chart's 1Gi default, which the E2E runs have been OOMKilled against.