### PR TITLE
Upgrades for CVEs and suppress false positives

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -376,7 +376,7 @@ ext {
   lombokVersion = "1.18.46"
   springSecurityVersion = "7.1.1"
   pactVersion = "4.7.5"
-  tomcatEmbedVersion = "11.0.24"
+  tomcatEmbedVersion = "11.0.25"
   nettyVersion = "4.1.136.Final"
   httpClient5Version = "5.6.4"
 }
@@ -403,6 +403,10 @@ dependencies {
   implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '6.1.0-RELEASE'
   implementation group: 'org.modelmapper', name: 'modelmapper', version: '3.2.6'
   implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.6.4'
+
+  implementation group: 'io.opentelemetry', name: 'opentelemetry-api', version: '1.65.0'
+  implementation group: 'io.opentelemetry', name: 'opentelemetry-context', version: '1.65.0'
+  implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv', version: '1.43.0'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.3.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -29,6 +29,20 @@
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib(-common|-jdk7|-jdk8)?@.*$</packageUrl>
     <cve>CVE-2020-29582</cve>
   </suppress>
+  <suppress until="2026-10-15">
+    <notes><![CDATA[
+    CVE-2026-54285 concerns the Javascript OpenTelemetry client. Re-review by the until date.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry(\.semconv)?/opentelemetry\-.*$</packageUrl>
+    <cve>CVE-2026-54285</cve>
+  </suppress>
+  <suppress until="2026-10-15">
+    <notes><![CDATA[
+    CVE-2026-41178 concerns the Go OpenTelemetry client. Re-review by the until date.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
+    <cve>CVE-2026-41178</cve>
+  </suppress>
   <!--End of false positives section -->
 
   <suppress until="2026-09-15">


### PR DESCRIPTION
### Change description

Upgrade embedded Tomcat version and OpenTelemetry dependencies to avoid CVEs. Also suppress false positives for Javascript and Go CVEs for OpenTelemetry.

### Testing done

Build run in PR pipeline

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

### PCS checklist

- [ ] New functional test classes carry the gating annotations (`@EnabledIfEnvironmentVariable(named = "CCD_ENABLED", ...)` + shutter guard) unless they must run on unlabelled PRs (HDPI-8084)
- [ ] Infrastructure / chart / suppression changes have a second pair of eyes from the service admins (HDPI-8153)
