### PR TITLE
HDPI-7052: grant document access to solicitor org roles under group access

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessGrants.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessGrants.java
@@ -66,6 +66,7 @@ final class AccessGrants {
         grants.putAll(DEFENDANT, Permission.CR);
         grants.putAll(CLAIMANT_SOLICITOR, Permission.CR);
         grants.putAll(DEFENDANT_SOLICITOR, Permission.CR);
+        grants.putAll(GA_CLAIMANT, Permission.CR);
         grants.putAll(GA_CLAIMANT_SOLICITOR, Permission.CR);
         grants.putAll(GA_DEFENDANT_SOLICITOR, Permission.CR);
         addReadAccess(grants, INTERNAL_READ_ROLES);

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessGrants.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessGrants.java
@@ -14,6 +14,7 @@ import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT_SOLIC
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.FEE_PAID_JUDGE;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_CLAIMANT;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_CLAIMANT_SOLICITOR;
+import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_DEFENDANT_SOLICITOR;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.HEARING_CENTRE_ADMIN;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.JUDGE;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.LEADERSHIP_JUDGE;
@@ -65,6 +66,8 @@ final class AccessGrants {
         grants.putAll(DEFENDANT, Permission.CR);
         grants.putAll(CLAIMANT_SOLICITOR, Permission.CR);
         grants.putAll(DEFENDANT_SOLICITOR, Permission.CR);
+        grants.putAll(GA_CLAIMANT_SOLICITOR, Permission.CR);
+        grants.putAll(GA_DEFENDANT_SOLICITOR, Permission.CR);
         addReadAccess(grants, INTERNAL_READ_ROLES);
         return grants;
     }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DocumentAccessTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DocumentAccessTest.java
@@ -12,6 +12,8 @@ import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.CITIZEN;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.CLAIMANT_SOLICITOR;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT_SOLICITOR;
+import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_CLAIMANT_SOLICITOR;
+import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_DEFENDANT_SOLICITOR;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.PCS_SOLICITOR;
 
 class DocumentAccessTest {
@@ -21,7 +23,9 @@ class DocumentAccessTest {
         CITIZEN,
         DEFENDANT,
         CLAIMANT_SOLICITOR,
-        DEFENDANT_SOLICITOR
+        DEFENDANT_SOLICITOR,
+        GA_CLAIMANT_SOLICITOR,
+        GA_DEFENDANT_SOLICITOR
     };
 
     private final DocumentAccess underTest = new DocumentAccess();

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DocumentAccessTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/DocumentAccessTest.java
@@ -12,6 +12,7 @@ import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.CITIZEN;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.CLAIMANT_SOLICITOR;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.DEFENDANT_SOLICITOR;
+import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_CLAIMANT;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_CLAIMANT_SOLICITOR;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.GA_DEFENDANT_SOLICITOR;
 import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole.PCS_SOLICITOR;
@@ -24,6 +25,7 @@ class DocumentAccessTest {
         DEFENDANT,
         CLAIMANT_SOLICITOR,
         DEFENDANT_SOLICITOR,
+        GA_CLAIMANT,
         GA_CLAIMANT_SOLICITOR,
         GA_DEFENDANT_SOLICITOR
     };


### PR DESCRIPTION
### Jira link

See [HDPI-7052](https://tools.hmcts.net/jira/browse/HDPI-7052)

### Change description

Under group access a solicitor is recognised by their **org** role (`claimant-solicitor` / `defendant-solicitor`), not the per-case `[CLAIMANTSOLICITOR]` / `[DEFENDANTSOLICITOR]`. `documentAccess()` only granted to the case roles, so ccd-data-store stripped the document field for org-role users. Adds the two solicitor org roles to the document grant.

### Testing done

`DocumentAccessTest` extended and passing. Labelled `enable_e2e_makeAClaim_test` to run the `@MAC` CaseFile-View document tests on preview.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
