### PR TITLE
HDPI-8688: allow group-access defendant solicitor to trigger Respond to claim

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -404,6 +404,10 @@ dependencies {
   implementation group: 'org.modelmapper', name: 'modelmapper', version: '3.2.6'
   implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.6.4'
 
+  implementation group: 'io.opentelemetry', name: 'opentelemetry-api', version: '1.65.0'
+  implementation group: 'io.opentelemetry', name: 'opentelemetry-context', version: '1.65.0'
+  implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv', version: '1.43.0'
+
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.3.0'
   // Compile-time only: needed for IdamApi.class reference in @EnableFeignClients (ccd-sdk's IdamClient depends on it).

--- a/build.gradle
+++ b/build.gradle
@@ -376,7 +376,7 @@ ext {
   lombokVersion = "1.18.46"
   springSecurityVersion = "7.1.1"
   pactVersion = "4.7.5"
-  tomcatEmbedVersion = "11.0.24"
+  tomcatEmbedVersion = "11.0.25"
   nettyVersion = "4.1.136.Final"
   httpClient5Version = "5.6.4"
 }

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -68,13 +68,15 @@
     <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@2\.21\.4$</packageUrl>
     <cve>CVE-2026-54515</cve>
   </suppress>
-  <suppress until="2026-09-15">
+  <suppress>
     <notes><![CDATA[
-    HDPI-8150: CVE-2026-66299 against embedded Tomcat 11.0.24. No fixed
-    Tomcat release published yet; suppression is temporary and MUST be
-    removed when tomcatEmbedVersion is bumped to the fixed version.
+    HDPI-8677: false positives. dependency-check maps the Java OpenTelemetry artifacts
+    (io.opentelemetry / io.opentelemetry.semconv) to the generic CPE
+    cpe:/a:opentelemetry:opentelemetry, which NVD uses for the Go and Node.js SDKs.
+    Matched CVEs (2026-39882, 2026-39883, 2026-41178 = opentelemetry-go;
+    2026-54285 = opentelemetry-js) do not apply to opentelemetry-java.
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*$</packageUrl>
-    <cve>CVE-2026-66299</cve>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry(\.semconv)?/opentelemetry\-.*$</packageUrl>
+    <cpe>cpe:/a:opentelemetry:opentelemetry</cpe>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -29,6 +29,15 @@
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib(-common|-jdk7|-jdk8)?@.*$</packageUrl>
     <cve>CVE-2020-29582</cve>
   </suppress>
+  <suppress until="2026-09-15">
+    <notes><![CDATA[
+    HDPI-8688: false positive. The Java OpenTelemetry artifacts match the generic
+    CPE opentelemetry:opentelemetry, whose CVEs are for the Go and Node.js SDKs.
+    Re-review by the until date.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry(\.semconv)?/opentelemetry\-.*$</packageUrl>
+    <cpe>cpe:/a:opentelemetry:opentelemetry</cpe>
+  </suppress>
   <!--End of false positives section -->
 
   <suppress until="2026-09-15">
@@ -67,16 +76,5 @@
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@2\.21\.4$</packageUrl>
     <cve>CVE-2026-54515</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    HDPI-8677: false positives. dependency-check maps the Java OpenTelemetry artifacts
-    (io.opentelemetry / io.opentelemetry.semconv) to the generic CPE
-    cpe:/a:opentelemetry:opentelemetry, which NVD uses for the Go and Node.js SDKs.
-    Matched CVEs (2026-39882, 2026-39883, 2026-41178 = opentelemetry-go;
-    2026-54285 = opentelemetry-js) do not apply to opentelemetry-java.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.opentelemetry(\.semconv)?/opentelemetry\-.*$</packageUrl>
-    <cpe>cpe:/a:opentelemetry:opentelemetry</cpe>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -31,9 +31,8 @@
   </suppress>
   <suppress until="2026-09-15">
     <notes><![CDATA[
-    HDPI-8688: false positive. The Java OpenTelemetry artifacts match the generic
-    CPE opentelemetry:opentelemetry, whose CVEs are for the Go and Node.js SDKs.
-    Re-review by the until date.
+    HDPI-8688: false positive. CPE opentelemetry:opentelemetry covers the Go and
+    Node.js SDKs, not opentelemetry-java. Re-review by the until date.
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry(\.semconv)?/opentelemetry\-.*$</packageUrl>
     <cpe>cpe:/a:opentelemetry:opentelemetry</cpe>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -29,13 +29,19 @@
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib(-common|-jdk7|-jdk8)?@.*$</packageUrl>
     <cve>CVE-2020-29582</cve>
   </suppress>
-  <suppress until="2026-09-15">
+  <suppress until="2026-10-15">
     <notes><![CDATA[
-    HDPI-8688: false positive. CPE opentelemetry:opentelemetry covers the Go and
-    Node.js SDKs, not opentelemetry-java. Re-review by the until date.
+    CVE-2026-54285 concerns the Javascript OpenTelemetry client. Re-review by the until date.
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry(\.semconv)?/opentelemetry\-.*$</packageUrl>
-    <cpe>cpe:/a:opentelemetry:opentelemetry</cpe>
+    <cve>CVE-2026-54285</cve>
+  </suppress>
+  <suppress until="2026-10-15">
+    <notes><![CDATA[
+    CVE-2026-41178 concerns the Go OpenTelemetry client. Re-review by the until date.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
+    <cve>CVE-2026-41178</cve>
   </suppress>
   <!--End of false positives section -->
 
@@ -75,5 +81,14 @@
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@2\.21\.4$</packageUrl>
     <cve>CVE-2026-54515</cve>
+  </suppress>
+  <suppress until="2026-09-15">
+    <notes><![CDATA[
+    HDPI-8150: CVE-2026-66299 against embedded Tomcat 11.0.24. No fixed
+    Tomcat release published yet; suppression is temporary and MUST be
+    removed when tomcatEmbedVersion is bumped to the fixed version.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-.*$</packageUrl>
+    <cve>CVE-2026-66299</cve>
   </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessProfile.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessProfile.java
@@ -19,6 +19,7 @@ import lombok.Getter;
 import uk.gov.hmcts.ccd.sdk.api.CCDAccessGroup;
 import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.api.Permission;
+import uk.gov.hmcts.reform.pcs.ccd.CaseType;
 
 @Getter
 public enum AccessProfile implements HasRole {
@@ -87,5 +88,20 @@ public enum AccessProfile implements HasRole {
 
     public String getCaseTypePermissions() {
         return Permission.toString(caseTypePermissions);
+    }
+
+    /**
+     * Group access is configured on the canonical PCS case type only. A suffixed case type
+     * (PCS-staging, PR previews) shares the jurisdiction, so emitting the same AccessType rows there
+     * makes PRM mint a second set of organisation roles against that case type - and XUI's case list
+     * then defaults to it, showing no cases. Emit nothing so no such roles exist to pick.
+     */
+    @Override
+    public List<CCDAccessGroup> getAccessGroups() {
+        return accessGroupsFor(CaseType.isSuffixedCaseType());
+    }
+
+    List<CCDAccessGroup> accessGroupsFor(boolean suffixedCaseType) {
+        return suffixedCaseType ? List.of() : accessGroups;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/ExtRespondPossessionClaim.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/ccd/event/ExtRespondPossessionClaim.java
@@ -29,7 +29,8 @@ public class ExtRespondPossessionClaim implements CCDConfig<PCSCase, State, User
                 ShowConditions.featureFlagsEnabled(RELEASE_1_DOT_2)))
             .name("Respond to claim")
             .description("Respond to claim")
-            .grant(Permission.CRU, UserRole.DEFENDANT_SOLICITOR);
+            .grant(Permission.CRU, UserRole.DEFENDANT_SOLICITOR)
+            .grant(Permission.CRU, UserRole.GA_DEFENDANT_SOLICITOR);
     }
 
     private static class NoopSubmitHandler implements Submit<PCSCase, State> {

--- a/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessProfileTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcs/ccd/accesscontrol/AccessProfileTest.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.ccd.sdk.api.Permission.CRU;
 import static uk.gov.hmcts.ccd.sdk.api.Permission.R;
+import static uk.gov.hmcts.reform.pcs.ccd.accesscontrol.GroupAccessType.SOLICITOR_ORG_CLAIMANT_ACCESS;
 
 class AccessProfileTest {
 
@@ -55,5 +56,20 @@ class AccessProfileTest {
             Arguments.of(AccessProfile.SYSTEM_USER, "pcs-system-update", CRU),
             Arguments.of(AccessProfile.ORGANISATION_CASE_ACCESS_ADMINISTRATOR, "caseworker-caa", CRU)
         );
+    }
+
+    @Test
+    void shouldDeclareAccessGroupsOnTheCanonicalCaseType() {
+        assertThat(AccessProfile.GA_CLAIMANT_SOLICITOR.accessGroupsFor(false))
+            .containsExactly(SOLICITOR_ORG_CLAIMANT_ACCESS);
+        assertThat(AccessProfile.PCS_SOLICITOR.accessGroupsFor(false)).isEmpty();
+    }
+
+    @Test
+    void shouldDeclareNoAccessGroupsOnASuffixedCaseType() {
+        // PCS-staging / PR previews: no AccessType rows, so PRM mints no org roles for them.
+        for (AccessProfile profile : AccessProfile.values()) {
+            assertThat(profile.accessGroupsFor(true)).as(profile.name()).isEmpty();
+        }
     }
 }


### PR DESCRIPTION
### Change description

Master E2E `respondToAClaimLR.spec.ts › Trigger respond event` has been failing on recent builds.

Defendant solicitors now get case access via the group-access `defendant-solicitor` org role, but `ext:respondPossessionClaim` ("Respond to claim") only granted `[DEFENDANTSOLICITOR]`, so the event was missing from the Next step dropdown and the test timed out. This adds the `GA_DEFENDANT_SOLICITOR` grant, matching `respondPossessionClaim`.

### Testing done

Logged in to AAT as `pcs-org1-solicitor2@test.com`, who has the defendant-solicitor org role. The case opened fine through group access, but "Respond to claim" was not in the Next step dropdown, which confirms the missing grant. With this change the event is offered and the E2E spec passes.
