### PR TITLE
HDPI-8685: queue a search reindex when NoC changes case representation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/CaseReindexService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/service/CaseReindexService.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.pcs.ccd.service;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Queues a single case for Elasticsearch reindexing.
+ *
+ * <p>CaseAccessGroups is derived at read time, so it only reaches the search index when the
+ * indexer refetches the case — which normally happens because every CCD event writes
+ * {@code ccd.case_data} and a trigger enqueues the case. Writes that change derivation inputs
+ * outside an event (e.g. a Notice of Change updating {@code claim_party_organisation}) must
+ * enqueue the case themselves, or the case list serves stale visibility: the incoming
+ * organisation never sees the case listed and the outgoing organisation keeps a ghost row.
+ *
+ * <p>The insert mirrors the SDK's own {@code enqueue_case_revision} trigger (conflict clause
+ * included) but without touching the case row. Replace with the SDK's
+ * {@code CaseReindexingService.reindex(caseRef)} once that API exists upstream.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CaseReindexService {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public void reindex(long caseReference) {
+        int queued = jdbcTemplate.update("""
+            insert into ccd.es_queue(reference, case_revision, enqueued_at)
+            select reference, case_revision, now()
+            from ccd.case_data
+            where reference = :reference
+            on conflict (reference) do update
+              set case_revision = greatest(ccd.es_queue.case_revision, excluded.case_revision),
+                  enqueued_at   = least(ccd.es_queue.enqueued_at, excluded.enqueued_at)
+            """,
+            Map.of("reference", caseReference));
+        log.info("Queued case {} for search reindexing ({} row)", caseReference, queued);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/task/NocAccessChangeTaskComponent.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/task/NocAccessChangeTaskComponent.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.pcs.ccd.model.NocAccessChangeTaskData;
+import uk.gov.hmcts.reform.pcs.ccd.service.CaseReindexService;
 import uk.gov.hmcts.reform.pcs.service.LegalRepresentativePartyLinkService;
 
 @Slf4j
@@ -26,13 +27,16 @@ public class NocAccessChangeTaskComponent {
     private final int maxRetries;
     private final Duration backoffDelay;
     private final LegalRepresentativePartyLinkService legalRepresentativePartyLinkService;
+    private final CaseReindexService caseReindexService;
 
     public NocAccessChangeTaskComponent(
         LegalRepresentativePartyLinkService legalRepresentativePartyLinkService,
+        CaseReindexService caseReindexService,
         @Value("${role-assignment.request.max-retries}") int maxRetries,
         @Value("${role-assignment.request.backoff-delay-seconds}") Duration backoffDelay
     ) {
         this.legalRepresentativePartyLinkService = legalRepresentativePartyLinkService;
+        this.caseReindexService = caseReindexService;
         this.maxRetries = maxRetries;
         this.backoffDelay = backoffDelay;
     }
@@ -54,6 +58,11 @@ public class NocAccessChangeTaskComponent {
                             taskData.getPartyId(),
                             taskData.getEmail(),
                             taskData.getOrganisationDetailsResponse());
+
+                    // Representation feeds the derived CaseAccessGroups served by search;
+                    // without this the new representative never sees the case in their
+                    // case list and the outgoing organisation keeps a stale row.
+                    caseReindexService.reindex(caseReference);
 
                     return new CompletionHandler.OnCompleteRemove<>();
                 } catch (Exception e) {

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/CaseReindexServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/service/CaseReindexServiceTest.java
@@ -1,0 +1,48 @@
+package uk.gov.hmcts.reform.pcs.ccd.service;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CaseReindexServiceTest {
+
+    private static final long CASE_REFERENCE = 1787849985141941L;
+
+    @Mock
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    private CaseReindexService underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new CaseReindexService(jdbcTemplate);
+    }
+
+    @Test
+    void shouldQueueTheCaseOnTheReindexQueue() {
+        when(jdbcTemplate.update(anyString(), anyMap())).thenReturn(1);
+
+        underTest.reindex(CASE_REFERENCE);
+
+        ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> params = ArgumentCaptor.forClass(Map.class);
+        verify(jdbcTemplate).update(sql.capture(), params.capture());
+
+        assertThat(sql.getValue()).contains("insert into ccd.es_queue");
+        assertThat(sql.getValue()).contains("on conflict (reference) do update");
+        assertThat(params.getValue()).containsEntry("reference", CASE_REFERENCE);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/task/NocAccessChangeTaskComponentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/task/NocAccessChangeTaskComponentTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.pcs.ccd.model.NocAccessChangeTaskData;
+import uk.gov.hmcts.reform.pcs.ccd.service.CaseReindexService;
 import uk.gov.hmcts.reform.pcs.reference.dto.OrganisationDetailsResponse;
 import uk.gov.hmcts.reform.pcs.service.LegalRepresentativePartyLinkService;
 
@@ -22,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,6 +34,9 @@ class NocAccessChangeTaskComponentTest {
 
     @Mock
     private LegalRepresentativePartyLinkService legalRepresentativePartyLinkService;
+
+    @Mock
+    private CaseReindexService caseReindexService;
 
     @Mock
     private TaskInstance<NocAccessChangeTaskData> taskInstance;
@@ -48,6 +53,7 @@ class NocAccessChangeTaskComponentTest {
     void setUp() {
         nocAccessChangeTaskComponent = new NocAccessChangeTaskComponent(
             legalRepresentativePartyLinkService,
+            caseReindexService,
             MAX_RETRIES,
             BACKOFF_DELAY
         );
@@ -78,6 +84,8 @@ class NocAccessChangeTaskComponentTest {
         verify(legalRepresentativePartyLinkService).linkLegalRepresentativeToParty(1L, partyId,
                                                                                    email,
                                                                                    organisationDetailsResponse);
+        // the rep change feeds derived CaseAccessGroups, so the case must be queued for reindexing
+        verify(caseReindexService).reindex(1L);
     }
 
     @Test
@@ -113,5 +121,6 @@ class NocAccessChangeTaskComponentTest {
         verify(legalRepresentativePartyLinkService).linkLegalRepresentativeToParty(1L, partyId,
                                                                                    email,
                                                                                    organisationDetailsResponse);
+        verifyNoInteractions(caseReindexService);
     }
 }


### PR DESCRIPTION
### Jira link

[HDPI-8685](https://tools.hmcts.net/jira/browse/HDPI-8685)

### Change description

Fixes **Issue 1**: after a Notice of Change the incoming solicitor can open the case but it never appears in their case list, and the outgoing org keeps a stale row (404 on click).

`CaseAccessGroups` is derived at read time and only reaches Elasticsearch when the case is re-indexed — which happens via a trigger on `ccd.case_data` writes. The NoC apply task updates `claim_party_organisation` **without writing the case row**, so nothing is queued and the index keeps the pre-NoC groups (verified on AAT: case `1787849985141941` — direct GET 200 as the new rep, searchCases total 0; `last_modified` unchanged in DB and ES).

Fix: after the representation link is persisted, queue the case on `ccd.es_queue` (same insert/conflict clause as the SDK's own trigger, without touching the case row). The existing indexer refetches, derives fresh groups, and rewrites the document — the new org's list shows the case and the outgoing org's stale row disappears in the same pass. Runs inside the task's retry envelope so link + reindex retry together.

### Notes

- Repeat NoC (A→B→C, and A→B→A) verified safe: `unlinkExistingRepresentation` ends the previous link and derivation filters to the active link, so the index converges to the current org each hop.
- Cases NoC'd before this fix stay stale until re-queued — backfill via the SDK's existing `CaseReindexingService.enqueueCasesModifiedSince(...)` after deploy.
- **Issues 2/3** on the ticket (regain-access / missing `claim_party_organisation` row on second NoC) look like a separate persistence defect in the relink path — not addressed here.
- SDK counterpart raised: [dtsse-ccd-config-generator#1077](https://github.com/hmcts/dtsse-ccd-config-generator/pull/1077) adds `CaseReindexingService.reindexCase(caseRef)` — once released, `CaseReindexService` here is replaced by that call.

### Testing done

Unit tests: reindex queued after a successful link; not queued when the link fails (failure propagates for retry). `compileJava`, `checkstyleMain/Test`, `NocAccessChangeTaskComponentTest` green.

AAT verification after merge: repeat the ticket's repro — after NoC as `pcs-org1-solicitor3@test.com`, the case appears in their case list within seconds, and the previous org's list drops it.
