### PR TITLE
HDPI-8698: tolerate unknown rd-professional fields, drop mistyped unused dxAddress

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcs/reference/dto/OrganisationDetailsResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcs/reference/dto/OrganisationDetailsResponse.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.pcs.reference.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,6 +11,8 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 import org.springframework.util.CollectionUtils;
 
+// rd-professional adds fields over time (dxAddress and friends); parse only what we use.
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 @Builder
 @NoArgsConstructor
@@ -81,6 +84,7 @@ public class OrganisationDetailsResponse {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ContactInformation {
         @JsonProperty("addressId")
         private String addressId;
@@ -107,9 +111,6 @@ public class OrganisationDetailsResponse {
 
         @JsonProperty("postCode")
         private String postCode;
-
-        @JsonProperty("dxAddress")
-        private List<String> dxAddress;
     }
 
     @Data


### PR DESCRIPTION
### Jira link

See [HDPI-8698](https://tools.hmcts.net/jira/browse/HDPI-8698)

### Change description

One file. OrganisationDetailsResponse declared dxAddress as List of String, but rd-professional returns DX addresses as objects (dxNumber, dxExchange). The AAT test organisations carry no DX addresses so this never fired; the organisations registered on perftest for performance testing do, so org lookups there fail with a Jackson MismatchedInputException and case journeys NPE, which is currently blocking performance testing.

The field is referenced nowhere in pcs code, so this removes it and adds JsonIgnoreProperties(ignoreUnknown = true) to the response DTO and its nested ContactInformation, matching the existing convention on external response DTOs (Payment, Audit, CaseRoleID). That fixes the blocker and immunises the DTO against future upstream schema additions.

### Testing done

compileJava clean. The failing path is environment-data dependent (needs an organisation with a DX address); verification is a perftest org lookup after deploy, which the perf team exercises immediately.