### PR TITLE
HDPI-7052: hide group-access types from ManageOrg on the staging case type

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessProfile.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessProfile.java
@@ -19,6 +19,7 @@ import lombok.Getter;
 import uk.gov.hmcts.ccd.sdk.api.CCDAccessGroup;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Permission;
+import uk.gov.hmcts.reform.pcs.ccd.CaseType;
 
 @Getter
 public enum AccessProfile implements HasRole {
@@ -87,5 +88,20 @@ public enum AccessProfile implements HasRole {
 
     public String getCaseTypePermissions() {
         return Permission.toString(caseTypePermissions);
+    }
+
+    /**
+     * Group access is configured on the canonical PCS case type only. A suffixed case type
+     * (PCS-staging, PR previews) shares the jurisdiction, so emitting the same AccessType rows there
+     * makes PRM mint a second set of organisation roles against that case type - and XUI's case list
+     * then defaults to it, showing no cases. Emit nothing so no such roles exist to pick.
+     */
+    @Override
+    public List<CCDAccessGroup> getAccessGroups() {
+        return accessGroupsFor(CaseType.isSuffixedCaseType());
+    }
+
+    List<CCDAccessGroup> accessGroupsFor(boolean suffixedCaseType) {
+        return suffixedCaseType ? List.of() : accessGroups;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessType.java
@@ -129,11 +129,7 @@ public enum GroupAccessType implements CCDAccessGroup {
             .getCaseAccessGroupIdTemplate().replace(ORG_IDENTIFIER_TEMPLATE, organisationId);
     }
 
-    /**
-     * Hidden from ManageOrg on the staging case type, which duplicates every row of the main
-     * one and doubles each checkbox. User ticks are keyed without case type, and ORM ignores
-     * Display, so PCS-staging role derivation is unaffected.
-     */
+    // Hidden on the staging case type so ManageOrg does not show duplicate checkboxes.
     public boolean isDisplay() {
         return display && !CaseType.isSuffixedCaseType();
     }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessType.java
@@ -129,12 +129,9 @@ public enum GroupAccessType implements CCDAccessGroup {
     }
 
     /**
-     * Hidden from ManageOrg on the staging clone. The staging definition (generated with
-     * {@code CASE_TYPE_SUFFIX} set) duplicates every access-type row of the main PCS case type
-     * under the same jurisdiction, so ManageOrg's "Additional types of access" screen renders
-     * each checkbox twice. User selections are keyed on (jurisdiction, profile, accessTypeId)
-     * with no case type, so the single visible row from the main case type covers both.
-     * ORM's role derivation never reads Display, so PCS-staging roles still derive.
+     * Hidden from ManageOrg on the staging case type, which duplicates every row of the main
+     * one and doubles each checkbox. User ticks are keyed without case type, and ORM ignores
+     * Display, so PCS-staging role derivation is unaffected.
      */
     public boolean isDisplay() {
         return display && System.getenv("CASE_TYPE_SUFFIX") == null;

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessType.java
@@ -13,6 +13,7 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toUnmodifiableMap;
 
 import lombok.Getter;
+import uk.gov.hmcts.reform.pcs.ccd.CaseType;
 import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyRole;
 
 import java.util.Arrays;
@@ -134,7 +135,7 @@ public enum GroupAccessType implements CCDAccessGroup {
      * Display, so PCS-staging role derivation is unaffected.
      */
     public boolean isDisplay() {
-        return display && System.getenv("CASE_TYPE_SUFFIX") == null;
+        return display && !CaseType.isSuffixedCaseType();
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessType.java
@@ -13,7 +13,6 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toUnmodifiableMap;
 
 import lombok.Getter;
-import uk.gov.hmcts.reform.pcs.ccd.CaseType;
 import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyRole;
 
 import java.util.Arrays;
@@ -127,11 +126,6 @@ public enum GroupAccessType implements CCDAccessGroup {
     public static String caseAccessGroupIdFor(String orgProfileId, PartyRole partyRole, String organisationId) {
         return CASE_ACCESS_GROUP_MAP.get(new Key(orgProfileId, partyRole))
             .getCaseAccessGroupIdTemplate().replace(ORG_IDENTIFIER_TEMPLATE, organisationId);
-    }
-
-    // Hidden on the staging case type so ManageOrg does not show duplicate checkboxes.
-    public boolean isDisplay() {
-        return display && !CaseType.isSuffixedCaseType();
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessType.java
@@ -129,6 +129,18 @@ public enum GroupAccessType implements CCDAccessGroup {
     }
 
     /**
+     * Hidden from ManageOrg on the staging clone. The staging definition (generated with
+     * {@code CASE_TYPE_SUFFIX} set) duplicates every access-type row of the main PCS case type
+     * under the same jurisdiction, so ManageOrg's "Additional types of access" screen renders
+     * each checkbox twice. User selections are keyed on (jurisdiction, profile, accessTypeId)
+     * with no case type, so the single visible row from the main case type covers both.
+     * ORM's role derivation never reads Display, so PCS-staging roles still derive.
+     */
+    public boolean isDisplay() {
+        return display && System.getenv("CASE_TYPE_SUFFIX") == null;
+    }
+
+    /**
      * Builds the case access group ID template from this constant's own {@code accessTypeId} and
      * group role, e.g. {@code "PCS:PCS:solicitor-org-claimant-access:claimant-solicitor:$ORGID$"}.
      */

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/entity/legalrepresentative/OrganisationEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/entity/legalrepresentative/OrganisationEntity.java
@@ -59,8 +59,7 @@ public class OrganisationEntity {
     private LocalDateTime lastModifiedDate;
 
     public void addParty(PartyEntity party) {
-        // Inactive links are history from previous representations of this party and must not
-        // block re-linking after a notice of change back to this organisation.
+        // Inactive links are history and must not block re-linking after a NoC back to this organisation.
         if (this.claimPartyOrganisationList.stream()
             .filter(e -> e.getActive() == YesOrNo.YES)
             .anyMatch(e -> e.getParty().getId().equals(party.getId()))) {

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/entity/legalrepresentative/OrganisationEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/entity/legalrepresentative/OrganisationEntity.java
@@ -59,8 +59,11 @@ public class OrganisationEntity {
     private LocalDateTime lastModifiedDate;
 
     public void addParty(PartyEntity party) {
+        // Inactive links are history from previous representations of this party and must not
+        // block re-linking after a notice of change back to this organisation.
         if (this.claimPartyOrganisationList.stream()
-            .anyMatch(e -> e.getParty().getId() == party.getId())) {
+            .filter(e -> e.getActive() == YesOrNo.YES)
+            .anyMatch(e -> e.getParty().getId().equals(party.getId()))) {
             log.warn("Party [{}] is already linked to Legal Representative Organisation [{}] and is active.",
                      party.getId(), this.getId());
             return;

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/entity/legalrepresentative/OrganisationEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/entity/legalrepresentative/OrganisationEntity.java
@@ -63,8 +63,8 @@ public class OrganisationEntity {
         if (this.claimPartyOrganisationList.stream()
             .filter(e -> e.getActive() == YesOrNo.YES)
             .anyMatch(e -> e.getParty().getId().equals(party.getId()))) {
-            log.warn("Party [{}] is already linked to Legal Representative Organisation [{}] and is active.",
-                     party.getId(), this.getId());
+            log.warn("Party [{}] already has an active link to Legal Representative Organisation [{}], "
+                         + "skipping re-link.", party.getId(), this.getId());
             return;
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessProfileTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessProfileTest.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.ccd.sdk.api.Permission.CRU;
 import static uk.gov.hmcts.ccd.sdk.api.Permission.R;
+import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.GroupAccessType.SOLICITOR_ORG_CLAIMANT_ACCESS;
 
 class AccessProfileTest {
 
@@ -55,5 +56,20 @@ class AccessProfileTest {
             Arguments.of(AccessProfile.SYSTEM_USER, "pcs-system-update", CRU),
             Arguments.of(AccessProfile.ORGANISATION_CASE_ACCESS_ADMINISTRATOR, "caseworker-caa", CRU)
         );
+    }
+
+    @Test
+    void shouldDeclareAccessGroupsOnTheCanonicalCaseType() {
+        assertThat(AccessProfile.GA_CLAIMANT_SOLICITOR.accessGroupsFor(false))
+            .containsExactly(SOLICITOR_ORG_CLAIMANT_ACCESS);
+        assertThat(AccessProfile.PCS_SOLICITOR.accessGroupsFor(false)).isEmpty();
+    }
+
+    @Test
+    void shouldDeclareNoAccessGroupsOnASuffixedCaseType() {
+        // PCS-staging / PR previews: no AccessType rows, so PRM mints no org roles for them.
+        for (AccessProfile profile : AccessProfile.values()) {
+            assertThat(profile.accessGroupsFor(true)).as(profile.name()).isEmpty();
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/entity/legalrepresentative/OrganisationEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/entity/legalrepresentative/OrganisationEntityTest.java
@@ -78,6 +78,47 @@ class OrganisationEntityTest {
     }
 
     @Test
+    void addParty_ShouldRelinkPartyWhenExistingLinkIsInactive() {
+        // given - the party was previously represented by this organisation, then moved away
+        UUID partyId = UUID.randomUUID();
+        PartyEntity party = PartyEntity.builder()
+            .id(partyId)
+            .build();
+
+        underTest.addParty(party);
+        underTest.getClaimPartyOrganisationList().getFirst().setActive(YesOrNo.NO);
+
+        // when - a notice of change brings the party back to this organisation
+        underTest.addParty(party);
+
+        // then - a fresh active link is created alongside the historic inactive one
+        assertThat(underTest.getClaimPartyOrganisationList()).hasSize(2);
+        assertThat(underTest.getClaimPartyOrganisationList().getFirst().getActive()).isEqualTo(YesOrNo.NO);
+
+        ClaimPartyOrganisationEntity relinked = underTest.getClaimPartyOrganisationList().get(1);
+        assertThat(relinked.getParty().getId()).isEqualTo(partyId);
+        assertThat(relinked.getActive()).isEqualTo(YesOrNo.YES);
+        assertThat(relinked.getOrganisation()).isEqualTo(underTest);
+    }
+
+    @Test
+    void addParty_ShouldNotAddPartyWhenActiveLinkMatchesByIdValue() {
+        // given - same party id carried by distinct entity instances (e.g. separate loads)
+        String partyId = "11111111-2222-3333-4444-555555555555";
+        underTest.addParty(PartyEntity.builder()
+            .id(UUID.fromString(partyId))
+            .build());
+
+        // when
+        underTest.addParty(PartyEntity.builder()
+            .id(UUID.fromString(partyId))
+            .build());
+
+        // then
+        assertThat(underTest.getClaimPartyOrganisationList()).hasSize(1);
+    }
+
+    @Test
     void addLegalRepresentativeOrganisationContactDetails_WithContactDetails_SetsReference() {
         // given
         ClaimPartyContactDetailsEntity contactDetails =


### PR DESCRIPTION
### Change description

The staging definition (`CASE_TYPE_SUFFIX=staging`) duplicates every AccessType row of the main PCS case type, so ManageOrg's **Additional types of access** screen shows each checkbox twice. This emits `Display=N` on the staging rows; ManageOrg already filters on that flag, so the duplicates disappear.

Safe: user ticks are keyed without case type, and ORM never reads Display — `PCS-staging` role derivation is unchanged.

Also fixes NoC back to a previous organisation leaving the party with no active organisation link. `OrganisationEntity.addParty` skipped creating a new link whenever *any* row existed for the party — including inactive history rows — so an A → B → A notice-of-change sequence deactivated the current link but never created the replacement, and the party ended up with no active organisation (repro: case 1787845845527279 on AAT). The guard now only skips on an active link, comparing party ids by value rather than reference.

### Testing done

`generateCCDConfig`: no suffix → `Display=Yes`; `CASE_TYPE_SUFFIX=staging` → `Display=No`.

NoC re-link: new unit tests in `OrganisationEntityTest` cover the A → B → A re-link (fresh active row created alongside the historic inactive one) and value-based id dedup; verified against AAT data that the broken case's party had zero active links after the third NoC.
