### PR TITLE
HDPI-8688: allow group-access defendant solicitor to trigger Respond to claim

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -376,7 +376,7 @@ ext {
   lombokVersion = "1.18.46"
   springSecurityVersion = "7.1.1"
   pactVersion = "4.7.5"
-  tomcatEmbedVersion = "11.0.24"
+  tomcatEmbedVersion = "11.0.25"
   nettyVersion = "4.1.136.Final"
   httpClient5Version = "5.6.4"
 }

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -68,13 +68,15 @@
     <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@2\.21\.4$</packageUrl>
     <cve>CVE-2026-54515</cve>
   </suppress>
-  <suppress until="2026-09-15">
+  <suppress>
     <notes><![CDATA[
-    HDPI-8150: CVE-2026-66299 against embedded Tomcat 11.0.24. No fixed
-    Tomcat release published yet; suppression is temporary and MUST be
-    removed when tomcatEmbedVersion is bumped to the fixed version.
+    HDPI-8677: false positives. dependency-check maps the Java OpenTelemetry artifacts
+    (io.opentelemetry / io.opentelemetry.semconv) to the generic CPE
+    cpe:/a:opentelemetry:opentelemetry, which NVD uses for the Go and Node.js SDKs.
+    Matched CVEs (2026-39882, 2026-39883, 2026-41178 = opentelemetry-go;
+    2026-54285 = opentelemetry-js) do not apply to opentelemetry-java.
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*$</packageUrl>
-    <cve>CVE-2026-66299</cve>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry(\.semconv)?/opentelemetry\-.*$</packageUrl>
+    <cpe>cpe:/a:opentelemetry:opentelemetry</cpe>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -29,6 +29,15 @@
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib(-common|-jdk7|-jdk8)?@.*$</packageUrl>
     <cve>CVE-2020-29582</cve>
   </suppress>
+  <suppress until="2026-09-15">
+    <notes><![CDATA[
+    HDPI-8688: false positive. The Java OpenTelemetry artifacts match the generic
+    CPE opentelemetry:opentelemetry, whose CVEs are for the Go and Node.js SDKs.
+    Re-review by the until date.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry(\.semconv)?/opentelemetry\-.*$</packageUrl>
+    <cpe>cpe:/a:opentelemetry:opentelemetry</cpe>
+  </suppress>
   <!--End of false positives section -->
 
   <suppress until="2026-09-15">
@@ -67,16 +76,5 @@
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@2\.21\.4$</packageUrl>
     <cve>CVE-2026-54515</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    HDPI-8677: false positives. dependency-check maps the Java OpenTelemetry artifacts
-    (io.opentelemetry / io.opentelemetry.semconv) to the generic CPE
-    cpe:/a:opentelemetry:opentelemetry, which NVD uses for the Go and Node.js SDKs.
-    Matched CVEs (2026-39882, 2026-39883, 2026-41178 = opentelemetry-go;
-    2026-54285 = opentelemetry-js) do not apply to opentelemetry-java.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.opentelemetry(\.semconv)?/opentelemetry\-.*$</packageUrl>
-    <cpe>cpe:/a:opentelemetry:opentelemetry</cpe>
   </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/ExtRespondPossessionClaim.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/ExtRespondPossessionClaim.java
@@ -29,7 +29,8 @@ public class ExtRespondPossessionClaim implements CCDConfig<PCSCase, State, User
                 ShowConditions.featureFlagsEnabled(RELEASE_1_DOT_2)))
             .name("Respond to claim")
             .description("Respond to claim")
-            .grant(Permission.CRU, UserRole.DEFENDANT_SOLICITOR);
+            .grant(Permission.CRU, UserRole.DEFENDANT_SOLICITOR)
+            .grant(Permission.CRU, UserRole.GA_DEFENDANT_SOLICITOR);
     }
 
     private static class NoopSubmitHandler implements Submit<PCSCase, State> {


### PR DESCRIPTION
### Change description

Master E2E `respondToAClaimLR.spec.ts › Trigger respond event` has been failing on recent builds.

Defendant solicitors now get case access via the group-access `defendant-solicitor` org role, but `ext:respondPossessionClaim` ("Respond to claim") only granted `[DEFENDANTSOLICITOR]`, so the event was missing from the Next step dropdown and the test timed out. This adds the `GA_DEFENDANT_SOLICITOR` grant, matching `respondPossessionClaim`.

### Dependency-check fix (blocking every build since 28 Aug)

- Tomcat embed 11.0.24 → 11.0.25 (ten CVEs fixed); the temporary `CVE-2026-66299` suppression removed.
- `opentelemetry-*` Java artifacts false-match the generic `opentelemetry:opentelemetry` CPE (CVEs are for the Go/Node SDKs) — suppressed by CPE.

### Testing done

Reproduced on AAT with `pcs-org1-solicitor2@test.com` (defendant-solicitor org role): case view resolves via group access but omits `ext:respondPossessionClaim`. Compile and checkstyle pass on Tomcat 11.0.25.
