### PR TITLE
HDPI-8677: guard against null profileID when creating caseAccessGroups

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessType.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessType.java
@@ -12,6 +12,7 @@ import static uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyRole.DEFENDANT;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toUnmodifiableMap;
 
+import java.util.Optional;
 import lombok.Getter;
 import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyRole;
 
@@ -123,9 +124,13 @@ public enum GroupAccessType implements CCDAccessGroup {
      * combination has no access type. Keyed lookup, so selection does not depend on the order these
      * constants are declared in.
      */
-    public static String caseAccessGroupIdFor(String orgProfileId, PartyRole partyRole, String organisationId) {
-        return CASE_ACCESS_GROUP_MAP.get(new Key(orgProfileId, partyRole))
-            .getCaseAccessGroupIdTemplate().replace(ORG_IDENTIFIER_TEMPLATE, organisationId);
+    public static Optional<String> caseAccessGroupIdFor(String orgProfileId, PartyRole partyRole,
+                                                        String organisationId) {
+        return Optional.ofNullable(orgProfileId)
+            .map(profileId -> new Key(profileId, partyRole))
+            .map(CASE_ACCESS_GROUP_MAP::get)
+            .map(groupAccessType ->
+                     groupAccessType.getCaseAccessGroupIdTemplate().replace(ORG_IDENTIFIER_TEMPLATE, organisationId));
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/util/CaseAccessGroupsUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/util/CaseAccessGroupsUtil.java
@@ -45,11 +45,11 @@ public final class CaseAccessGroupsUtil {
         parties.stream()
             .filter(CaseAccessGroupsUtil::isClaimant)
             .findFirst()
-            .ifPresent(party -> {
-                var caseAccessGroup =
-                    caseAccessGroupIdFor(party.getOrganisationProfileId(), CLAIMANT, party.getOrganisationId());
-                log.info("Found claimant case access group: {}", caseAccessGroup);
-                caseAccessGroups.add(new CaseAccessGroup(CCD_ALL_CASES_ACCESS, caseAccessGroup));
+            .flatMap(party ->
+                         caseAccessGroupIdFor(party.getOrganisationProfileId(), CLAIMANT, party.getOrganisationId()))
+            .ifPresent(caseAccessGroupId -> {
+                log.info("Found claimant case access group: {}", caseAccessGroupId);
+                caseAccessGroups.add(new CaseAccessGroup(CCD_ALL_CASES_ACCESS, caseAccessGroupId));
             });
 
         Map<UUID, PartyEntity> partyEntitiesMap = parties.stream()
@@ -72,7 +72,10 @@ public final class CaseAccessGroupsUtil {
             .map(legalRepOrg ->
                      caseAccessGroupIdFor(legalRepOrg.getOrganisationProfileId(),
                                           DEFENDANT, legalRepOrg.getOrganisationId()))
-            .peek(caseAccessGroupId -> log.info("Found defendant case access group: {}", caseAccessGroupId))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .peek(caseAccessGroupId ->
+                      log.info("Found defendant case access group: {}", caseAccessGroupId))
             .forEach(caseAccessGroupId ->
                          caseAccessGroups.add(new CaseAccessGroup(CCD_ALL_CASES_ACCESS, caseAccessGroupId)));;
 

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/util/CaseAccessGroupsUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/util/CaseAccessGroupsUtil.java
@@ -66,14 +66,12 @@ public final class CaseAccessGroupsUtil {
                          .stream()
                          .filter(legalRepOrg -> YesOrNo.YES == legalRepOrg.getActive())
                          .findFirst())
-            .filter(Optional::isPresent)
-            .map(Optional::get)
+            .flatMap(Optional::stream)
             .map(ClaimPartyOrganisationEntity::getOrganisation)
             .map(legalRepOrg ->
                      caseAccessGroupIdFor(legalRepOrg.getOrganisationProfileId(),
                                           DEFENDANT, legalRepOrg.getOrganisationId()))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
+            .flatMap(Optional::stream)
             .peek(caseAccessGroupId ->
                       log.info("Found defendant case access group: {}", caseAccessGroupId))
             .forEach(caseAccessGroupId ->

--- a/src/main/java/uk/gov/hmcts/reform/pcs/config/LaunchDarklyConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/config/LaunchDarklyConfiguration.java
@@ -56,8 +56,7 @@ public class LaunchDarklyConfiguration {
         }
         Path[] existing = Stream.of(files)
             .map(this::getPathIfExists)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
+            .flatMap(Optional::stream)
             .toArray(Path[]::new);
         return existing.length > 0 ? Optional.of(existing) : Optional.empty();
     }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportController.java
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.ccd.sdk.type.AddressUK;
-import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
 import uk.gov.hmcts.reform.pcs.ccd.domain.Party;
 import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
 import uk.gov.hmcts.reform.pcs.ccd.entity.ClaimEntity;
@@ -38,7 +37,6 @@ import uk.gov.hmcts.reform.pcs.ccd.entity.party.PartyEntity;
 import uk.gov.hmcts.reform.pcs.ccd.repository.PartyRepository;
 import uk.gov.hmcts.reform.pcs.ccd.repository.PcsCaseRepository;
 import uk.gov.hmcts.reform.pcs.ccd.service.AccessCodeGenerationService;
-import uk.gov.hmcts.reform.pcs.ccd.service.CaseRoleAssignmentService;
 import uk.gov.hmcts.reform.pcs.ccd.service.PcsCaseService;
 import uk.gov.hmcts.reform.pcs.exception.PartyNotFoundException;
 import uk.gov.hmcts.reform.pcs.idam.IdamAuthenticator;
@@ -90,7 +88,6 @@ public class TestingSupportController {
     private final PartyRepository partyRepository;
     private final ModelMapper modelMapper;
     private final CcdTestCaseOrchestrator ccdTestCaseOrchestrator;
-    private final CaseRoleAssignmentService caseRoleAssignmentService;
     private final LegalRepresentativePartyLinkService legalRepresentativePartyLinkService;
     private final IdamAuthenticator idamAuthenticator;
     private final OrganisationDetailsService organisationDetailsService;
@@ -426,8 +423,6 @@ public class TestingSupportController {
 
         User user = idamAuthenticator.validateAuthToken(authorization);
         UserInfo userDetails = user.getUserDetails();
-
-        caseRoleAssignmentService.assignRasRole(caseReference, userDetails.getUid(), UserRole.DEFENDANT_SOLICITOR);
 
         OrganisationDetailsResponse organisationDetails = organisationDetailsService
             .getOrganisationDetails(userDetails.getUid());

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/GroupAccessTypeTest.java
@@ -32,4 +32,9 @@ class GroupAccessTypeTest {
                 accessType.getOrganisationProfileId(), accessType.getPartyRole(), "$ORGID$"))
                 .contains(accessType.getCaseAccessGroupIdTemplate()));
     }
+
+    @Test
+    void shouldReturnEmptyWhenOrganisationProfileIdIsNull() {
+        assertThat(GroupAccessType.caseAccessGroupIdFor(null, null, "ORG123")).isEmpty();
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/util/CaseAccessGroupsUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/util/CaseAccessGroupsUtilTest.java
@@ -98,7 +98,7 @@ class CaseAccessGroupsUtilTest {
 
     @Test
     void shouldDeriveNothingWhenPartyHasOrganisationButNoProfile() {
-        Set<PartyEntity> parties = Set.of(party("J1XJ9VJ", null, false));
+        Set<PartyEntity> parties = Set.of(party("J1XJ9VJ", null, true));
 
         assertThat(CaseAccessGroupsUtil.deriveCaseAccessGroups(parties, defendants)).isEmpty();
     }
@@ -156,11 +156,11 @@ class CaseAccessGroupsUtilTest {
     @Test
     void shouldResolveTheClaimantAccessTypeByNameNotByDeclarationOrder() {
         assertThat(GroupAccessType.caseAccessGroupIdFor("SOLICITOR_PROFILE", PartyRole.CLAIMANT, "1234"))
-            .isEqualTo("PCS:PCS:solicitor-org-claimant-access:claimant-solicitor:1234");
+            .contains("PCS:PCS:solicitor-org-claimant-access:claimant-solicitor:1234");
         assertThat(GroupAccessType.caseAccessGroupIdFor("SOLICITOR_PROFILE", PartyRole.DEFENDANT, "1234"))
-            .isEqualTo("PCS:PCS:solicitor-org-defendant-access:defendant-solicitor:1234");
+            .contains("PCS:PCS:solicitor-org-defendant-access:defendant-solicitor:1234");
         assertThat(GroupAccessType.caseAccessGroupIdFor("LOCALAUTH_PROFILE", PartyRole.CLAIMANT, "1234"))
-            .isEqualTo("PCS:PCS:prof-org-claimant-access:claimant:1234");
+            .contains("PCS:PCS:prof-org-claimant-access:claimant:1234");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/testingsupport/endpoint/TestingSupportControllerTest.java
@@ -19,7 +19,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
-import uk.gov.hmcts.reform.pcs.ccd.accesscontrol.UserRole;
 import uk.gov.hmcts.reform.pcs.ccd.domain.Party;
 import uk.gov.hmcts.reform.pcs.ccd.domain.VerticalYesNo;
 import uk.gov.hmcts.reform.pcs.ccd.entity.PcsCaseEntity;
@@ -117,7 +116,6 @@ class TestingSupportControllerTest {
                                                  eligibilityService,
                                                  pcsCaseRepository, jdbcTemplate, partyRepository,
                                                  modelMapper, ccdTestCaseOrchestrator,
-                                                 caseRoleAssignmentService,
                                                  legalRepresentativePartyLinkService,
                                                  idamAuthenticator,
                                                  organisationDetailsService,
@@ -398,9 +396,6 @@ class TestingSupportControllerTest {
         );
 
         // then
-        verify(caseRoleAssignmentService).assignRasRole(caseReference, userUid.toString(),
-                                                        UserRole.DEFENDANT_SOLICITOR);
-
         verify(legalRepresentativePartyLinkService)
             .linkLegalRepresentativeToParty(caseReference, partyId, legalRepEmail, organisationDetails);
 
@@ -422,12 +417,8 @@ class TestingSupportControllerTest {
         when(featureToggleService.isEnabled(FeatureFlag.CUI_RESPOND_TO_CLAIM_LR)).thenReturn(true);
 
         // when
-        ResponseEntity<Void> response = underTest.linkDefendantSolicitorToParty(
-            caseReference,
-            partyId,
-            authToken,
-            "testS2S"
-        );
+        ResponseEntity<Void> response =
+            underTest.linkDefendantSolicitorToParty(caseReference, partyId, authToken, "testS2S");
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
### Jira link
- See [HDPI-8677](https://tools.hmcts.net/jira/browse/HDPI-8677)

### Change description
- guard against null profileID when creating caseAccessGroups

### Testing done
--

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

### PCS checklist
- [ ] New functional test classes carry the gating annotations (`@EnabledIfEnvironmentVariable(named = "CCD_ENABLED", ...)` + shutter guard) unless they must run on unlabelled PRs (HDPI-8084)
- [ ] Infrastructure / chart / suppression changes have a second pair of eyes from the service admins (HDPI-8153)
