### PR TITLE
HDPI-6033: return a validation error, not a 500, when a make-an-application submit names a party that isn't on the case

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/SubmitEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/SubmitEventHandler.java
@@ -77,10 +77,7 @@ public class SubmitEventHandler implements Submit<PCSCase, State> {
         try {
             applicantParty = getApplicantParty(caseReference, caseData);
         } catch (PartyNotFoundException | IllegalArgumentException ex) {
-            // currentRepresentedPartyId is client-supplied case data - the server sets it from a
-            // case+org scoped list at start, so a value that no longer resolves is bad input, not
-            // a server fault. Return a validation error rather than a 500 (which CCD reports as a
-            // 502, indistinguishable from an outage).
+            // client-supplied party id that no longer resolves is bad input, not a server fault
             log.warn("Applicant party could not be resolved on genapp submit for case {}: {}",
                 caseReference, ex.getMessage());
             return errorResponse("The selected party is not available on this case");

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/SubmitEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/SubmitEventHandler.java
@@ -78,8 +78,8 @@ public class SubmitEventHandler implements Submit<PCSCase, State> {
             applicantParty = getApplicantParty(caseReference, caseData);
         } catch (PartyNotFoundException | IllegalArgumentException ex) {
             // client-supplied party id that no longer resolves is bad input, not a server fault
-            log.warn("Applicant party could not be resolved on genapp submit for case {}: {}",
-                caseReference, ex.getMessage());
+            log.warn("Applicant party unresolved on genapp submit: partyId={}, caseReference={}",
+                caseData.getCurrentRepresentedPartyId(), caseReference, ex);
             return errorResponse("The selected party is not available on this case");
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/SubmitEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/SubmitEventHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.kagkarlsson.scheduler.SchedulerClient;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.sdk.api.EventPayload;
 import uk.gov.hmcts.ccd.sdk.api.callback.Submit;
@@ -46,6 +47,7 @@ import static uk.gov.hmcts.reform.pcs.feesandpay.task.FeesAndPayTaskComponent.FE
 
 @Component("genAppSubmitEventHandler")
 @RequiredArgsConstructor
+@Slf4j
 public class SubmitEventHandler implements Submit<PCSCase, State> {
 
     private final PcsCaseService pcsCaseService;
@@ -70,7 +72,19 @@ public class SubmitEventHandler implements Submit<PCSCase, State> {
         PCSCase caseData = eventPayload.caseData();
 
         PcsCaseEntity pcsCaseEntity = pcsCaseService.loadCase(caseReference);
-        PartyEntity applicantParty = getApplicantParty(caseReference, caseData);
+
+        PartyEntity applicantParty;
+        try {
+            applicantParty = getApplicantParty(caseReference, caseData);
+        } catch (PartyNotFoundException | IllegalArgumentException ex) {
+            // currentRepresentedPartyId is client-supplied case data - the server sets it from a
+            // case+org scoped list at start, so a value that no longer resolves is bad input, not
+            // a server fault. Return a validation error rather than a 500 (which CCD reports as a
+            // 502, indistinguishable from an outage).
+            log.warn("Applicant party could not be resolved on genapp submit for case {}: {}",
+                caseReference, ex.getMessage());
+            return errorResponse("The selected party is not available on this case");
+        }
 
         GenAppRequest createGenAppRequest = getGenAppRequest(caseData);
 

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/SubmitEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/SubmitEventHandlerTest.java
@@ -37,7 +37,6 @@ import uk.gov.hmcts.reform.pcs.ccd.service.genapp.GenAppDocumentGenerator;
 import uk.gov.hmcts.reform.pcs.ccd.service.genapp.GenAppFeeCalculator;
 import uk.gov.hmcts.reform.pcs.ccd.service.genapp.GenAppService;
 import uk.gov.hmcts.reform.pcs.ccd.service.party.PartyService;
-import uk.gov.hmcts.reform.pcs.exception.PartyNotFoundException;
 import uk.gov.hmcts.reform.pcs.feesandpay.model.FeeDetails;
 import uk.gov.hmcts.reform.pcs.feesandpay.model.FeesAndPayTaskData;
 import uk.gov.hmcts.reform.pcs.feesandpay.service.PaymentService;
@@ -51,7 +50,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -259,7 +257,7 @@ class SubmitEventHandlerTest {
         }
 
         @Test
-        void shouldThrowErrorIfApplicantIsNotRepresentedByCurrentUser() {
+        void shouldReturnValidationErrorIfApplicantIsNotRepresentedByCurrentUser() {
             // Given
             UUID representedPartyUuid = UUID.randomUUID();
             XuiGenAppRequest genAppRequest = XuiGenAppRequest.builder()
@@ -279,10 +277,14 @@ class SubmitEventHandlerTest {
                 .thenReturn(false);
 
             // When
-            Throwable throwable = catchThrowable(() -> underTest.submit(eventPayload(caseData)));
+            SubmitResponse<State> submitResponse = underTest.submit(eventPayload(caseData));
 
-            // Then
-            assertThat(throwable).isInstanceOf(PartyNotFoundException.class);
+            // Then - a client-supplied party id that does not resolve is a validation error,
+            // not an unhandled 500.
+            assertThat(submitResponse.getErrors())
+                .containsExactly("The selected party is not available on this case");
+            verify(genAppService, never())
+                .createGenAppEntity(any(GenAppRequest.class), any(), any(), any());
         }
 
         private void stubLegalRepForParty(UUID representedPartyUuid) {

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/SubmitEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/SubmitEventHandlerTest.java
@@ -286,6 +286,53 @@ class SubmitEventHandlerTest {
                 .createGenAppEntity(any(GenAppRequest.class), any(), any(), any());
         }
 
+        @Test
+        void shouldReturnValidationErrorIfRepresentedPartyIdIsMalformed() {
+            // Given
+            XuiGenAppRequest genAppRequest = XuiGenAppRequest.builder()
+                .applicationType(GenAppType.SET_ASIDE)
+                .build();
+
+            PCSCase caseData = PCSCase.builder()
+                .currentRepresentedPartyId("not-a-uuid")
+                .xuiGenAppRequest(genAppRequest)
+                .build();
+
+            // When
+            SubmitResponse<State> submitResponse = underTest.submit(eventPayload(caseData));
+
+            // Then
+            assertThat(submitResponse.getErrors())
+                .containsExactly("The selected party is not available on this case");
+            verify(genAppService, never())
+                .createGenAppEntity(any(GenAppRequest.class), any(), any(), any());
+        }
+
+        @Test
+        void shouldReturnValidationErrorIfOrganisationCannotBeResolved() {
+            // Given
+            UUID representedPartyUuid = UUID.randomUUID();
+            XuiGenAppRequest genAppRequest = XuiGenAppRequest.builder()
+                .applicationType(GenAppType.SET_ASIDE)
+                .build();
+
+            PCSCase caseData = PCSCase.builder()
+                .currentRepresentedPartyId(representedPartyUuid.toString())
+                .xuiGenAppRequest(genAppRequest)
+                .build();
+
+            when(organisationService.getOrganisationIdForCurrentUser()).thenReturn(null);
+
+            // When
+            SubmitResponse<State> submitResponse = underTest.submit(eventPayload(caseData));
+
+            // Then
+            assertThat(submitResponse.getErrors())
+                .containsExactly("The selected party is not available on this case");
+            verify(genAppService, never())
+                .createGenAppEntity(any(GenAppRequest.class), any(), any(), any());
+        }
+
         private void stubLegalRepForParty(UUID representedPartyUuid) {
             UUID currentUserId = UUID.randomUUID();
             String orgId = "org";

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/SubmitEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/event/genapp/SubmitEventHandlerTest.java
@@ -279,8 +279,7 @@ class SubmitEventHandlerTest {
             // When
             SubmitResponse<State> submitResponse = underTest.submit(eventPayload(caseData));
 
-            // Then - a client-supplied party id that does not resolve is a validation error,
-            // not an unhandled 500.
+            // Then - an unresolved party id is a validation error, not an unhandled 500
             assertThat(submitResponse.getErrors())
                 .containsExactly("The selected party is not available on this case");
             verify(genAppService, never())


### PR DESCRIPTION
### Jira link

See [HDPI-6033](https://tools.hmcts.net/jira/browse/HDPI-6033)

### Change description

A make-an-application submit whose `currentRepresentedPartyId` did not resolve on the case threw an unhandled `PartyNotFoundException` → HTTP 500 (CCD reports this to callers as a 502, indistinguishable from an outage). The id is client-supplied case data, so this catches it in the submit handler and returns the handler's existing `errorResponse` validation message instead. No change to the party lookup, guard, or queries.

### Testing done

Renamed the unit test that asserted the old throw to assert the new validation response (`SubmitEventHandlerTest`); it passes and `errorResponse` is verified. Also reproduced the original 500 as a functional test against a preview before the fix.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

### PCS checklist

- [ ] New functional test classes carry the gating annotations (`@EnabledIfEnvironmentVariable(named = "CCD_ENABLED", ...)` + shutter guard) unless they must run on unlabelled PRs (HDPI-8084)
- [ ] Infrastructure / chart / suppression changes have a second pair of eyes from the service admins (HDPI-8153)